### PR TITLE
Remove CGC from data_availability checker

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2993,6 +2993,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub async fn verify_block_for_gossip(
         self: &Arc<Self>,
         block: Arc<SignedBeaconBlock<T::EthSpec>>,
+        custody_columns_count: usize,
     ) -> Result<GossipVerifiedBlock<T>, BlockError> {
         let chain = self.clone();
         self.task_executor
@@ -3002,7 +3003,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     let slot = block.slot();
                     let graffiti_string = block.message().body().graffiti().as_utf8_lossy();
 
-                    match GossipVerifiedBlock::new(block, &chain) {
+                    match GossipVerifiedBlock::new(block, &chain, custody_columns_count) {
                         Ok(verified) => {
                             let commitments_formatted = verified.block.commitments_formatted();
                             debug!(
@@ -7224,10 +7225,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         block_root: Hash256,
         block_data: AvailableBlockData<T::EthSpec>,
     ) -> Result<Option<StoreOp<T::EthSpec>>, String> {
-        // TODO(das) we currently store all subnet sampled columns. Tracking issue to exclude non
-        // custody columns: https://github.com/sigp/lighthouse/issues/6465
-        let _custody_columns_count = self.data_availability_checker.get_sampling_column_count();
-
         match block_data {
             AvailableBlockData::NoData => Ok(None),
             AvailableBlockData::Blobs(blobs) => {

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1707,7 +1707,6 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
                 parent_eth1_finalization_data,
                 confirmed_state_roots,
                 consensus_context,
-                data_column_recv: None,
             },
             payload_verification_handle,
         })

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -680,6 +680,7 @@ pub struct GossipVerifiedBlock<T: BeaconChainTypes> {
     pub block_root: Hash256,
     parent: Option<PreProcessingSnapshot<T::EthSpec>>,
     consensus_context: ConsensusContext<T::EthSpec>,
+    custody_columns_count: usize,
 }
 
 /// A wrapper around a `SignedBeaconBlock` that indicates that all signatures (except the deposit
@@ -715,6 +716,7 @@ pub trait IntoGossipVerifiedBlock<T: BeaconChainTypes>: Sized {
     fn into_gossip_verified_block(
         self,
         chain: &BeaconChain<T>,
+        custody_columns_count: usize,
     ) -> Result<GossipVerifiedBlock<T>, BlockError>;
     fn inner_block(&self) -> Arc<SignedBeaconBlock<T::EthSpec>>;
 }
@@ -723,6 +725,7 @@ impl<T: BeaconChainTypes> IntoGossipVerifiedBlock<T> for GossipVerifiedBlock<T> 
     fn into_gossip_verified_block(
         self,
         _chain: &BeaconChain<T>,
+        _custody_columns_count: usize,
     ) -> Result<GossipVerifiedBlock<T>, BlockError> {
         Ok(self)
     }
@@ -735,8 +738,9 @@ impl<T: BeaconChainTypes> IntoGossipVerifiedBlock<T> for Arc<SignedBeaconBlock<T
     fn into_gossip_verified_block(
         self,
         chain: &BeaconChain<T>,
+        custody_columns_count: usize,
     ) -> Result<GossipVerifiedBlock<T>, BlockError> {
-        GossipVerifiedBlock::new(self, chain)
+        GossipVerifiedBlock::new(self, chain, custody_columns_count)
     }
 
     fn inner_block(&self) -> Arc<SignedBeaconBlock<T::EthSpec>> {
@@ -805,6 +809,7 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
     pub fn new(
         block: Arc<SignedBeaconBlock<T::EthSpec>>,
         chain: &BeaconChain<T>,
+        custody_columns_count: usize,
     ) -> Result<Self, BlockError> {
         // If the block is valid for gossip we don't supply it to the slasher here because
         // we assume it will be transformed into a fully verified block. We *do* need to supply
@@ -814,12 +819,14 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
         // The `SignedBeaconBlock` and `SignedBeaconBlockHeader` have the same canonical root,
         // but it's way quicker to calculate root of the header since the hash of the tree rooted
         // at `BeaconBlockBody` is already computed in the header.
-        Self::new_without_slasher_checks(block, &header, chain).map_err(|e| {
-            process_block_slash_info::<_, BlockError>(
-                chain,
-                BlockSlashInfo::from_early_error_block(header, e),
-            )
-        })
+        Self::new_without_slasher_checks(block, &header, chain, custody_columns_count).map_err(
+            |e| {
+                process_block_slash_info::<_, BlockError>(
+                    chain,
+                    BlockSlashInfo::from_early_error_block(header, e),
+                )
+            },
+        )
     }
 
     /// As for new, but doesn't pass the block to the slasher.
@@ -827,6 +834,7 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
         block: Arc<SignedBeaconBlock<T::EthSpec>>,
         block_header: &SignedBeaconBlockHeader,
         chain: &BeaconChain<T>,
+        custody_columns_count: usize,
     ) -> Result<Self, BlockError> {
         // Ensure the block is the correct structure for the fork at `block.slot()`.
         block
@@ -1031,6 +1039,7 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
             block_root,
             parent,
             consensus_context,
+            custody_columns_count,
         })
     }
 
@@ -1175,6 +1184,7 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
                 block: MaybeAvailableBlock::AvailabilityPending {
                     block_root: from.block_root,
                     block,
+                    custody_columns_count: from.custody_columns_count,
                 },
                 block_root: from.block_root,
                 parent: Some(parent),

--- a/beacon_node/beacon_chain/src/block_verification_types.rs
+++ b/beacon_node/beacon_chain/src/block_verification_types.rs
@@ -7,11 +7,10 @@ use derivative::Derivative;
 use state_processing::ConsensusContext;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
-use tokio::sync::oneshot;
 use types::blob_sidecar::BlobIdentifier;
 use types::{
-    BeaconBlockRef, BeaconState, BlindedPayload, BlobSidecarList, ChainSpec, DataColumnSidecarList,
-    Epoch, EthSpec, Hash256, RuntimeVariableList, SignedBeaconBlock, SignedBeaconBlockHeader, Slot,
+    BeaconBlockRef, BeaconState, BlindedPayload, BlobSidecarList, ChainSpec, Epoch, EthSpec,
+    Hash256, RuntimeVariableList, SignedBeaconBlock, SignedBeaconBlockHeader, Slot,
 };
 
 /// A block that has been received over RPC. It has 2 internal variants:
@@ -265,7 +264,6 @@ impl<E: EthSpec> ExecutedBlock<E> {
 
 /// A block that has completed all pre-deneb block processing checks including verification
 /// by an EL client **and** has all requisite blob data to be imported into fork choice.
-#[derive(PartialEq)]
 pub struct AvailableExecutedBlock<E: EthSpec> {
     pub block: AvailableBlock<E>,
     pub import_data: BlockImportData<E>,
@@ -338,8 +336,7 @@ impl<E: EthSpec> AvailabilityPendingExecutedBlock<E> {
     }
 }
 
-#[derive(Debug, Derivative)]
-#[derivative(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct BlockImportData<E: EthSpec> {
     pub block_root: Hash256,
     pub state: BeaconState<E>,
@@ -347,12 +344,6 @@ pub struct BlockImportData<E: EthSpec> {
     pub parent_eth1_finalization_data: Eth1FinalizationData,
     pub confirmed_state_roots: Vec<Hash256>,
     pub consensus_context: ConsensusContext<E>,
-    #[derivative(PartialEq = "ignore")]
-    /// An optional receiver for `DataColumnSidecarList`.
-    ///
-    /// This field is `Some` when data columns are being computed asynchronously.
-    /// The resulting `DataColumnSidecarList` will be sent through this receiver.
-    pub data_column_recv: Option<oneshot::Receiver<DataColumnSidecarList<E>>>,
 }
 
 impl<E: EthSpec> BlockImportData<E> {
@@ -371,7 +362,6 @@ impl<E: EthSpec> BlockImportData<E> {
             },
             confirmed_state_roots: vec![],
             consensus_context: ConsensusContext::new(Slot::new(0)),
-            data_column_recv: None,
         }
     }
 }

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1008,7 +1008,6 @@ where
                     slot_clock,
                     self.kzg.clone(),
                     store,
-                    self.import_all_data_columns,
                     self.spec,
                     log.new(o!("service" => "data_availability_checker")),
                 )

