### PR TITLE
PoC dedicated process X errors

### DIFF
--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -74,9 +74,9 @@ pub use self::historical_blocks::HistoricalBlockError;
 pub use attestation_verification::Error as AttestationError;
 pub use beacon_fork_choice_store::{BeaconForkChoiceStore, Error as ForkChoiceStoreError};
 pub use block_verification::{
-    get_block_root, BlockError, ExecutionPayloadError, ExecutionPendingBlock, GossipVerifiedBlock,
-    IntoExecutionPendingBlock, IntoGossipVerifiedBlockContents, PayloadVerificationOutcome,
-    PayloadVerificationStatus,
+    get_block_root, BlobProcessError, BlockError, BlockProcessError, ExecutionPayloadError,
+    ExecutionPendingBlock, GossipVerifiedBlock, IntoExecutionPendingBlock,
+    IntoGossipVerifiedBlockContents, PayloadVerificationOutcome, PayloadVerificationStatus,
 };
 pub use block_verification_types::AvailabilityPendingExecutedBlock;
 pub use block_verification_types::ExecutedBlock;

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -1883,7 +1883,8 @@ where
                 NotifyExecutionLayer::Yes,
                 || Ok(()),
             )
-            .await?
+            .await
+            .map_err(|_| BlockError::BeaconChainError(todo!("placeholder")))?
             .try_into()
             .unwrap();
         self.chain.recompute_head_at_current_slot().await;
@@ -1909,7 +1910,8 @@ where
                 NotifyExecutionLayer::Yes,
                 || Ok(()),
             )
-            .await?
+            .await
+            .map_err(|_| BlockError::BeaconChainError(todo!("placeholder")))?
             .try_into()
             .expect("block blobs are available");
         self.chain.recompute_head_at_current_slot().await;

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -8,6 +8,7 @@ use crate::sync::{
 use beacon_chain::block_verification_types::{AsBlock, RpcBlock};
 use beacon_chain::data_availability_checker::AvailabilityCheckError;
 use beacon_chain::data_availability_checker::MaybeAvailableBlock;
+use beacon_chain::BlobProcessError;
 use beacon_chain::{
     validator_monitor::get_slot_delay_ms, AvailabilityProcessingStatus, BeaconChainError,
     BeaconChainTypes, BlockError, ChainSegmentResult, HistoricalBlockError, NotifyExecutionLayer,
@@ -279,7 +280,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "slot" => %slot,
                 );
             }
-            Err(BlockError::BlockIsAlreadyKnown(_)) => {
+            Err(BlobProcessError::AlreadyImported(_)) => {
                 debug!(
                     self.log,
                     "Blobs have already been imported";

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -249,7 +249,7 @@ impl TestRig {
         )
     }
 
-    fn parent_block_processed(&mut self, chain_hash: Hash256, result: BlockProcessingResult<E>) {
+    fn parent_block_processed(&mut self, chain_hash: Hash256, result: BlockProcessingResult) {
         self.send_sync_message(SyncMessage::BlockComponentProcessed {
             process_type: BlockProcessType::ParentLookup { chain_hash },
             result,
@@ -266,7 +266,7 @@ impl TestRig {
     fn single_block_component_processed(
         &mut self,
         id: SingleLookupReqId,
-        result: BlockProcessingResult<E>,
+        result: BlockProcessingResult,
     ) {
         self.send_sync_message(SyncMessage::BlockComponentProcessed {
             process_type: BlockProcessType::SingleBlock { id: id.id },
@@ -288,7 +288,7 @@ impl TestRig {
     fn single_blob_component_processed(
         &mut self,
         id: SingleLookupReqId,
-        result: BlockProcessingResult<E>,
+        result: BlockProcessingResult,
     ) {
         self.send_sync_message(SyncMessage::BlockComponentProcessed {
             process_type: BlockProcessType::SingleBlob { id: id.id },


### PR DESCRIPTION
Currently block process and blob process both return the same `BlockError`. While convenient there are many variants of `BlockError` that don't make sense for blob process.

This PR explores having dedicated error types for:
- `ProcessBlockError`: returned by `process_block` (verifies block and calls `import_block`)
- `ProcessBlobError`: returned by `process_blob` (verifies blob and calls `import_block`)
- `BlockImportError`: returned by `import_block`

If we want to have a common routine in sync for block component at some level we have to coerce block and blob errors into the same thing.

