### PR TITLE
Group invalid block error variants

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2704,7 +2704,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             if let Err(e) = block.as_block().fork_name(&self.spec) {
                 return Err(ChainSegmentResult::Failed {
                     imported_blocks,
-                    error: BlockError::InconsistentFork(e),
+                    error: e.into(),
                 });
             }
 

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -77,7 +77,7 @@ pub use beacon_fork_choice_store::{BeaconForkChoiceStore, Error as ForkChoiceSto
 pub use block_verification::{
     build_blob_data_column_sidecars, get_block_root, BlockError, ExecutionPayloadError,
     ExecutionPendingBlock, GossipVerifiedBlock, IntoExecutionPendingBlock, IntoGossipVerifiedBlock,
-    PayloadVerificationOutcome, PayloadVerificationStatus,
+    InvalidBlockError, PayloadVerificationOutcome, PayloadVerificationStatus,
 };
 pub use block_verification_types::AvailabilityPendingExecutedBlock;
 pub use block_verification_types::ExecutedBlock;

--- a/beacon_node/beacon_chain/tests/rewards.rs
+++ b/beacon_node/beacon_chain/tests/rewards.rs
@@ -7,7 +7,7 @@ use beacon_chain::test_utils::{
 use beacon_chain::{
     test_utils::{AttestationStrategy, BlockStrategy, RelativeSyncCommittee},
     types::{Epoch, EthSpec, Keypair, MinimalEthSpec},
-    BlockError, ChainConfig, StateSkipConfig, WhenSlotSkipped,
+    BlockError, ChainConfig, InvalidBlockError, StateSkipConfig, WhenSlotSkipped,
 };
 use eth2::lighthouse::attestation_rewards::TotalAttestationRewards;
 use eth2::lighthouse::StandardAttestationRewards;
@@ -278,7 +278,7 @@ async fn test_rewards_base_multi_inclusion() {
     // funky hack: on first try, the state root will mismatch due to our modification
     // thankfully, the correct state root is reported back, so we just take that one :^)
     // there probably is a better way...
-    let Err(BlockError::StateRootMismatch { local, .. }) = harness
+    let Err(BlockError::InvalidBlock(InvalidBlockError::StateRootMismatch { local, .. })) = harness
         .process_block(slot, block.0.canonical_root(), block.clone())
         .await
     else {

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1273,20 +1273,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
                 return None;
             }
-            Err(e @ BlockError::StateRootMismatch { .. })
-            | Err(e @ BlockError::IncorrectBlockProposer { .. })
-            | Err(e @ BlockError::BlockSlotLimitReached)
+            Err(e @ BlockError::InvalidBlock { .. })
             | Err(e @ BlockError::ProposalSignatureInvalid)
             | Err(e @ BlockError::NonLinearSlots)
-            | Err(e @ BlockError::UnknownValidator(_))
-            | Err(e @ BlockError::PerBlockProcessingError(_))
             | Err(e @ BlockError::NonLinearParentRoots)
-            | Err(e @ BlockError::BlockIsNotLaterThanParent { .. })
-            | Err(e @ BlockError::InvalidSignature)
             | Err(e @ BlockError::WeakSubjectivityConflict)
-            | Err(e @ BlockError::InconsistentFork(_))
             | Err(e @ BlockError::ExecutionPayloadError(_))
-            | Err(e @ BlockError::ParentExecutionPayloadInvalid { .. })
             | Err(e @ BlockError::GenesisBlock) => {
                 warn!(self.log, "Could not verify block for gossip. Rejecting the block";
                             "error" => %e);

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -11,7 +11,8 @@ use beacon_chain::data_availability_checker::MaybeAvailableBlock;
 use beacon_chain::data_column_verification::verify_kzg_for_data_column_list;
 use beacon_chain::{
     validator_monitor::get_slot_delay_ms, AvailabilityProcessingStatus, BeaconChainError,
-    BeaconChainTypes, BlockError, ChainSegmentResult, HistoricalBlockError, NotifyExecutionLayer,
+    BeaconChainTypes, BlockError, ChainSegmentResult, HistoricalBlockError, InvalidBlockError,
+    NotifyExecutionLayer,
 };
 use beacon_processor::{
     work_reprocessing_queue::{QueuedRpcBlock, ReprocessQueueMessage},
@@ -805,7 +806,9 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     })
                 }
             }
-            ref err @ BlockError::ParentExecutionPayloadInvalid { ref parent_root } => {
+            ref err @ BlockError::InvalidBlock(
+                InvalidBlockError::ParentExecutionPayloadInvalid { ref parent_root },
+            ) => {
                 warn!(
                     self.log,
                     "Failed to sync chain built on invalid parent";

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1708,7 +1708,7 @@ fn test_parent_lookup_too_many_processing_attempts_must_blacklist() {
         rig.assert_not_failed_chain(block_root);
         // send the right parent but fail processing
         rig.parent_lookup_block_response(id, peer_id, Some(parent.clone().into()));
-        rig.parent_block_processed(block_root, BlockError::InvalidSignature.into());
+        rig.parent_block_processed(block_root, BlockError::ProposalSignatureInvalid.into());
         rig.parent_lookup_block_response(id, peer_id, None);
         rig.expect_penalty(peer_id, "lookup_block_processing_failure");
     }


### PR DESCRIPTION
If we adopt multiple big matches of BlockError, it maybe convenient to group all error variants that are BeaconBlock spec invalid conditions