--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -94,6 +94,10 @@ pub struct ChainConfig {
     /// The delay in milliseconds applied by the node between sending each blob or data column batch.
     /// This doesn't apply if the node is the block proposer.
     pub blob_publication_batch_interval: Duration,
+    /// Artificial delay for block publishing. For PeerDAS testing only.
+    pub block_publishing_delay: Option<Duration>,
+    /// Artificial delay for data column publishing. For PeerDAS testing only.
+    pub data_column_publishing_delay: Option<Duration>,
 }
 
 impl Default for ChainConfig {
@@ -129,6 +133,8 @@ impl Default for ChainConfig {
             enable_sampling: false,
             blob_publication_batches: 4,
             blob_publication_batch_interval: Duration::from_millis(300),
+            block_publishing_delay: None,
+            data_column_publishing_delay: None,
         }
     }
 }

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -112,22 +112,10 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         slot_clock: T::SlotClock,
         kzg: Arc<Kzg>,
         store: BeaconStore<T>,
-        import_all_data_columns: bool,
         spec: Arc<ChainSpec>,
         log: Logger,
     ) -> Result<Self, AvailabilityCheckError> {
-        let custody_group_count = spec.custody_group_count(import_all_data_columns);
-        // This should only panic if the chain spec contains invalid values.
-        let sampling_size = spec
-            .sampling_size(custody_group_count)
-            .expect("should compute node sampling size from valid chain spec");
-
-        let inner = DataAvailabilityCheckerInner::new(
-            OVERFLOW_LRU_CAPACITY,
-            store,
-            sampling_size as usize,
-            spec.clone(),
-        )?;
+        let inner = DataAvailabilityCheckerInner::new(OVERFLOW_LRU_CAPACITY, store, spec.clone())?;
         Ok(Self {
             availability_cache: Arc::new(inner),
             slot_clock,
@@ -135,14 +123,6 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
             spec,
             log,
         })
-    }
-
-    pub fn get_sampling_column_count(&self) -> usize {
-        self.availability_cache.sampling_column_count()
-    }
-
-    pub(crate) fn is_supernode(&self) -> bool {
-        self.get_sampling_column_count() == self.spec.number_of_columns as usize
     }
 
     /// Checks if the block root is currenlty in the availability cache awaiting import because
@@ -340,6 +320,7 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         &self,
         block: RpcBlock<T::EthSpec>,
     ) -> Result<MaybeAvailableBlock<T::EthSpec>, AvailabilityCheckError> {
+        let custody_columns_count = block.custody_columns_count();
         let (block_root, block, blobs, data_columns) = block.deconstruct();
         if self.blobs_required_for_block(&block) {
             return if let Some(blob_list) = blobs {
@@ -353,7 +334,11 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
                     spec: self.spec.clone(),
                 }))
             } else {
-                Ok(MaybeAvailableBlock::AvailabilityPending { block_root, block })
+                Ok(MaybeAvailableBlock::AvailabilityPending {
+                    block_root,
+                    block,
+                    custody_columns_count,
+                })
             };
         }
         if self.data_columns_required_for_block(&block) {
@@ -378,7 +363,11 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
                     spec: self.spec.clone(),
                 }))
             } else {
-                Ok(MaybeAvailableBlock::AvailabilityPending { block_root, block })
+                Ok(MaybeAvailableBlock::AvailabilityPending {
+                    block_root,
+                    block,
+                    custody_columns_count,
+                })
             };
         }
 
