### PR TITLE
Optimize duty performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8789,6 +8789,7 @@ dependencies = [
  "lighthouse_version",
  "lockfile",
  "logging",
+ "lru 0.7.8",
  "malloc_utils",
  "monitoring_api",
  "parking_lot 0.12.1",

--- a/crypto/curdleproofs_whisk/src/lib.rs
+++ b/crypto/curdleproofs_whisk/src/lib.rs
@@ -175,8 +175,8 @@ fn serialize_shuffle_trackers(
 }
 
 pub struct WhiskTrackerG1Affine {
-    r_g: G1Affine,
-    k_r_g: G1Affine,
+    pub r_g: G1Affine,
+    pub k_r_g: G1Affine,
 }
 
 impl TryFrom<&WhiskTracker> for WhiskTrackerG1Affine {

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -64,3 +64,4 @@ malloc_utils = { path = "../common/malloc_utils" }
 sysinfo = "0.26.5"
 system_health = { path = "../common/system_health" }
 logging = { path = "../common/logging" }
+lru = "0.7.1"

--- a/validator_client/src/http_metrics/metrics.rs
+++ b/validator_client/src/http_metrics/metrics.rs
@@ -139,6 +139,18 @@ lazy_static::lazy_static! {
         "vc_beacon_proposer_duties_reorged_total",
         "Total count of proposer duties reorged, dependent root changed",
     );
+    pub static ref PROPOSER_WHISK_DUTY_NOTIFIED_LATE: Result<IntCounter> = try_create_int_counter(
+        "vc_beacon_whisk_duty_notified_late",
+        "Total count of times a whisk is duty is notified on or after the duty's slot",
+    );
+    pub static ref PROPOSER_FIND_TRACKER_CACHE_HIT: Result<IntCounter> = try_create_int_counter(
+        "vc_beacon_find_tracker_cache_hit_total",
+        "Total count of cache hits for find tracker fn",
+    );
+    pub static ref PROPOSER_FIND_TRACKER_MATCH: Result<Histogram> = try_create_histogram(
+        "vc_beacon_find_tracker_match_times_seconds",
+        "Time to find tracker match in seconds",
+    );
     /*
      * Endpoint metrics
      */

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -42,6 +42,7 @@ use duties_service::DutiesService;
 use environment::RuntimeContext;
 use eth2::{reqwest::ClientBuilder, types::Graffiti, BeaconNodeHttpClient, StatusCode, Timeouts};
 use http_api::ApiSecret;
+use lru::LruCache;
 use notifier::spawn_notifier;
 use parking_lot::RwLock;
 use preparation_service::{PreparationService, PreparationServiceBuilder};
@@ -446,6 +447,7 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             attesters: <_>::default(),
             proposers: <_>::default(),
             sync_duties: <_>::default(),
+            whisk_tracker_cache: RwLock::new(LruCache::new(3 * T::slots_per_epoch() as usize)),
             slot_clock: slot_clock.clone(),
             beacon_nodes: beacon_nodes.clone(),
             validator_store: validator_store.clone(),


### PR DESCRIPTION
Finding matching trackers on each slot is too expensive for large validator counts. For hosts with 2000 keys it can take 20-30 sec to find trackers on all slots of an epoch. To fix this issue:
- cache find tracker results to compute once per tracker
- update block proposer service after each tracker, do not process the full epoch at once