### PR TITLE
Typed-initialized beacon state caches

### DIFF
--- a/consensus/types/src/beacon_state/compact_state.rs
+++ b/consensus/types/src/beacon_state/compact_state.rs
@@ -47,15 +47,6 @@ macro_rules! full_to_compact {
             current_justified_checkpoint: $s.current_justified_checkpoint,
             finalized_checkpoint: $s.finalized_checkpoint,
 
-            // Caches.
-            total_active_balance: $s.total_active_balance.clone(),
-            committee_caches: $s.committee_caches.clone(),
-            progressive_balances_cache: $s.progressive_balances_cache.clone(),
-            pubkey_cache: $s.pubkey_cache.clone(),
-            exit_cache: $s.exit_cache.clone(),
-            slashings_cache: $s.slashings_cache.clone(),
-            epoch_cache: $s.epoch_cache.clone(),
-
             // Variant-specific fields
             $(
                 $extra_fields: $s.$extra_fields.clone()
@@ -109,15 +100,6 @@ macro_rules! compact_to_full {
             previous_justified_checkpoint: $inner.previous_justified_checkpoint,
             current_justified_checkpoint: $inner.current_justified_checkpoint,
             finalized_checkpoint: $inner.finalized_checkpoint,
-
-            // Caching
-            total_active_balance: $inner.total_active_balance,
-            committee_caches: $inner.committee_caches,
-            progressive_balances_cache: $inner.progressive_balances_cache,
-            pubkey_cache: $inner.pubkey_cache,
-            exit_cache: $inner.exit_cache,
-            slashings_cache: $inner.slashings_cache,
-            epoch_cache: $inner.epoch_cache,
 
             // Variant-specific fields
             $(

--- a/consensus/types/src/beacon_state/exit_cache.rs
+++ b/consensus/types/src/beacon_state/exit_cache.rs
@@ -3,9 +3,8 @@ use rpds::HashTrieMapSync as HashTrieMap;
 use safe_arith::SafeArith;
 
 /// Map from exit epoch to the number of validators with that exit epoch.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ExitCache {
-    initialized: bool,
     exit_epoch_counts: HashTrieMap<Epoch, u64>,
 }
 

--- a/consensus/types/src/beacon_state/progressive_balances_cache.rs
+++ b/consensus/types/src/beacon_state/progressive_balances_cache.rs
@@ -13,13 +13,8 @@ use safe_arith::SafeArith;
 /// epochs. The cached values can be utilised by fork choice to calculate unrealized justification
 /// and finalization instead of converting epoch participation arrays to balances for each block we
 /// process.
-#[derive(Default, Debug, PartialEq, Arbitrary, Clone)]
-pub struct ProgressiveBalancesCache {
-    inner: Option<Inner>,
-}
-
 #[derive(Debug, PartialEq, Arbitrary, Clone)]
-struct Inner {
+pub struct ProgressiveBalancesCache {
     pub current_epoch: Epoch,
     pub previous_epoch_cache: EpochTotalBalances,
     pub current_epoch_cache: EpochTotalBalances,

--- a/consensus/types/src/beacon_state/pubkey_cache.rs
+++ b/consensus/types/src/beacon_state/pubkey_cache.rs
@@ -3,7 +3,7 @@ use rpds::HashTrieMapSync as HashTrieMap;
 
 type ValidatorIndex = usize;
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct PubkeyCache {
     /// Maintain the number of keys added to the map. It is not sufficient to just use the
     /// HashTrieMap len, as it does not increase when duplicate keys are added. Duplicate keys are
@@ -13,6 +13,17 @@ pub struct PubkeyCache {
 }
 
 impl PubkeyCache {
+    pub fn from_pubkeys(pubkeys: Vec<PublicKeyBytes>) -> Self {
+        let mut pubkey_cache = Self {
+            len: 0,
+            map: <_>::default(),
+        };
+        for (i, pubkey) in pubkeys.into_iter().enumerate() {
+            pubkey_cache.insert(pubkey, i);
+        }
+        pubkey_cache
+    }
+
     /// Returns the number of validator indices added to the map so far.
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> ValidatorIndex {

--- a/consensus/types/src/beacon_state/slashings_cache.rs
+++ b/consensus/types/src/beacon_state/slashings_cache.rs
@@ -1,11 +1,11 @@
-use crate::{BeaconStateError, Slot, Validator};
+use crate::{Slot, Validator};
 use arbitrary::Arbitrary;
 use rpds::HashTrieSetSync as HashTrieSet;
 
 /// Persistent (cheap to clone) cache of all slashed validator indices.
-#[derive(Debug, Default, Clone, PartialEq, Arbitrary)]
+#[derive(Debug, Clone, PartialEq, Arbitrary)]
 pub struct SlashingsCache {
-    latest_block_slot: Option<Slot>,
+    latest_block_slot: Slot,
     #[arbitrary(default)]
     slashed_validators: HashTrieSet<usize>,
 }
@@ -23,34 +23,13 @@ impl SlashingsCache {
             .filter_map(|(i, validator)| validator.slashed().then_some(i))
             .collect();
         Self {
-            latest_block_slot: Some(latest_block_slot),
+            latest_block_slot,
             slashed_validators,
         }
     }
 
-    pub fn is_initialized(&self, slot: Slot) -> bool {
-        self.latest_block_slot == Some(slot)
-    }
-
-    pub fn check_initialized(&self, latest_block_slot: Slot) -> Result<(), BeaconStateError> {
-        if self.is_initialized(latest_block_slot) {
-            Ok(())
-        } else {
-            Err(BeaconStateError::SlashingsCacheUninitialized {
-                initialized_slot: self.latest_block_slot,
-                latest_block_slot,
-            })
-        }
-    }
-
-    pub fn record_validator_slashing(
-        &mut self,
-        block_slot: Slot,
-        validator_index: usize,
-    ) -> Result<(), BeaconStateError> {
-        self.check_initialized(block_slot)?;
+    pub fn record_validator_slashing(&mut self, block_slot: Slot, validator_index: usize) {
         self.slashed_validators.insert_mut(validator_index);
-        Ok(())
     }
 
     pub fn is_slashed(&self, validator_index: usize) -> bool {
@@ -58,6 +37,6 @@ impl SlashingsCache {
     }
 
     pub fn update_latest_block_slot(&mut self, latest_block_slot: Slot) {
-        self.latest_block_slot = Some(latest_block_slot);
+        self.latest_block_slot = latest_block_slot;
     }
 }


### PR DESCRIPTION
Current beacon_state caches have three states:
- **Uninitialized**: set to default when state is decoded
- **Initialized**: after doing some calculation with state's data + spec
- **Stale**: when calculated data is not longer in sync with a mutated state

This PR explorers removing the first state **Uninitialized** by having two types:
- `BeaconStateInner` / `BeaconState`: the thing you deserialize to
- `BeaconState` /  `CachedBeaconState`: wrapper struct that includes the caches

`CachedBeaconState` does not implement default and must calculate all structs on allocation.