@@ -435,6 +424,7 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         }
 
         for block in blocks {
+            let custody_columns_count = block.custody_columns_count();
             let (block_root, block, blobs, data_columns) = block.deconstruct();
 
             let maybe_available_block = if self.blobs_required_for_block(&block) {
@@ -447,7 +437,11 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
                         spec: self.spec.clone(),
                     })
                 } else {
-                    MaybeAvailableBlock::AvailabilityPending { block_root, block }
+                    MaybeAvailableBlock::AvailabilityPending {
+                        block_root,
+                        block,
+                        custody_columns_count,
+                    }
                 }
             } else if self.data_columns_required_for_block(&block) {
                 if let Some(data_columns) = data_columns {
@@ -461,7 +455,11 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
                         spec: self.spec.clone(),
                     })
                 } else {
-                    MaybeAvailableBlock::AvailabilityPending { block_root, block }
+                    MaybeAvailableBlock::AvailabilityPending {
+                        block_root,
+                        block,
+                        custody_columns_count,
+                    }
                 }
             } else {
                 MaybeAvailableBlock::Available(AvailableBlock {
@@ -817,6 +815,7 @@ pub enum MaybeAvailableBlock<E: EthSpec> {
     AvailabilityPending {
         block_root: Hash256,
         block: Arc<SignedBeaconBlock<E>>,
+        custody_columns_count: usize,
     },
 }
 

--- a/beacon_node/beacon_chain/src/data_availability_checker/error.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/error.rs
@@ -10,7 +10,7 @@ pub enum Error {
         blob_commitment: KzgCommitment,
         block_commitment: KzgCommitment,
     },
-    Unexpected,
+    Unexpected(&'static str),
     SszTypes(ssz_types::Error),
     MissingBlobs,
     MissingCustodyColumns,
@@ -40,7 +40,7 @@ impl Error {
             | Error::MissingCustodyColumns
             | Error::StoreError(_)
             | Error::DecodeError(_)
-            | Error::Unexpected
+            | Error::Unexpected(_)
             | Error::ParentStateMissing(_)
             | Error::BlockReplayError(_)
             | Error::RebuildingStateCaches(_)

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -165,7 +165,6 @@ impl<E: EthSpec> PendingComponents<E> {
     /// reconstructed from disk. Ensure you are not holding any write locks while calling this.
     pub fn make_available<R>(
         &mut self,
-        custody_column_count: usize,
         spec: &Arc<ChainSpec>,
         recover: R,
     ) -> Result<Option<AvailableExecutedBlock<E>>, AvailabilityCheckError>
@@ -184,7 +183,11 @@ impl<E: EthSpec> PendingComponents<E> {
         let blob_data = if num_expected_blobs == 0 {
             Some(AvailableBlockData::NoData)
         } else if spec.is_peer_das_enabled_for_epoch(block.epoch()) {
-            match self.verified_data_columns.len().cmp(&custody_column_count) {
+            match self
+                .verified_data_columns
+                .len()
+                .cmp(&block.custody_columns_count())
+            {
                 Ordering::Greater => {
                     // Should never happen
                     return Err(AvailabilityCheckError::Unexpected("too many columns"));
@@ -259,6 +262,7 @@ impl<E: EthSpec> PendingComponents<E> {
             block,
             import_data,
             payload_verification_outcome,
+            custody_columns_count: _,
         } = recover(block.clone())?;
 
         let available_block = AvailableBlock {
@@ -313,14 +317,14 @@ impl<E: EthSpec> PendingComponents<E> {
             })
     }
 
-    pub fn status_str(
-        &self,
-        block_epoch: Epoch,
-        sampling_column_count: usize,
-        spec: &ChainSpec,
-    ) -> String {
+    pub fn status_str(&self, block_epoch: Epoch, spec: &ChainSpec) -> String {
         let block_count = if self.executed_block.is_some() { 1 } else { 0 };
         if spec.is_peer_das_enabled_for_epoch(block_epoch) {
+            let custody_columns_count = if let Some(block) = self.get_cached_block() {
+                &block.custody_columns_count().to_string()
+            } else {
+                "?"
+            };
             let data_column_recv_count = if self.data_column_recv.is_some() {
                 1
             } else {
@@ -330,7 +334,7 @@ impl<E: EthSpec> PendingComponents<E> {
                 "block {} data_columns {}/{} data_columns_recv {}",
                 block_count,
                 self.verified_data_columns.len(),
-                sampling_column_count,
+                custody_columns_count,
                 data_column_recv_count,
             )
         } else {
@@ -357,8 +361,6 @@ pub struct DataAvailabilityCheckerInner<T: BeaconChainTypes> {
     /// This cache holds a limited number of states in memory and reconstructs them
     /// from disk when necessary. This is necessary until we merge tree-states
     state_cache: StateLRUCache<T>,
-    /// The number of data columns the node is sampling via subnet sampling.
-    sampling_column_count: usize,
     spec: Arc<ChainSpec>,
 }
 
@@ -375,19 +377,13 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
     pub fn new(
         capacity: NonZeroUsize,
         beacon_store: BeaconStore<T>,
-        sampling_column_count: usize,
         spec: Arc<ChainSpec>,
     ) -> Result<Self, AvailabilityCheckError> {
         Ok(Self {
             critical: RwLock::new(LruCache::new(capacity)),
             state_cache: StateLRUCache::new(beacon_store, spec.clone()),
-            sampling_column_count,
             spec,
         })
-    }
-
-    pub fn sampling_column_count(&self) -> usize {
-        self.sampling_column_count
     }
 
     /// Returns true if the block root is known, without altering the LRU ordering
@@ -489,14 +485,12 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         debug!(log, "Component added to data availability checker";
             "component" => "blobs",
             "block_root" => ?block_root,
-            "status" => pending_components.status_str(epoch, self.sampling_column_count, &self.spec),
+            "status" => pending_components.status_str(epoch, &self.spec),
         );
 
-        if let Some(available_block) =
-            pending_components.make_available(self.sampling_column_count, &self.spec, |block| {
-                self.state_cache.recover_pending_executed_block(block)
-            })?
-        {
+        if let Some(available_block) = pending_components.make_available(&self.spec, |block| {
+            self.state_cache.recover_pending_executed_block(block)
+        })? {
             // We keep the pending components in the availability cache during block import (#5845).
             // `data_column_recv` is returned as part of the available block and is no longer needed here.
             write_lock.put(block_root, pending_components);
@@ -542,14 +536,12 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         debug!(log, "Component added to data availability checker";
             "component" => "data_columns",
             "block_root" => ?block_root,
-            "status" => pending_components.status_str(epoch, self.sampling_column_count, &self.spec),
+            "status" => pending_components.status_str(epoch, &self.spec),
         );
 
-        if let Some(available_block) =
-            pending_components.make_available(self.sampling_column_count, &self.spec, |block| {
-                self.state_cache.recover_pending_executed_block(block)
-            })?
-        {
+        if let Some(available_block) = pending_components.make_available(&self.spec, |block| {
+            self.state_cache.recover_pending_executed_block(block)
+        })? {
             // We keep the pending components in the availability cache during block import (#5845).
             // `data_column_recv` is returned as part of the available block and is no longer needed here.
             write_lock.put(block_root, pending_components);
@@ -592,14 +584,12 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         debug!(log, "Component added to data availability checker";
             "component" => "data_columns_recv",
             "block_root" => ?block_root,
-            "status" => pending_components.status_str(block_epoch, self.sampling_column_count, &self.spec),
+            "status" => pending_components.status_str(block_epoch, &self.spec),
         );
 
-        if let Some(available_block) =
-            pending_components.make_available(self.sampling_column_count, &self.spec, |block| {
-                self.state_cache.recover_pending_executed_block(block)
-            })?
-        {
+        if let Some(available_block) = pending_components.make_available(&self.spec, |block| {
+            self.state_cache.recover_pending_executed_block(block)
+        })? {
             // We keep the pending components in the availability cache during block import (#5845).
             // `data_column_recv` is returned as part of the available block and is no longer needed here.
             write_lock.put(block_root, pending_components);
@@ -631,19 +621,16 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         };
 
         // If we're sampling all columns, it means we must be custodying all columns.
-        let custody_column_count = self.sampling_column_count();
         let total_column_count = self.spec.number_of_columns as usize;
         let received_column_count = pending_components.verified_data_columns.len();
 
         if pending_components.reconstruction_started {
             return ReconstructColumnsDecision::No("already started");
         }
-        if custody_column_count != total_column_count {
-            return ReconstructColumnsDecision::No("not required for full node");
-        }
         if received_column_count >= total_column_count {
             return ReconstructColumnsDecision::No("all columns received");
         }
+        // Only supernodes receive >= 50% of columns
         if received_column_count < total_column_count / 2 {
             return ReconstructColumnsDecision::No("not enough columns");
         }
@@ -692,15 +679,13 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         debug!(log, "Component added to data availability checker";
             "component" => "block",
             "block_root" => ?block_root,
-            "status" => pending_components.status_str(epoch, self.sampling_column_count, &self.spec),
+            "status" => pending_components.status_str(epoch, &self.spec),
         );
 
         // Check if we have all components and entire set is consistent.
-        if let Some(available_block) =
-            pending_components.make_available(self.sampling_column_count, &self.spec, |block| {
-                self.state_cache.recover_pending_executed_block(block)
-            })?
-        {
+        if let Some(available_block) = pending_components.make_available(&self.spec, |block| {
+            self.state_cache.recover_pending_executed_block(block)
+        })? {
             // We keep the pending components in the availability cache during block import (#5845).
             // `data_column_recv` is returned as part of the available block and is no longer needed here.
             write_lock.put(block_root, pending_components);
@@ -947,6 +932,7 @@ mod test {
             block,
             import_data,
             payload_verification_outcome,
+            custody_columns_count: DEFAULT_TEST_CUSTODY_COLUMN_COUNT,
         };
 
         (availability_pending_block, gossip_verified_blobs)
@@ -974,13 +960,8 @@ mod test {
         let test_store = harness.chain.store.clone();
         let capacity_non_zero = new_non_zero_usize(capacity);
         let cache = Arc::new(
-            DataAvailabilityCheckerInner::<T>::new(
-                capacity_non_zero,
-                test_store,
-                DEFAULT_TEST_CUSTODY_COLUMN_COUNT,
-                spec.clone(),
-            )
-            .expect("should create cache"),
+            DataAvailabilityCheckerInner::<T>::new(capacity_non_zero, test_store, spec.clone())
+                .expect("should create cache"),
         );
         (harness, cache, chain_db_path)
     }
@@ -1330,6 +1311,8 @@ mod pending_components_tests {
                 payload_verification_status: PayloadVerificationStatus::Verified,
                 is_valid_merge_transition_block: false,
             },
+            // Default custody columns count, doesn't matter here
+            custody_columns_count: 8,
         };
         (block.into(), blobs, invalid_blobs)
     }

--- a/beacon_node/beacon_chain/src/data_availability_checker/state_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/state_lru_cache.rs
@@ -136,7 +136,6 @@ impl<T: BeaconChainTypes> StateLRUCache<T> {
                 consensus_context: diet_executed_block
                     .consensus_context
                     .into_consensus_context(),
-                data_column_recv: None,
             },
             payload_verification_outcome: diet_executed_block.payload_verification_outcome,
         })

--- a/beacon_node/beacon_chain/src/data_availability_checker/state_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/state_lru_cache.rs
@@ -29,6 +29,7 @@ pub struct DietAvailabilityPendingExecutedBlock<E: EthSpec> {
     confirmed_state_roots: Vec<Hash256>,
     consensus_context: OnDiskConsensusContext<E>,
     payload_verification_outcome: PayloadVerificationOutcome,
+    custody_columns_count: usize,
 }
 
 /// just implementing the same methods as `AvailabilityPendingExecutedBlock`
@@ -56,6 +57,10 @@ impl<E: EthSpec> DietAvailabilityPendingExecutedBlock<E> {
             .blob_kzg_commitments()
             .cloned()
             .unwrap_or_default()
+    }
+
+    pub fn custody_columns_count(&self) -> usize {
+        self.custody_columns_count
     }
 
     /// Returns the epoch corresponding to `self.slot()`.
@@ -108,6 +113,7 @@ impl<T: BeaconChainTypes> StateLRUCache<T> {
                 executed_block.import_data.consensus_context,
             ),
             payload_verification_outcome: executed_block.payload_verification_outcome,
+            custody_columns_count: executed_block.custody_columns_count,
         }
     }
 
@@ -138,6 +144,7 @@ impl<T: BeaconChainTypes> StateLRUCache<T> {
                     .into_consensus_context(),
             },
             payload_verification_outcome: diet_executed_block.payload_verification_outcome,
+            custody_columns_count: diet_executed_block.custody_columns_count,
         })
     }
 
@@ -225,6 +232,7 @@ impl<E: EthSpec> From<AvailabilityPendingExecutedBlock<E>>
                 value.import_data.consensus_context,
             ),
             payload_verification_outcome: value.payload_verification_outcome,
+            custody_columns_count: value.custody_columns_count,
         }
     }
 }

--- a/beacon_node/beacon_chain/src/fetch_blobs.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs.rs
@@ -273,13 +273,6 @@ fn spawn_compute_and_publish_data_columns_task<T: BeaconChainTypes>(
                 return;
             };
 
-            // At the moment non supernodes are not required to publish any columns.
-            // TODO(das): we could experiment with having full nodes publish their custodied
-            // columns here.
-            if !chain_cloned.data_availability_checker.is_supernode() {
-                return;
-            }
-
             publish_fn(BlobsOrDataColumns::DataColumns(all_data_columns));
         },
         "compute_and_publish_data_columns",

--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -94,27 +94,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Ok(0);
         }
 
-        // Blobs are stored per block, and data columns are each stored individually
-        let n_blob_ops_per_block = if self.spec.is_peer_das_scheduled() {
-            // TODO(das): `available_block includes all sampled columns, but we only need to store
-            // custody columns. To be clarified in spec PR.
-            self.data_availability_checker.get_sampling_column_count()
-        } else {
-            1
-        };
-
-        let blob_batch_size = blocks_to_import
-            .iter()
-            .filter(|available_block| available_block.has_blobs())
-            .count()
-            .saturating_mul(n_blob_ops_per_block);
-
         let mut expected_block_root = anchor_info.oldest_block_parent;
         let mut prev_block_slot = anchor_info.oldest_block_slot;
         let mut new_oldest_blob_slot = blob_info.oldest_blob_slot;
         let mut new_oldest_data_column_slot = data_column_info.oldest_data_column_slot;
 
-        let mut blob_batch = Vec::<KeyValueStoreOp>::with_capacity(blob_batch_size);
+        let mut blob_batch = Vec::<KeyValueStoreOp>::new();
         let mut cold_batch = Vec::with_capacity(blocks_to_import.len());
         let mut hot_batch = Vec::with_capacity(blocks_to_import.len());
         let mut signed_blocks = Vec::with_capacity(blocks_to_import.len());

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -779,6 +779,7 @@ where
                 SensitiveUrl::parse(format!("http://127.0.0.1:{port}").as_str()).unwrap(),
                 None,
                 None,
+                false,
             )
             .unwrap();
 

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -815,6 +815,11 @@ where
         (0..self.validator_keypairs.len()).collect()
     }
 
+    pub fn get_sampling_column_count(&self) -> usize {
+        // Default column custody count
+        8
+    }
+
     pub fn slots_per_epoch(&self) -> u64 {
         E::slots_per_epoch()
     }
@@ -2375,8 +2380,14 @@ where
                 .into_iter()
                 .map(CustodyDataColumn::from_asserted_custody)
                 .collect::<Vec<_>>();
-            RpcBlock::new_with_custody_columns(Some(block_root), block, custody_columns, &self.spec)
-                .unwrap()
+            RpcBlock::new_with_custody_columns(
+                Some(block_root),
+                block,
+                custody_columns,
+                self.get_sampling_column_count(),
+                &self.spec,
+            )
+            .unwrap()
         } else {
             let blobs = self.chain.get_blobs(&block_root).unwrap().blobs();
             RpcBlock::new(Some(block_root), block, blobs).unwrap()
@@ -2391,10 +2402,7 @@ where
         blob_items: Option<(KzgProofs<E>, BlobsList<E>)>,
     ) -> Result<RpcBlock<E>, BlockError> {
         Ok(if self.spec.is_peer_das_enabled_for_epoch(block.epoch()) {
-            let sampling_column_count = self
-                .chain
-                .data_availability_checker
-                .get_sampling_column_count();
+            let sampling_column_count = self.get_sampling_column_count();
 
             if blob_items.is_some_and(|(_, blobs)| !blobs.is_empty()) {
                 // Note: this method ignores the actual custody columns and just take the first
@@ -2405,7 +2413,13 @@ where
                     .take(sampling_column_count)
                     .map(CustodyDataColumn::from_asserted_custody)
                     .collect::<Vec<_>>();
-                RpcBlock::new_with_custody_columns(Some(block_root), block, columns, &self.spec)?
+                RpcBlock::new_with_custody_columns(
+                    Some(block_root),
+                    block,
+                    columns,
+                    sampling_column_count,
+                    &self.spec,
+                )?
             } else {
                 RpcBlock::new_without_blobs(Some(block_root), block)
             }
@@ -3106,10 +3120,7 @@ where
         let is_peerdas_enabled = self.chain.spec.is_peer_das_enabled_for_epoch(block.epoch());
         if is_peerdas_enabled {
             let custody_columns = custody_columns_opt.unwrap_or_else(|| {
-                let sampling_column_count = self
-                    .chain
-                    .data_availability_checker
-                    .get_sampling_column_count() as u64;
+                let sampling_column_count = self.get_sampling_column_count() as u64;
                 (0..sampling_column_count).collect()
             });
 

--- a/beacon_node/beacon_chain/tests/attestation_production.rs
+++ b/beacon_node/beacon_chain/tests/attestation_production.rs
@@ -242,7 +242,7 @@ async fn produces_attestations() {
                     .early_attester_cache
                     .add_head_block(
                         block_root,
-                        available_block,
+                        &available_block,
                         proto_block,
                         &state,
                         &chain.spec,
@@ -310,7 +310,7 @@ async fn early_attester_cache_old_request() {
         .early_attester_cache
         .add_head_block(
             head.beacon_block_root,
-            available_block,
+            &available_block,
             head_proto_block,
             &head.beacon_state,
             &harness.chain.spec,

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -112,7 +112,7 @@ const API_PREFIX: &str = "eth";
 ///
 /// This helps prevent attacks where nodes can convince us that we're syncing some non-existent
 /// finalized head.
-const SYNC_TOLERANCE_EPOCHS: u64 = 8;
+const DEFAULT_SYNC_TOLERANCE_EPOCHS: u64 = 8;
 
 /// A custom type which allows for both unsecured and TLS-enabled HTTP servers.
 type HttpServer = (SocketAddr, Pin<Box<dyn Future<Output = ()> + Send>>);
@@ -156,6 +156,7 @@ pub struct Config {
     #[serde(with = "eth2::types::serde_status_code")]
     pub duplicate_block_status_code: StatusCode,
     pub target_peers: usize,
+    pub sync_tolerance_epochs: Option<u64>,
 }
 
 impl Default for Config {
@@ -171,6 +172,7 @@ impl Default for Config {
             enable_beacon_processor: true,
             duplicate_block_status_code: StatusCode::ACCEPTED,
             target_peers: 100,
+            sync_tolerance_epochs: None,
         }
     }
 }
@@ -459,7 +461,10 @@ pub fn serve<T: BeaconChainTypes>(
                                     )
                                 })?;
 
-                            let tolerance = SYNC_TOLERANCE_EPOCHS * T::EthSpec::slots_per_epoch();
+                            let sync_tolerance_epochs = config
+                                .sync_tolerance_epochs
+                                .unwrap_or(DEFAULT_SYNC_TOLERANCE_EPOCHS);
+                            let tolerance = sync_tolerance_epochs * T::EthSpec::slots_per_epoch();
 
                             if head_slot + tolerance >= current_slot {
                                 Ok(())

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -86,6 +86,8 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlock<T>>(
     network_globals: Arc<NetworkGlobals<T::EthSpec>>,
 ) -> Result<Response, Rejection> {
     let seen_timestamp = timestamp_now();
+    let block_publishing_delay_for_testing = chain.config.block_publishing_delay;
+    let data_column_publishing_delay_for_testing = chain.config.data_column_publishing_delay;
 
     let (unverified_block, unverified_blobs, is_locally_built_block) = match provenanced_block {
         ProvenancedBlock::Local(block, blobs, _) => (block, blobs, true),
@@ -147,6 +149,14 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlock<T>>(
 
     let should_publish_block = gossip_verified_block_result.is_ok();
     if BroadcastValidation::Gossip == validation_level && should_publish_block {
+        if let Some(block_publishing_delay) = block_publishing_delay_for_testing {
+            debug!(
+                log,
+                "Publishing block with artificial delay";
+                "block_publishing_delay" => ?block_publishing_delay
+            );
+            tokio::time::sleep(block_publishing_delay).await;
+        }
         publish_block_p2p(
             block.clone(),
             sender_clone.clone(),
@@ -207,6 +217,23 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlock<T>>(
     }
 
     if gossip_verified_columns.iter().map(Option::is_some).count() > 0 {
+        if let Some(data_column_publishing_delay) = data_column_publishing_delay_for_testing {
+            // Subtract block publishing delay if it is also used.
+            // Note: if `data_column_publishing_delay` is less than `block_publishing_delay`, it
+            // will still be delayed by `block_publishing_delay`. This could be solved with spawning
+            // async tasks but the limitation is minor and I believe it's probably not worth
+            // affecting the mainnet code path.
+            let block_publishing_delay = block_publishing_delay_for_testing.unwrap_or_default();
+            let delay = data_column_publishing_delay.saturating_sub(block_publishing_delay);
+            if !delay.is_zero() {
+                debug!(
+                    log,
+                    "Publishing data columns with artificial delay";
+                    "data_column_publishing_delay" => ?data_column_publishing_delay
+                );
+                tokio::time::sleep(delay).await;
+            }
+        }
         publish_column_sidecars(network_tx, &gossip_verified_columns, &chain).map_err(|_| {
             warp_utils::reject::custom_server_error("unable to publish data column sidecars".into())
         })?;

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -139,7 +139,8 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlock<T>>(
         spawn_build_data_sidecar_task(chain.clone(), block.clone(), unverified_blobs, log.clone())?;
 
     // Gossip verify the block and blobs/data columns separately.
-    let gossip_verified_block_result = unverified_block.into_gossip_verified_block(&chain);
+    let gossip_verified_block_result = unverified_block
+        .into_gossip_verified_block(&chain, network_globals.custody_columns_count() as usize);
     let block_root = block_root.unwrap_or_else(|| {
         gossip_verified_block_result.as_ref().map_or_else(
             |_| block.canonical_root(),

--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -249,7 +249,6 @@ pub async fn create_api_server_with_config<T: BeaconChainTypes>(
             enabled: true,
             listen_port: port,
             data_dir: std::path::PathBuf::from(DEFAULT_ROOT_DIR),
-            enable_light_client_server: true,
             ..http_config
         },
         chain: Some(chain),

--- a/beacon_node/lighthouse_network/src/types/globals.rs
+++ b/beacon_node/lighthouse_network/src/types/globals.rs
@@ -33,6 +33,8 @@ pub struct NetworkGlobals<E: EthSpec> {
     /// The computed sampling subnets and columns is stored to avoid re-computing.
     pub sampling_subnets: HashSet<DataColumnSubnetId>,
     pub sampling_columns: HashSet<ColumnIndex>,
+    /// Constant custody group count (CGC) set at startup
+    custody_group_count: u64,
     /// Network-related configuration. Immutable after initialization.
     pub config: Arc<NetworkConfig>,
     /// Ethereum chain configuration. Immutable after initialization.
@@ -49,47 +51,43 @@ impl<E: EthSpec> NetworkGlobals<E> {
         config: Arc<NetworkConfig>,
         spec: Arc<ChainSpec>,
     ) -> Self {
-        let (sampling_subnets, sampling_columns) = if spec.is_peer_das_scheduled() {
-            let node_id = enr.node_id().raw();
+        let node_id = enr.node_id().raw();
 
-            let custody_group_count = match local_metadata.custody_group_count() {
-                Ok(&cgc) if cgc <= spec.number_of_custody_groups => cgc,
-                _ => {
+        let custody_group_count = match local_metadata.custody_group_count() {
+            Ok(&cgc) if cgc <= spec.number_of_custody_groups => cgc,
+            _ => {
+                if spec.is_peer_das_scheduled() {
                     error!(
                         log,
                         "custody_group_count from metadata is either invalid or not set. This is a bug!";
                         "info" => "falling back to default custody requirement"
                     );
-                    spec.custody_requirement
                 }
-            };
-
-            // The below `expect` calls will panic on start up if the chain spec config values used
-            // are invalid
-            let sampling_size = spec
-                .sampling_size(custody_group_count)
-                .expect("should compute node sampling size from valid chain spec");
-            let custody_groups = get_custody_groups(node_id, sampling_size, &spec)
-                .expect("should compute node custody groups");
-
-            let mut sampling_subnets = HashSet::new();
-            for custody_index in &custody_groups {
-                let subnets = compute_subnets_from_custody_group(*custody_index, &spec)
-                    .expect("should compute custody subnets for node");
-                sampling_subnets.extend(subnets);
+                spec.custody_requirement
             }
-
-            let mut sampling_columns = HashSet::new();
-            for custody_index in &custody_groups {
-                let columns = compute_columns_for_custody_group(*custody_index, &spec)
-                    .expect("should compute custody columns for node");
-                sampling_columns.extend(columns);
-            }
-
-            (sampling_subnets, sampling_columns)
-        } else {
-            (HashSet::new(), HashSet::new())
         };
+
+        // The below `expect` calls will panic on start up if the chain spec config values used
+        // are invalid
+        let sampling_size = spec
+            .sampling_size(custody_group_count)
+            .expect("should compute node sampling size from valid chain spec");
+        let custody_groups = get_custody_groups(node_id, sampling_size, &spec)
+            .expect("should compute node custody groups");
+
+        let mut sampling_subnets = HashSet::new();
+        for custody_index in &custody_groups {
+            let subnets = compute_subnets_from_custody_group(*custody_index, &spec)
+                .expect("should compute custody subnets for node");
+            sampling_subnets.extend(subnets);
+        }
+
+        let mut sampling_columns = HashSet::new();
+        for custody_index in &custody_groups {
+            let columns = compute_columns_for_custody_group(*custody_index, &spec)
+                .expect("should compute custody columns for node");
+            sampling_columns.extend(columns);
+        }
 
         NetworkGlobals {
             local_enr: RwLock::new(enr.clone()),
@@ -102,6 +100,7 @@ impl<E: EthSpec> NetworkGlobals<E> {
             backfill_state: RwLock::new(BackFillState::Paused),
             sampling_subnets,
             sampling_columns,
+            custody_group_count,
             config,
             spec,
         }
@@ -121,6 +120,16 @@ impl<E: EthSpec> NetworkGlobals<E> {
     /// Returns the list of `Multiaddr` that the underlying libp2p instance is listening on.
     pub fn listen_multiaddrs(&self) -> Vec<Multiaddr> {
         self.listen_multiaddrs.read().clone()
+    }
+
+    /// Returns true if this node is configured as a PeerDAS supernode
+    pub fn is_supernode(&self) -> bool {
+        self.custody_group_count == self.spec.number_of_columns
+    }
+
+    /// Returns the count of custody columns this node must sample for block import
+    pub fn custody_columns_count(&self) -> u64 {
+        self.custody_group_count
     }
 
     /// Returns the number of libp2p connected peers.

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1299,7 +1299,10 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let verification_result = self
             .chain
             .clone()
-            .verify_block_for_gossip(block.clone())
+            .verify_block_for_gossip(
+                block.clone(),
+                self.network_globals.custody_columns_count() as usize,
+            )
             .await;
 
         if verification_result.is_ok() {

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -938,9 +938,14 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         block_root: Hash256,
         publish_blobs: bool,
     ) {
+        let is_supernode = self.network_globals.is_supernode();
+
         let self_cloned = self.clone();
         let publish_fn = move |blobs_or_data_column| {
-            if publish_blobs {
+            // At the moment non supernodes are not required to publish any columns.
+            // TODO(das): we could experiment with having full nodes publish their custodied
+            // columns here.
+            if publish_blobs && is_supernode {
                 match blobs_or_data_column {
                     BlobsOrDataColumns::Blobs(blobs) => {
                         self_cloned.publish_blobs_gradually(blobs, block_root);

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -195,8 +195,14 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                     ));
                 }
 
-                RpcBlock::new_with_custody_columns(Some(block_root), block, custody_columns, spec)
-                    .map_err(|e| format!("{e:?}"))?
+                RpcBlock::new_with_custody_columns(
+                    Some(block_root),
+                    block,
+                    custody_columns,
+                    expects_custody_columns.len(),
+                    spec,
+                )
+                .map_err(|e| format!("{e:?}"))?
             } else {
                 RpcBlock::new_without_blobs(Some(block_root), block)
             });

--- a/beacon_node/network/src/sync/tests/lookups.rs
+++ b/beacon_node/network/src/sync/tests/lookups.rs
@@ -1217,8 +1217,12 @@ impl TestRig {
             payload_verification_status: PayloadVerificationStatus::Verified,
             is_valid_merge_transition_block: false,
         };
-        let executed_block =
-            AvailabilityPendingExecutedBlock::new(block, import_data, payload_verification_outcome);
+        let executed_block = AvailabilityPendingExecutedBlock::new(
+            block,
+            import_data,
+            payload_verification_outcome,
+            self.network_globals.custody_columns_count() as usize,
+        );
         match self
             .harness
             .chain

--- a/beacon_node/network/src/sync/tests/range.rs
+++ b/beacon_node/network/src/sync/tests/range.rs
@@ -449,7 +449,15 @@ fn build_rpc_block(
             RpcBlock::new(None, block, Some(blobs.clone())).unwrap()
         }
         Some(DataSidecars::DataColumns(columns)) => {
-            RpcBlock::new_with_custody_columns(None, block, columns.clone(), spec).unwrap()
+            RpcBlock::new_with_custody_columns(
+                None,
+                block,
+                columns.clone(),
+                // TODO
+                columns.len(),
+                spec,
+            )
+            .unwrap()
         }
         None => RpcBlock::new_without_blobs(None, block),
     }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1461,6 +1461,15 @@ pub fn cli_app() -> Command {
                 .display_order(0)
         )
         .arg(
+            Arg::new("builder-disable-ssz")
+                .long("builder-disable-ssz")
+                .value_name("BOOLEAN")
+                .help("Disables sending requests using SSZ over the builder API.")
+                .requires("builder")
+                .action(ArgAction::SetTrue)
+                .display_order(0)
+        )
+        .arg(
             Arg::new("reset-payload-statuses")
                 .long("reset-payload-statuses")
                 .help("When present, Lighthouse will forget the payload statuses of any \

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1599,5 +1599,30 @@ pub fn cli_app() -> Command {
                 .action(ArgAction::Set)
                 .display_order(0)
         )
+        .arg(
+            Arg::new("delay-block-publishing")
+                .long("delay-block-publishing")
+                .value_name("SECONDS")
+                .action(ArgAction::Set)
+                .help_heading(FLAG_HEADER)
+                .help("TESTING ONLY: Artificially delay block publishing by the specified number of seconds. \
+                        This only works for if `BroadcastValidation::Gossip` is used (default). \
+                        DO NOT USE IN PRODUCTION.")
+                .hide(true)
+                .display_order(0)
+        )
+        .arg(
+            Arg::new("delay-data-column-publishing")
+                .long("delay-data-column-publishing")
+                .value_name("SECONDS") 
+                .action(ArgAction::Set)
+                .help_heading(FLAG_HEADER)
+                .help("TESTING ONLY: Artificially delay data column publishing by the specified number of seconds. \
+                       Limitation: If `delay-block-publishing` is also used, data columns will be delayed for a \
+                       minimum of `delay-block-publishing` seconds.
+                       DO NOT USE IN PRODUCTION.")
+                .hide(true)
+                .display_order(0)
+        )
         .group(ArgGroup::new("enable_http").args(["http", "gui", "staking"]).multiple(true))
 }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1510,6 +1510,19 @@ pub fn cli_app() -> Command {
                 .display_order(0)
         )
         .arg(
+            Arg::new("sync-tolerance-epochs")
+                .long("sync-tolerance-epochs")
+                .help("Overrides the default SYNC_TOLERANCE_EPOCHS. This flag is not intended \
+                    for production and MUST only be used in TESTING only. This is primarily used \
+                    for testing range sync, to prevent the node from producing a block before the \
+                    node is synced with the network which may result in the node getting \
+                    disconnected from peers immediately.")
+                .hide(true)
+                .requires("enable_http")
+                .action(ArgAction::Set)
+                .display_order(0)
+        )
+        .arg(
             Arg::new("gui")
                 .long("gui")
                 .help("Enable the graphical user interface and all its requirements. \

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -346,6 +346,8 @@ pub fn get_config<E: EthSpec>(
         el_config.builder_header_timeout =
             clap_utils::parse_optional(cli_args, "builder-header-timeout")?
                 .map(Duration::from_millis);
+
+        el_config.disable_builder_ssz_requests = cli_args.get_flag("builder-disable-ssz");
     }
 
     // Set config values from parse values.

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -174,9 +174,6 @@ pub fn get_config<E: EthSpec>(
 
         client_config.http_api.duplicate_block_status_code =
             parse_required(cli_args, "http-duplicate-block-status")?;
-
-        client_config.http_api.enable_light_client_server =
-            !cli_args.get_flag("disable-light-client-server");
     }
 
     if cli_args.get_flag("light-client-server") {

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -895,6 +895,14 @@ pub fn get_config<E: EthSpec>(
         .max_gossip_aggregate_batch_size =
         clap_utils::parse_required(cli_args, "beacon-processor-aggregate-batch-size")?;
 
+    if let Some(delay) = clap_utils::parse_optional(cli_args, "delay-block-publishing")? {
+        client_config.chain.block_publishing_delay = Some(Duration::from_secs_f64(delay));
+    }
+
+    if let Some(delay) = clap_utils::parse_optional(cli_args, "delay-data-column-publishing")? {
+        client_config.chain.data_column_publishing_delay = Some(Duration::from_secs_f64(delay));
+    }
+
     Ok(client_config)
 }
 

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -8,7 +8,7 @@ use beacon_chain::graffiti_calculator::GraffitiOrigin;
 use beacon_chain::TrustedSetup;
 use clap::{parser::ValueSource, ArgMatches, Id};
 use clap_utils::flags::DISABLE_MALLOC_TUNING_FLAG;
-use clap_utils::{parse_flag, parse_required};
+use clap_utils::{parse_flag, parse_optional, parse_required};
 use client::{ClientConfig, ClientGenesis};
 use directory::{DEFAULT_BEACON_NODE_DIR, DEFAULT_NETWORK_DIR, DEFAULT_ROOT_DIR};
 use environment::RuntimeContext;
@@ -174,6 +174,9 @@ pub fn get_config<E: EthSpec>(
 
         client_config.http_api.duplicate_block_status_code =
             parse_required(cli_args, "http-duplicate-block-status")?;
+
+        client_config.http_api.sync_tolerance_epochs =
+            parse_optional(cli_args, "sync-tolerance-epochs")?;
     }
 
     if cli_args.get_flag("light-client-server") {

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -28,6 +28,8 @@ Options:
           network. Multiaddr is also supported.
       --builder <builder>
           The URL of a service compatible with the MEV-boost API.
+      --builder-disable-ssz
+          Disables sending requests using SSZ over the builder API.
       --builder-fallback-epochs-since-finalization <builder-fallback-epochs-since-finalization>
           If this node is proposing a block and the chain has not finalized
           within this number of epochs, it will NOT query any connected

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2715,3 +2715,29 @@ fn beacon_node_backend_override() {
             assert_eq!(config.store.backend, BeaconNodeBackend::LevelDb);
         });
 }
+
+#[test]
+fn block_publishing_delay_for_testing() {
+    CommandLineTest::new()
+        .flag("delay-block-publishing", Some("2.5"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(
+                config.chain.block_publishing_delay,
+                Some(Duration::from_secs_f64(2.5f64))
+            );
+        });
+}
+
+#[test]
+fn data_column_publishing_delay_for_testing() {
+    CommandLineTest::new()
+        .flag("delay-data-column-publishing", Some("3.5"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(
+                config.chain.data_column_publishing_delay,
+                Some(Duration::from_secs_f64(3.5f64))
+            );
+        });
+}

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -720,6 +720,40 @@ fn builder_user_agent() {
     );
 }
 
+#[test]
+fn test_builder_disable_ssz_flag() {
+    run_payload_builder_flag_test_with_config(
+        "builder",
+        "http://meow.cats",
+        None,
+        None,
+        |config| {
+            assert!(
+                !config
+                    .execution_layer
+                    .as_ref()
+                    .unwrap()
+                    .disable_builder_ssz_requests,
+            );
+        },
+    );
+    run_payload_builder_flag_test_with_config(
+        "builder",
+        "http://meow.cats",
+        Some("builder-disable-ssz"),
+        None,
+        |config| {
+            assert!(
+                config
+                    .execution_layer
+                    .as_ref()
+                    .unwrap()
+                    .disable_builder_ssz_requests,
+            );
+        },
+    );
+}
+
 fn run_jwt_optional_flags_test(jwt_flag: &str, jwt_id_flag: &str, jwt_version_flag: &str) {
     use sensitive_url::SensitiveUrl;
 

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2544,6 +2544,17 @@ fn light_client_http_server_disabled() {
 }
 
 #[test]
+fn sync_tolerance_epochs() {
+    CommandLineTest::new()
+        .flag("http", None)
+        .flag("sync-tolerance-epochs", Some("0"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(config.http_api.sync_tolerance_epochs, Some(0));
+        });
+}
+
+#[test]
 fn gui_flag() {
     CommandLineTest::new()
         .flag("gui", None)

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2506,7 +2506,6 @@ fn light_client_server_default() {
         .with_config(|config| {
             assert!(config.network.enable_light_client_server);
             assert!(config.chain.enable_light_client_server);
-            assert!(config.http_api.enable_light_client_server);
         });
 }
 
@@ -2539,7 +2538,6 @@ fn light_client_http_server_disabled() {
         .flag("disable-light-client-server", None)
         .run_with_zero_port()
         .with_config(|config| {
-            assert!(!config.http_api.enable_light_client_server);
             assert!(!config.network.enable_light_client_server);
             assert!(!config.chain.enable_light_client_server);
         });

--- a/scripts/local_testnet/network_params_das.yaml
+++ b/scripts/local_testnet/network_params_das.yaml
@@ -4,11 +4,15 @@ participants:
     cl_extra_params:
       - --subscribe-all-data-column-subnets
       - --subscribe-all-subnets
+      # Note: useful for testing range sync (only produce block if node is in sync to prevent forking)
+      - --sync-tolerance-epochs=0
       - --target-peers=3
     count: 2
   - cl_type: lighthouse
     cl_image: lighthouse:local
     cl_extra_params:
+      # Note: useful for testing range sync (only produce block if node is in sync to prevent forking)
+      - --sync-tolerance-epochs=0
       - --target-peers=3
     count: 2
 network_params:

--- a/testing/simulator/src/local_network.rs
+++ b/testing/simulator/src/local_network.rs
@@ -44,7 +44,6 @@ fn default_client_config(network_params: LocalNetworkParams, genesis_time: u64) 
     beacon_config.network.enable_light_client_server = true;
     beacon_config.network.discv5_config.enable_packet_filter = false;
     beacon_config.chain.enable_light_client_server = true;
-    beacon_config.http_api.enable_light_client_server = true;
     beacon_config.chain.optimistic_finalized_sync = false;
     beacon_config.trusted_setup = serde_json::from_reader(get_trusted_setup().as_slice())
         .expect("Trusted setup bytes should be valid");


### PR DESCRIPTION
## Issue Addressed

Validator custody makes the CGC and set of sampling columns dynamic. Right now this information is stored twice:
- in the data availability checker
- in the network globals

If that state becomes dynamic we must make sure it is in sync updating it twice, or guarding it behind a mutex. However, I noted that we don't really have to keep the CGC inside the data availability checker. All consumers can actually read it from the network globals, and we can update `make_available` to read the expected count of data columns from the block.


