### PR TITLE
Remove block types with both execute and availability properties

### DIFF
--- a/beacon_node/beacon_chain/src/data_availability_checker/state_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/state_lru_cache.rs
@@ -1,4 +1,5 @@
 use crate::block_verification_types::AsBlock;
+use crate::ExecutedBlock;
 use crate::{
     block_verification_types::BlockImportData,
     data_availability_checker::{AvailabilityCheckError, STATE_LRU_CAPACITY_NON_ZERO},
@@ -72,7 +73,7 @@ impl<T: BeaconChainTypes> StateLRUCache<T> {
     /// keep around in memory.
     pub fn register_pending_executed_block(
         &self,
-        executed_block: AvailabilityPendingExecutedBlock<T::EthSpec>,
+        executed_block: ExecutedBlock<T::EthSpec>,
     ) -> DietAvailabilityPendingExecutedBlock<T::EthSpec> {
         let state = executed_block.import_data.state;
         let state_root = executed_block.block.state_root();

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -7,7 +7,6 @@ use crate::sync::{
 };
 use beacon_chain::block_verification_types::{AsBlock, RpcBlock};
 use beacon_chain::data_availability_checker::AvailabilityCheckError;
-use beacon_chain::data_availability_checker::MaybeAvailableBlock;
 use beacon_chain::{
     validator_monitor::get_slot_delay_ms, AvailabilityProcessingStatus, BeaconChainError,
     BeaconChainTypes, BlockError, ChainSegmentResult, HistoricalBlockError, NotifyExecutionLayer,
@@ -475,10 +474,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         {
             Ok(blocks) => blocks
                 .into_iter()
-                .filter_map(|maybe_available| match maybe_available {
-                    MaybeAvailableBlock::Available(block) => Some(block),
-                    MaybeAvailableBlock::AvailabilityPending { .. } => None,
-                })
+                .filter_map(|maybe_available| maybe_available.into_available())
                 .collect::<Vec<_>>(),
             Err(e) => match e {
                 AvailabilityCheckError::StoreError(_)


### PR DESCRIPTION
### Motivation

Those where the good old days..

```
SignedBeaconBlock --------
         |               |
         |      GossipVerifiedBlock
         |               |
SignatureVerifiedBlock  <-
         |   
ExecutionPendingBlock
         |
        END
```

Where block types had a linear progression. Now there are two states progressing in parallel: execution + availability. Now block types are nested, featuring a combination of enums and names with double status

- `ExecutionPendingBlock`: `MaybeAvailableBlock` + import data
- `MaybeAvailableBlock`:
  - Available: `AvailableBlock`
  - Not available: `SignedBeaconBlock`
- `Availability`
  - Available: `AvailableExecutedBlock`
  - Not available: `()`
- `ExecutedBlock`:
  - Available: `AvailableExecutedBlock`
  - AvailabilityPending: `AvailabilityPendingExecutedBlock`
- `AvailabilityPendingExecutedBlock`: `SignedBeaconBlock` + import data
- `AvailableExecutedBlock`: `AvailableBlock` + import data

### Changes

This PR explores returning linearity by making availability a property of the block types, since it happens in the background.

```
SignedBeaconBlock --------
         |               |
         |      GossipVerifiedBlock
         |               |
SignatureVerifiedBlock  <-
         |   
ExecutionPendingBlock
         |
   ExecutedBlock
         |
ExecutedAvailableBlock
```

#### TODO

- [ ] Remove `AvailabilityPendingExecutedBlock`. It's existence does not affect things too much now as its main consumer (the overflow cache) is isolated.