### PR TITLE
Add ChainSegmentBlock WIP

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_block_streamer.rs
+++ b/beacon_node/beacon_chain/src/beacon_block_streamer.rs
@@ -754,12 +754,14 @@ mod tests {
                     terminal_block.timestamp = timestamp;
                 }
             });
-        // finish out merge epoch
-        harness.extend_slots(slots_per_epoch / 2).await;
-        // finish rest of epochs
-        harness
-            .extend_slots((num_epochs - 1 - bellatrix_fork_epoch) * slots_per_epoch)
-            .await;
+        {
+            // finish out merge epoch
+            harness.extend_slots(slots_per_epoch / 2).await;
+            // finish rest of epochs
+            harness
+                .extend_slots((num_epochs - 1 - bellatrix_fork_epoch) * slots_per_epoch)
+                .await;
+        }
 
         let head = harness.chain.head_snapshot();
         let state = &head.beacon_state;

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -16,7 +16,7 @@ use crate::block_verification::{
     GossipVerifiedBlock, IntoExecutionPendingBlock,
 };
 use crate::block_verification_types::{
-    AsBlock, AvailableExecutedBlock, BlockImportData, ExecutedBlock, RpcBlock,
+    AsBlock, AvailableExecutedBlock, BlockImportData, ChainSegmentBlock, ExecutedBlock,
 };
 pub use crate::canonical_head::CanonicalHead;
 use crate::chain_config::ChainConfig;
@@ -132,9 +132,6 @@ use types::payload::BlockProductionVersion;
 use types::*;
 
 pub type ForkChoiceError = fork_choice::Error<crate::ForkChoiceStoreError>;
-
-/// Alias to appease clippy.
-type HashBlockTuple<E> = (Hash256, RpcBlock<E>);
 
 // These keys are all zero because they get stored in different columns, see `DBColumn` type.
 pub const BEACON_CHAIN_DB_KEY: Hash256 = Hash256::ZERO;
@@ -2730,8 +2727,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// This method is potentially long-running and should not run on the core executor.
     pub fn filter_chain_segment(
         self: &Arc<Self>,
-        chain_segment: Vec<RpcBlock<T::EthSpec>>,
-    ) -> Result<Vec<HashBlockTuple<T::EthSpec>>, ChainSegmentResult> {
+        chain_segment: Vec<ChainSegmentBlock<T::EthSpec>>,
+    ) -> Result<Vec<ChainSegmentBlock<T::EthSpec>>, ChainSegmentResult> {
         // This function will never import any blocks.
         let imported_blocks = vec![];
         let mut filtered_chain_segment = Vec::with_capacity(chain_segment.len());
@@ -2742,19 +2739,19 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let children = chain_segment
             .iter()
             .skip(1)
-            .map(|block| (block.parent_root(), block.slot()))
+            .map(|block| (block.block.parent_root(), block.block.slot()))
             .collect::<Vec<_>>();
 
         for (i, block) in chain_segment.into_iter().enumerate() {
             // Ensure the block is the correct structure for the fork at `block.slot()`.
-            if let Err(e) = block.as_block().fork_name(&self.spec) {
+            if let Err(e) = block.block.as_block().fork_name(&self.spec) {
                 return Err(ChainSegmentResult::Failed {
                     imported_blocks,
                     error: BlockError::InconsistentFork(e),
                 });
             }
 
-            let block_root = block.block_root();
+            let block_root = block.block.block_root();
 
             if let Some((child_parent_root, child_slot)) = children.get(i) {
                 // If this block has a child in this chain segment, ensure that its parent root matches
@@ -2770,7 +2767,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 }
 
                 // Ensure that the slots are strictly increasing throughout the chain segment.
-                if *child_slot <= block.slot() {
+                if *child_slot <= block.block.slot() {
                     return Err(ChainSegmentResult::Failed {
                         imported_blocks,
                         error: BlockError::NonLinearSlots,
@@ -2780,7 +2777,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
             match check_block_relevancy(block.as_block(), block_root, self) {
                 // If the block is relevant, add it to the filtered chain segment.
-                Ok(_) => filtered_chain_segment.push((block_root, block)),
+                Ok(_) => filtered_chain_segment.push(block),
                 // If the block is already known, simply ignore this block.
                 //
                 // Note that `check_block_relevancy` is incapable of returning
@@ -2839,7 +2836,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// `Self::process_block`.
     pub async fn process_chain_segment(
         self: &Arc<Self>,
-        chain_segment: Vec<RpcBlock<T::EthSpec>>,
+        chain_segment: Vec<ChainSegmentBlock<T::EthSpec>>,
         notify_execution_layer: NotifyExecutionLayer,
     ) -> ChainSegmentResult {
         for block in chain_segment.iter() {
@@ -2870,9 +2867,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }
         };
 
-        while let Some((_root, block)) = filtered_chain_segment.first() {
+        while let Some(block) = filtered_chain_segment.first() {
             // Determine the epoch of the first block in the remaining segment.
-            let start_epoch = block.epoch();
+            let start_epoch = block.block.epoch();
 
             // The `last_index` indicates the position of the first block in an epoch greater
             // than the current epoch: partitioning the blocks into a run of blocks in the same
@@ -2880,7 +2877,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             // the same `BeaconState`.
             let last_index = filtered_chain_segment
                 .iter()
-                .position(|(_root, block)| block.epoch() > start_epoch)
+                .position(|block| block.block.epoch() > start_epoch)
                 .unwrap_or(filtered_chain_segment.len());
 
             let mut blocks = filtered_chain_segment.split_off(last_index);

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -50,7 +50,7 @@
 
 use crate::beacon_snapshot::PreProcessingSnapshot;
 use crate::blob_verification::GossipBlobError;
-use crate::block_verification_types::{AsBlock, BlockImportData, RpcBlock};
+use crate::block_verification_types::{AsBlock, BlockImportData, ChainSegmentBlock, RpcBlock};
 use crate::data_availability_checker::{AvailabilityCheckError, MaybeAvailableBlock};
 use crate::data_column_verification::GossipDataColumnError;
 use crate::eth1_finalization_cache::Eth1FinalizationData;
@@ -613,21 +613,20 @@ pub(crate) fn process_block_slash_info<T: BeaconChainTypes, TErr: BlockBlobError
 /// The given `chain_segment` must contain only blocks from the same epoch, otherwise an error
 /// will be returned.
 pub fn signature_verify_chain_segment<T: BeaconChainTypes>(
-    mut chain_segment: Vec<(Hash256, RpcBlock<T::EthSpec>)>,
+    chain_segment: Vec<ChainSegmentBlock<T::EthSpec>>,
     chain: &BeaconChain<T>,
 ) -> Result<Vec<SignatureVerifiedBlock<T>>, BlockError> {
     if chain_segment.is_empty() {
         return Ok(vec![]);
     }
 
-    let (first_root, first_block) = chain_segment.remove(0);
-    let (mut parent, first_block) = load_parent(first_block, chain)?;
-    let slot = first_block.slot();
-    chain_segment.insert(0, (first_root, first_block));
+    let first_block = chain_segment.first().expect("not empty");
+    let (mut parent, _) = load_parent(first_block.block.clone(), chain)?;
+    let slot = first_block.block.slot();
 
     let highest_slot = chain_segment
         .last()
-        .map(|(_, block)| block.slot())
+        .map(|block| block.block.slot())
         .unwrap_or_else(|| slot);
 
     let state = cheap_state_advance_to_obtain_committees::<_, BlockError>(
@@ -640,9 +639,9 @@ pub fn signature_verify_chain_segment<T: BeaconChainTypes>(
     // verify signatures before matching blocks and data
     let pubkey_cache = get_validator_pubkey_cache(chain)?;
     let mut signature_verifier = get_signature_verifier(&state, &pubkey_cache, &chain.spec);
-    for (block_root, block) in &chain_segment {
+    for block in &chain_segment {
         let mut consensus_context =
-            ConsensusContext::new(block.slot()).set_current_block_root(*block_root);
+            ConsensusContext::new(block.block.slot()).set_current_block_root(block.block_root());
         signature_verifier.include_all_signatures(block.as_block(), &mut consensus_context)?;
     }
     if signature_verifier.verify().is_err() {
@@ -650,7 +649,7 @@ pub fn signature_verify_chain_segment<T: BeaconChainTypes>(
     }
 
     // Verify that blobs or data columns signatures match
-    for (_, block) in &chain_segment {
+    for block in &chain_segment {
         if let Some(indices) = block.non_matching_blobs_signed_headers() {
             if !indices.is_empty() {
                 return Err(BlockError::InvalidBlobsSignature(indices));
@@ -666,15 +665,14 @@ pub fn signature_verify_chain_segment<T: BeaconChainTypes>(
     // Should check correct proposer cheap for added protection if blocks and columns don't match
 
     // unzip chain segment and verify kzg in bulk
-    let (roots, blocks): (Vec<_>, Vec<_>) = chain_segment.into_iter().unzip();
     let maybe_available_blocks = chain
         .data_availability_checker
-        .verify_kzg_for_rpc_blocks(blocks)?;
+        .verify_kzg_for_chain_segment(chain_segment)?;
     // zip it back up
-    let mut signature_verified_blocks = roots
+    let mut signature_verified_blocks = maybe_available_blocks
         .into_iter()
-        .zip(maybe_available_blocks)
-        .map(|(block_root, maybe_available_block)| {
+        .map(|maybe_available_block| {
+            let block_root = maybe_available_block.block_root();
             let consensus_context = ConsensusContext::new(maybe_available_block.slot())
                 .set_current_block_root(block_root);
             SignatureVerifiedBlock {
@@ -1298,15 +1296,11 @@ impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for RpcBlock<T::EthSpec> 
         // Perform an early check to prevent wasting time on irrelevant blocks.
         let block_root = check_block_relevancy(self.as_block(), block_root, chain)
             .map_err(|e| BlockSlashInfo::SignatureNotChecked(self.signed_block_header(), e))?;
-        let maybe_available = chain
-            .data_availability_checker
-            .verify_kzg_for_rpc_block(self.clone())
-            .map_err(|e| {
-                BlockSlashInfo::SignatureNotChecked(
-                    self.signed_block_header(),
-                    BlockError::AvailabilityCheck(e),
-                )
-            })?;
+        let maybe_available = MaybeAvailableBlock::AvailabilityPending {
+            block_root,
+            block: self.block_cloned(),
+            custody_columns_count: self.custody_columns_count(),
+        };
         SignatureVerifiedBlock::check_slashable(maybe_available, block_root, chain)?
             .into_execution_pending_block_slashable(block_root, chain, notify_execution_layer)
     }

--- a/beacon_node/beacon_chain/src/block_verification_types.rs
+++ b/beacon_node/beacon_chain/src/block_verification_types.rs
@@ -30,8 +30,34 @@ use types::{
 #[derivative(Hash(bound = "E: EthSpec"))]
 pub struct RpcBlock<E: EthSpec> {
     block_root: Hash256,
-    block: RpcBlockInner<E>,
+    block: Arc<SignedBeaconBlock<E>>,
     custody_columns_count: usize,
+}
+
+#[derive(Clone)]
+pub struct ChainSegmentBlock<E: EthSpec> {
+    pub block: RpcBlock<E>,
+    pub blob_data: ChainSegmentBlockData<E>,
+}
+
+impl<E: EthSpec> ChainSegmentBlock<E> {
+    pub fn block_root(&self) -> Hash256 {
+        self.block.block_root()
+    }
+
+    pub fn as_block(&self) -> &SignedBeaconBlock<E> {
+        self.block.as_block()
+    }
+}
+
+#[derive(Clone)]
+pub enum ChainSegmentBlockData<E: EthSpec> {
+    /// Variant for all pre-Deneb blocks
+    PreDeneb,
+    /// Variant for all >= Deneb && < Fulu blocks regardless if they have data or not
+    PostDeneb(BlobSidecarList<E>),
+    /// Variant for all >= Fulu blocks regardless if they have data or not
+    PostFulu(CustodyDataColumnList<E>, Vec<ColumnIndex>),
 }
 
 impl<E: EthSpec> Debug for RpcBlock<E> {
@@ -50,206 +76,91 @@ impl<E: EthSpec> RpcBlock<E> {
     }
 
     pub fn as_block(&self) -> &SignedBeaconBlock<E> {
-        match &self.block {
-            RpcBlockInner::Block(block) => block,
-            RpcBlockInner::BlockAndBlobs(block, _) => block,
-            RpcBlockInner::BlockAndCustodyColumns(block, _, _) => block,
-        }
+        &self.block
     }
 
     pub fn block_cloned(&self) -> Arc<SignedBeaconBlock<E>> {
-        match &self.block {
-            RpcBlockInner::Block(block) => block.clone(),
-            RpcBlockInner::BlockAndBlobs(block, _) => block.clone(),
-            RpcBlockInner::BlockAndCustodyColumns(block, _, _) => block.clone(),
-        }
+        self.block.clone()
     }
+}
 
-    pub fn blobs(&self) -> Option<&BlobSidecarList<E>> {
-        match &self.block {
-            RpcBlockInner::Block(_) => None,
-            RpcBlockInner::BlockAndBlobs(_, blobs) => Some(blobs),
-            RpcBlockInner::BlockAndCustodyColumns(_, _, _) => None,
-        }
-    }
-
-    pub fn custody_columns(&self) -> Option<&CustodyDataColumnList<E>> {
-        match &self.block {
-            RpcBlockInner::Block(_) => None,
-            RpcBlockInner::BlockAndBlobs(_, _) => None,
-            RpcBlockInner::BlockAndCustodyColumns(_, data_columns, _) => Some(data_columns),
-        }
-    }
-
+impl<E: EthSpec> ChainSegmentBlock<E> {
     pub fn non_matching_blobs_signed_headers(&self) -> Option<Vec<ColumnIndex>> {
-        match &self.block {
-            RpcBlockInner::Block(_) => None,
-            RpcBlockInner::BlockAndBlobs(block, blobs) => Some(
+        match &self.blob_data {
+            ChainSegmentBlockData::PreDeneb => None,
+            ChainSegmentBlockData::PostDeneb(blobs) => Some(
                 blobs
                     .iter()
-                    .filter(|blob| &blob.signed_block_header.signature != block.signature())
+                    .filter(|blob| {
+                        &blob.signed_block_header.signature != self.block.as_block().signature()
+                    })
                     .map(|blob| blob.index)
                     .collect(),
             ),
-            RpcBlockInner::BlockAndCustodyColumns(..) => None,
+            ChainSegmentBlockData::PostFulu(..) => None,
         }
     }
 
     pub fn non_matching_custody_columns_signed_headers(&self) -> Option<Vec<ColumnIndex>> {
-        match &self.block {
-            RpcBlockInner::Block(_) => None,
-            RpcBlockInner::BlockAndBlobs(..) => None,
-            RpcBlockInner::BlockAndCustodyColumns(block, data_columns, _) => Some(
+        match &self.blob_data {
+            ChainSegmentBlockData::PreDeneb => None,
+            ChainSegmentBlockData::PostDeneb(..) => None,
+            ChainSegmentBlockData::PostFulu(data_columns, ..) => Some(
                 data_columns
                     .iter()
                     .filter(|column| {
-                        &column.as_data_column().signed_block_header.signature != block.signature()
+                        &column.as_data_column().signed_block_header.signature
+                            != self.block.as_block().signature()
                     })
                     .map(|column| column.index())
                     .collect(),
             ),
         }
     }
-}
 
-/// Note: This variant is intentionally private because we want to safely construct the
-/// internal variants after applying consistency checks to ensure that the block and blobs
-/// are consistent with respect to each other.
-#[derive(Debug, Clone, Derivative)]
-#[derivative(Hash(bound = "E: EthSpec"))]
-enum RpcBlockInner<E: EthSpec> {
-    /// **Range sync**: Variant for all pre-Deneb blocks
-    /// **Lookup sync**: Variant used for all blocks of all forks, regardless if the have data or
-    /// not. Note: this is confusing and should be fixed in a later refactor.
-    Block(Arc<SignedBeaconBlock<E>>),
-    /// Variant for all post-Deneb blocks regardless if they have data or not. Only used for chain
-    /// segments in range sync
-    BlockAndBlobs(Arc<SignedBeaconBlock<E>>, BlobSidecarList<E>),
-    /// Variant for all post-Fulu blocks regardless if they have data or not. Only used for chain
-    /// segments in range sync
-    BlockAndCustodyColumns(
-        Arc<SignedBeaconBlock<E>>,
-        CustodyDataColumnList<E>,
-        Vec<ColumnIndex>,
-    ),
-}
-
-impl<E: EthSpec> RpcBlock<E> {
-    /// Constructs a `Block` variant.
-    pub fn new_without_blobs(
-        block_root: Option<Hash256>,
-        block: Arc<SignedBeaconBlock<E>>,
-        custody_columns_count: usize,
-    ) -> Self {
-        let block_root = block_root.unwrap_or_else(|| get_block_root(&block));
-
-        Self {
-            block_root,
-            block: RpcBlockInner::Block(block),
-            custody_columns_count,
-        }
-    }
-
-    /// Constructs a new `BlockAndBlobs` variant after making consistency
-    /// checks between the provided blocks and blobs. This struct makes no
-    /// guarantees about whether blobs should be present, only that they are
-    /// consistent with the block. An empty list passed in for `blobs` is
-    /// viewed the same as `None` passed in.
-    pub fn new(
-        block_root: Option<Hash256>,
-        block: Arc<SignedBeaconBlock<E>>,
-        blobs: Option<BlobSidecarList<E>>,
-    ) -> Result<Self, AvailabilityCheckError> {
-        let block_root = block_root.unwrap_or_else(|| get_block_root(&block));
-        // Treat empty blob lists as if they are missing.
-        let blobs = blobs.filter(|b| !b.is_empty());
-
-        if let (Some(blobs), Ok(block_commitments)) = (
-            blobs.as_ref(),
-            block.message().body().blob_kzg_commitments(),
-        ) {
-            if blobs.len() != block_commitments.len() {
-                return Err(AvailabilityCheckError::MissingBlobs);
-            }
-            for (blob, &block_commitment) in blobs.iter().zip(block_commitments.iter()) {
-                let blob_commitment = blob.kzg_commitment;
-                if blob_commitment != block_commitment {
-                    return Err(AvailabilityCheckError::KzgCommitmentMismatch {
-                        block_commitment,
-                        blob_commitment,
-                    });
-                }
-            }
-        }
-        let inner = match blobs {
-            Some(blobs) => RpcBlockInner::BlockAndBlobs(block, blobs),
-            None => RpcBlockInner::Block(block),
-        };
+    pub fn new_pre_deneb(block: RpcBlock<E>) -> Result<Self, AvailabilityCheckError> {
         Ok(Self {
-            block_root,
-            block: inner,
-            // Block is before PeerDAS
-            custody_columns_count: 0,
+            block,
+            blob_data: ChainSegmentBlockData::PreDeneb,
         })
     }
 
-    pub fn new_with_custody_columns(
-        block_root: Option<Hash256>,
-        block: Arc<SignedBeaconBlock<E>>,
+    pub fn new_post_deneb(
+        block: RpcBlock<E>,
+        blobs: BlobSidecarList<E>,
+    ) -> Result<Self, AvailabilityCheckError> {
+        Ok(Self {
+            block,
+            blob_data: ChainSegmentBlockData::PostDeneb(blobs),
+        })
+    }
+
+    pub fn new_post_fulu(
+        block: RpcBlock<E>,
         custody_columns: Vec<CustodyDataColumn<E>>,
         expected_custody_indices: Vec<ColumnIndex>,
         spec: &ChainSpec,
     ) -> Result<Self, AvailabilityCheckError> {
-        let block_root = block_root.unwrap_or_else(|| get_block_root(&block));
-
-        let custody_columns_count = expected_custody_indices.len();
-        let inner = RpcBlockInner::BlockAndCustodyColumns(
-            block,
-            RuntimeVariableList::new(custody_columns, spec.number_of_columns as usize)?,
-            expected_custody_indices,
-        );
         Ok(Self {
-            block_root,
-            block: inner,
-            custody_columns_count,
+            block,
+            blob_data: ChainSegmentBlockData::PostFulu(
+                RuntimeVariableList::new(custody_columns, spec.number_of_columns as usize)?,
+                expected_custody_indices,
+            ),
         })
     }
+}
 
-    #[allow(clippy::type_complexity)]
-    pub fn deconstruct(
-        self,
-    ) -> (
-        Hash256,
-        Arc<SignedBeaconBlock<E>>,
-        Option<BlobSidecarList<E>>,
-        Option<(CustodyDataColumnList<E>, Vec<ColumnIndex>)>,
-    ) {
-        let block_root = self.block_root();
-        match self.block {
-            RpcBlockInner::Block(block) => (block_root, block, None, None),
-            RpcBlockInner::BlockAndBlobs(block, blobs) => (block_root, block, Some(blobs), None),
-            RpcBlockInner::BlockAndCustodyColumns(
-                block,
-                data_columns,
-                expected_custody_indices,
-            ) => (
-                block_root,
-                block,
-                None,
-                Some((data_columns, expected_custody_indices)),
-            ),
-        }
-    }
-    pub fn n_blobs(&self) -> usize {
-        match &self.block {
-            RpcBlockInner::Block(_) | RpcBlockInner::BlockAndCustodyColumns(_, _, _) => 0,
-            RpcBlockInner::BlockAndBlobs(_, blobs) => blobs.len(),
-        }
-    }
-    pub fn n_data_columns(&self) -> usize {
-        match &self.block {
-            RpcBlockInner::Block(_) | RpcBlockInner::BlockAndBlobs(_, _) => 0,
-            RpcBlockInner::BlockAndCustodyColumns(_, data_columns, _) => data_columns.len(),
+impl<E: EthSpec> RpcBlock<E> {
+    pub fn new(
+        block_root: Option<Hash256>,
+        block: Arc<SignedBeaconBlock<E>>,
+        custody_columns_count: usize,
+    ) -> Self {
+        Self {
+            block_root: block_root.unwrap_or_else(|| get_block_root(&block)),
+            block,
+            custody_columns_count,
         }
     }
 }
@@ -561,18 +472,10 @@ impl<E: EthSpec> AsBlock<E> for RpcBlock<E> {
         self.as_block().message()
     }
     fn as_block(&self) -> &SignedBeaconBlock<E> {
-        match &self.block {
-            RpcBlockInner::Block(block) => block,
-            RpcBlockInner::BlockAndBlobs(block, _) => block,
-            RpcBlockInner::BlockAndCustodyColumns(block, _, _) => block,
-        }
+        &self.block
     }
     fn block_cloned(&self) -> Arc<SignedBeaconBlock<E>> {
-        match &self.block {
-            RpcBlockInner::Block(block) => block.clone(),
-            RpcBlockInner::BlockAndBlobs(block, _) => block.clone(),
-            RpcBlockInner::BlockAndCustodyColumns(block, _, _) => block.clone(),
-        }
+        self.block.clone()
     }
     fn canonical_root(&self) -> Hash256 {
         self.as_block().canonical_root()

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -1,6 +1,7 @@
 use crate::blob_verification::{verify_kzg_for_blob_list, GossipVerifiedBlob, KzgVerifiedBlobList};
 use crate::block_verification_types::{
-    AvailabilityPendingExecutedBlock, AvailableExecutedBlock, RpcBlock,
+    AvailabilityPendingExecutedBlock, AvailableExecutedBlock, ChainSegmentBlock,
+    ChainSegmentBlockData,
 };
 use crate::data_availability_checker::overflow_lru_cache::{
     DataAvailabilityCheckerInner, ReconstructColumnsDecision,
@@ -19,7 +20,7 @@ use tracing::{debug, error, info_span, Instrument};
 use types::blob_sidecar::{BlobIdentifier, BlobSidecar, FixedBlobSidecarList};
 use types::{
     BlobSidecarList, ChainSpec, ColumnIndex, DataColumnIdentifier, DataColumnSidecar,
-    DataColumnSidecarList, Epoch, EthSpec, Hash256, RuntimeVariableList, SignedBeaconBlock,
+    DataColumnSidecarList, Epoch, EthSpec, Hash256, SignedBeaconBlock,
 };
 
 mod error;
@@ -27,7 +28,7 @@ mod overflow_lru_cache;
 mod state_lru_cache;
 
 use crate::data_column_verification::{
-    verify_kzg_for_data_column_list_with_scoring, CustodyDataColumn, GossipVerifiedDataColumn,
+    verify_kzg_for_data_column_list_with_scoring, GossipVerifiedDataColumn,
     KzgVerifiedCustodyDataColumn, KzgVerifiedDataColumn,
 };
 use crate::metrics::{
@@ -315,183 +316,102 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
             .remove_pending_components(block_root)
     }
 
-    /// Verifies kzg commitments for an RpcBlock, returns a `MaybeAvailableBlock` that may
-    /// include the fully available block.
-    ///
-    /// WARNING: This function assumes all required blobs are already present, it does NOT
-    ///          check if there are any missing blobs.
-    pub fn verify_kzg_for_rpc_block(
-        &self,
-        block: RpcBlock<T::EthSpec>,
-    ) -> Result<MaybeAvailableBlock<T::EthSpec>, AvailabilityCheckError> {
-        let custody_columns_count = block.custody_columns_count();
-        let (block_root, block, blobs, data_columns) = block.deconstruct();
-        if self.blobs_required_for_block(&block) {
-            return if let Some(blob_list) = blobs {
-                verify_kzg_for_blob_list(blob_list.iter(), &self.kzg)
-                    .map_err(AvailabilityCheckError::InvalidBlobs)?;
-                Ok(MaybeAvailableBlock::Available(AvailableBlock {
-                    block_root,
-                    block,
-                    blob_data: AvailableBlockData::Blobs(blob_list),
-                    blobs_available_timestamp: None,
-                    spec: self.spec.clone(),
-                }))
-            } else {
-                Ok(MaybeAvailableBlock::AvailabilityPending {
-                    block_root,
-                    block,
-                    custody_columns_count,
-                })
-            };
-        }
-        if self.data_columns_required_for_block(&block) {
-            return if let Some((data_column_list, _)) = data_columns.as_ref() {
-                verify_kzg_for_data_column_list_with_scoring(
-                    data_column_list
-                        .iter()
-                        .map(|custody_column| custody_column.as_data_column()),
-                    &self.kzg,
-                )
-                .map_err(AvailabilityCheckError::InvalidColumn)?;
-                Ok(MaybeAvailableBlock::Available(AvailableBlock {
-                    block_root,
-                    block,
-                    blob_data: AvailableBlockData::DataColumns(
-                        data_column_list
-                            .into_iter()
-                            .map(|d| d.clone_arc())
-                            .collect(),
-                    ),
-                    blobs_available_timestamp: None,
-                    spec: self.spec.clone(),
-                }))
-            } else {
-                Ok(MaybeAvailableBlock::AvailabilityPending {
-                    block_root,
-                    block,
-                    custody_columns_count,
-                })
-            };
-        }
-
-        Ok(MaybeAvailableBlock::Available(AvailableBlock {
-            block_root,
-            block,
-            blob_data: AvailableBlockData::NoData,
-            blobs_available_timestamp: None,
-            spec: self.spec.clone(),
-        }))
-    }
-
     /// Checks if a vector of blocks are available. Returns a vector of `MaybeAvailableBlock`
     /// This is more efficient than calling `verify_kzg_for_rpc_block` in a loop as it does
     /// all kzg verification at once
     ///
     /// WARNING: This function assumes all required blobs are already present, it does NOT
     ///          check if there are any missing blobs.
-    pub fn verify_kzg_for_rpc_blocks(
+    pub fn verify_kzg_for_chain_segment(
         &self,
-        blocks: Vec<RpcBlock<T::EthSpec>>,
+        blocks: Vec<ChainSegmentBlock<T::EthSpec>>,
     ) -> Result<Vec<MaybeAvailableBlock<T::EthSpec>>, AvailabilityCheckError> {
-        let mut results = Vec::with_capacity(blocks.len());
-        let all_blobs = blocks
-            .iter()
-            .filter(|block| self.blobs_required_for_block(block.as_block()))
-            // this clone is cheap as it's cloning an Arc
-            .filter_map(|block| block.blobs().cloned())
-            .flatten()
-            .collect::<Vec<_>>();
+        let mut data_columns_to_verify_batch = vec![];
+        let mut blobs_to_verify_batch = vec![];
+
+        // TODO(das): we could do the matching first before spending CPU cycles on KZG verification
+        let results = blocks
+            .into_iter()
+            .map(|ChainSegmentBlock { block, blob_data }| {
+                let blob_data = match blob_data {
+                    ChainSegmentBlockData::PreDeneb => AvailableBlockData::NoData,
+                    ChainSegmentBlockData::PostDeneb(blobs) => {
+                        if !block.as_block().has_data() {
+                            AvailableBlockData::NoData
+                        } else {
+                            // Assert that we received the expected number of blobs
+                            if blobs.len() != block.as_block().num_expected_blobs() {
+                                return Err(AvailabilityCheckError::MissingBlobs);
+                            }
+
+                            // Verify that the blob sidecars are correct.
+                            // - KZG proof: verified above in this function
+                            // - Header signature: has been verified in TBD
+                            // - Inclusion proof: has been verified in TBD
+
+                            blobs_to_verify_batch.extend(blobs.clone());
+                            AvailableBlockData::Blobs(blobs)
+                        }
+                    }
+                    ChainSegmentBlockData::PostFulu(data_columns, expected_custody_indices) => {
+                        if !block.as_block().has_data() {
+                            AvailableBlockData::NoData
+                        } else {
+                            // Assert that we received the expected number and exact set of columns
+                            let received_indices = HashSet::<ColumnIndex>::from_iter(
+                                data_columns.iter().map(|d| d.index()),
+                            );
+
+                            let missing_custody_columns = expected_custody_indices
+                                .into_iter()
+                                .filter(|index| !received_indices.contains(index))
+                                .collect::<Vec<_>>();
+
+                            if !missing_custody_columns.is_empty() {
+                                return Err(AvailabilityCheckError::MissingCustodyColumns(
+                                    missing_custody_columns,
+                                ));
+                            }
+
+                            // Verify that the data column sidecars are correct.
+                            // - KZG proof: verified above in this function
+                            // - Header signature: has been verified in TBD
+                            // - Inclusion proof: has been verified in TBD
+
+                            data_columns_to_verify_batch.extend(data_columns.clone());
+                            AvailableBlockData::DataColumns(
+                                data_columns.into_iter().map(|d| d.into_inner()).collect(),
+                            )
+                        }
+                    }
+                };
+
+                Ok(MaybeAvailableBlock::Available(AvailableBlock {
+                    block_root: block.block_root(),
+                    block: block.block_cloned(),
+                    blob_data,
+                    blobs_available_timestamp: None,
+                    spec: self.spec.clone(),
+                }))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         // verify kzg for all blobs at once
-        if !all_blobs.is_empty() {
-            verify_kzg_for_blob_list(all_blobs.iter(), &self.kzg)
+        if !blobs_to_verify_batch.is_empty() {
+            verify_kzg_for_blob_list(blobs_to_verify_batch.iter(), &self.kzg)
                 .map_err(AvailabilityCheckError::InvalidBlobs)?;
         }
 
-        let all_data_columns = blocks
-            .iter()
-            .filter(|block| self.data_columns_required_for_block(block.as_block()))
-            // this clone is cheap as it's cloning an Arc
-            .filter_map(|block| block.custody_columns().cloned())
-            .flatten()
-            .map(CustodyDataColumn::into_inner)
-            .collect::<Vec<_>>();
-        let all_data_columns =
-            RuntimeVariableList::from_vec(all_data_columns, self.spec.number_of_columns as usize);
-
         // verify kzg for all data columns at once
-        if !all_data_columns.is_empty() {
+        if !data_columns_to_verify_batch.is_empty() {
             // Attributes fault to the specific peer that sent an invalid column
-            verify_kzg_for_data_column_list_with_scoring(all_data_columns.iter(), &self.kzg)
-                .map_err(AvailabilityCheckError::InvalidColumn)?;
-        }
-
-        // TODO(das): we could do the matching first before spending CPU cycles on KZG verification
-        for block in blocks {
-            let custody_columns_count = block.custody_columns_count();
-            let (block_root, block, blobs, data_columns) = block.deconstruct();
-
-            let maybe_available_block = if self.blobs_required_for_block(&block) {
-                if let Some(blobs) = blobs {
-                    MaybeAvailableBlock::Available(AvailableBlock {
-                        block_root,
-                        block,
-                        blob_data: AvailableBlockData::Blobs(blobs),
-                        blobs_available_timestamp: None,
-                        spec: self.spec.clone(),
-                    })
-                } else {
-                    MaybeAvailableBlock::AvailabilityPending {
-                        block_root,
-                        block,
-                        custody_columns_count,
-                    }
-                }
-            } else if self.data_columns_required_for_block(&block) {
-                if let Some((data_columns, expected_custody_indices)) = data_columns {
-                    let received_indices =
-                        HashSet::<ColumnIndex>::from_iter(data_columns.iter().map(|d| d.index()));
-
-                    let missing_custody_columns = expected_custody_indices
-                        .into_iter()
-                        .filter(|index| !received_indices.contains(index))
-                        .collect::<Vec<_>>();
-
-                    if !missing_custody_columns.is_empty() {
-                        return Err(AvailabilityCheckError::MissingCustodyColumns(
-                            missing_custody_columns,
-                        ));
-                    }
-
-                    MaybeAvailableBlock::Available(AvailableBlock {
-                        block_root,
-                        block,
-                        blob_data: AvailableBlockData::DataColumns(
-                            data_columns.into_iter().map(|d| d.into_inner()).collect(),
-                        ),
-                        blobs_available_timestamp: None,
-                        spec: self.spec.clone(),
-                    })
-                } else {
-                    // This is unreachable. If a block returns true for
-                    // `data_columns_required_for_block` it must be a Fulu block. All Fulu RpcBlocks
-                    // are constructed with the `DataColumns` variant, so `data_columns` must be Some
-                    return Err(AvailabilityCheckError::Unexpected(
-                        "Data columns should be Some for a Fulu block".to_string(),
-                    ));
-                }
-            } else {
-                MaybeAvailableBlock::Available(AvailableBlock {
-                    block_root,
-                    block,
-                    blob_data: AvailableBlockData::NoData,
-                    blobs_available_timestamp: None,
-                    spec: self.spec.clone(),
-                })
-            };
-
-            results.push(maybe_available_block);
+            verify_kzg_for_data_column_list_with_scoring(
+                data_columns_to_verify_batch
+                    .iter()
+                    .map(|d| d.as_data_column()),
+                &self.kzg,
+            )
+            .map_err(AvailabilityCheckError::InvalidColumn)?;
         }
 
         Ok(results)
@@ -508,16 +428,6 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
     /// - If the epoch is from prior to the data availability boundary, no data columns are required.
     pub fn data_columns_required_for_epoch(&self, epoch: Epoch) -> bool {
         self.da_check_required_for_epoch(epoch) && self.spec.is_peer_das_enabled_for_epoch(epoch)
-    }
-
-    /// See `Self::blobs_required_for_epoch`
-    fn blobs_required_for_block(&self, block: &SignedBeaconBlock<T::EthSpec>) -> bool {
-        block.num_expected_blobs() > 0 && self.blobs_required_for_epoch(block.epoch())
-    }
-
-    /// See `Self::data_columns_required_for_epoch`
-    fn data_columns_required_for_block(&self, block: &SignedBeaconBlock<T::EthSpec>) -> bool {
-        block.num_expected_blobs() > 0 && self.data_columns_required_for_epoch(block.epoch())
     }
 
     /// The epoch at which we require a data availability check in block processing.
@@ -838,6 +748,13 @@ impl<E: EthSpec> MaybeAvailableBlock<E> {
         match self {
             Self::Available(block) => block.block_cloned(),
             Self::AvailabilityPending { block, .. } => block.clone(),
+        }
+    }
+
+    pub fn block_root(&self) -> Hash256 {
+        match self {
+            Self::Available(block) => block.block_root,
+            Self::AvailabilityPending { block_root, .. } => *block_root,
         }
     }
 }

--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -1,4 +1,4 @@
-use crate::block_verification_types::{MaybeAvailableBlock, RpcBlock};
+use crate::block_verification_types::{ChainSegmentBlock, MaybeAvailableBlock};
 use crate::data_availability_checker::{AvailabilityCheckError, AvailableBlockData};
 use crate::{metrics, BeaconChain, BeaconChainTypes};
 use itertools::Itertools;
@@ -80,7 +80,7 @@ impl From<AvailabilityCheckError> for HistoricalBlockError {
 impl<T: BeaconChainTypes> BeaconChain<T> {
     pub fn assert_correct_historical_block_chain(
         &self,
-        blocks: &[RpcBlock<T::EthSpec>],
+        blocks: &[ChainSegmentBlock<T::EthSpec>],
     ) -> Result<(), HistoricalBlockError> {
         let anchor_info = self.store.get_anchor_info();
         let mut expected_block_root = anchor_info.oldest_block_parent;
@@ -119,7 +119,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// Return the number of blocks successfully imported.
     pub fn import_historical_block_batch(
         &self,
-        blocks: Vec<RpcBlock<T::EthSpec>>,
+        blocks: Vec<ChainSegmentBlock<T::EthSpec>>,
     ) -> Result<usize, HistoricalBlockError> {
         // First check that chain of blocks is correct
         self.assert_correct_historical_block_chain(&blocks)?;
@@ -148,7 +148,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // checked the block root is correct first.
         let mut blocks = self
             .data_availability_checker
-            .verify_kzg_for_rpc_blocks(blocks)
+            .verify_kzg_for_chain_segment(blocks)
             .and_then(|blocks| {
                 blocks
                     .into_iter()

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -1,5 +1,5 @@
 use crate::blob_verification::GossipVerifiedBlob;
-use crate::block_verification_types::{AsBlock, RpcBlock};
+use crate::block_verification_types::{AsBlock, ChainSegmentBlock, RpcBlock};
 use crate::data_column_verification::CustodyDataColumn;
 use crate::kzg_utils::build_data_column_sidecars;
 use crate::observed_operations::ObservationOutcome;
@@ -18,7 +18,7 @@ use crate::{
     BeaconChain, BeaconChainTypes, BlockError, ChainConfig, ServerSentEventHandler,
     StateSkipConfig,
 };
-use crate::{get_block_root, BeaconBlockResponseWrapper};
+use crate::{get_block_root, BeaconBlockResponseWrapper, ChainSegmentResult};
 use bls::get_withdrawal_credentials;
 use eth2::types::SignedBlockContentsTuple;
 use execution_layer::test_utils::generate_genesis_header;
@@ -778,12 +778,14 @@ where
         let block = self.chain.head_beacon_block();
         let block_root = block.canonical_root();
         self.build_rpc_block_from_store_blobs(Some(block_root), block)
+            .block
     }
 
     pub fn get_full_block(&self, block_root: &Hash256) -> RpcBlock<E> {
         let block = self.chain.get_blinded_block(block_root).unwrap().unwrap();
         let full_block = self.chain.store.make_full_block(block_root, block).unwrap();
         self.build_rpc_block_from_store_blobs(Some(*block_root), Arc::new(full_block))
+            .block
     }
 
     pub fn get_all_validators(&self) -> Vec<usize> {
@@ -2312,18 +2314,12 @@ where
         let (block, blob_items) = block_contents;
 
         let rpc_block = self.build_rpc_block_from_blobs(block_root, block, blob_items)?;
-        let block_hash: SignedBeaconBlockHash = self
-            .chain
-            .process_block(
-                block_root,
-                rpc_block,
-                NotifyExecutionLayer::Yes,
-                BlockImportSource::RangeSync,
-                || Ok(()),
-            )
-            .await?
-            .try_into()
-            .expect("block blobs are available");
+        let block_hash = chain_segment_result_to_block_err(
+            self.chain
+                .process_chain_segment(vec![rpc_block], NotifyExecutionLayer::Yes)
+                .await,
+        )?
+        .into();
         self.chain.recompute_head_at_current_slot().await;
         Ok(block_hash)
     }
@@ -2336,18 +2332,12 @@ where
 
         let block_root = block.canonical_root();
         let rpc_block = self.build_rpc_block_from_blobs(block_root, block, blob_items)?;
-        let block_hash: SignedBeaconBlockHash = self
-            .chain
-            .process_block(
-                block_root,
-                rpc_block,
-                NotifyExecutionLayer::Yes,
-                BlockImportSource::RangeSync,
-                || Ok(()),
-            )
-            .await?
-            .try_into()
-            .expect("block blobs are available");
+        let block_hash: SignedBeaconBlockHash = chain_segment_result_to_block_err(
+            self.chain
+                .process_chain_segment(vec![rpc_block], NotifyExecutionLayer::Yes)
+                .await,
+        )?
+        .into();
         self.chain.recompute_head_at_current_slot().await;
         Ok(block_hash)
     }
@@ -2358,36 +2348,40 @@ where
         &self,
         block_root: Option<Hash256>,
         block: Arc<SignedBeaconBlock<E>>,
-    ) -> RpcBlock<E> {
+    ) -> ChainSegmentBlock<E> {
         let block_root = block_root.unwrap_or_else(|| get_block_root(&block));
-        let has_blobs = block
-            .message()
-            .body()
-            .blob_kzg_commitments()
-            .is_ok_and(|c| !c.is_empty());
-        if !has_blobs {
-            return RpcBlock::new_without_blobs(Some(block_root), block, 0);
-        }
+        let sampling_column_count = self.get_sampling_column_count();
 
         // Blobs are stored as data columns from Fulu (PeerDAS)
         if self.spec.is_peer_das_enabled_for_epoch(block.epoch()) {
-            let columns = self.chain.get_data_columns(&block_root).unwrap().unwrap();
+            let columns = if block.has_data() {
+                self.chain.get_data_columns(&block_root).unwrap().unwrap()
+            } else {
+                vec![]
+            };
             let expected_custody_indices = columns.iter().map(|d| d.index).collect::<Vec<_>>();
             let custody_columns = columns
                 .into_iter()
                 .map(CustodyDataColumn::from_asserted_custody)
                 .collect::<Vec<_>>();
-            RpcBlock::new_with_custody_columns(
-                Some(block_root),
-                block,
+            ChainSegmentBlock::new_post_fulu(
+                RpcBlock::new(Some(block_root), block, sampling_column_count),
                 custody_columns,
                 expected_custody_indices,
                 &self.spec,
             )
             .unwrap()
         } else {
-            let blobs = self.chain.get_blobs(&block_root).unwrap().blobs();
-            RpcBlock::new(Some(block_root), block, blobs).unwrap()
+            let blobs = if block.has_data() {
+                self.chain.get_blobs(&block_root).unwrap().blobs()
+            } else {
+                None
+            };
+            ChainSegmentBlock::new_post_deneb(
+                RpcBlock::new(Some(block_root), block, sampling_column_count),
+                blobs.unwrap_or_else(|| RuntimeVariableList::empty(0)),
+            )
+            .unwrap()
         }
     }
 
@@ -2397,31 +2391,30 @@ where
         block_root: Hash256,
         block: Arc<SignedBeaconBlock<E, FullPayload<E>>>,
         blob_items: Option<(KzgProofs<E>, BlobsList<E>)>,
-    ) -> Result<RpcBlock<E>, BlockError> {
-        Ok(if self.spec.is_peer_das_enabled_for_epoch(block.epoch()) {
-            let sampling_column_count = self.get_sampling_column_count();
+    ) -> Result<ChainSegmentBlock<E>, BlockError> {
+        let sampling_column_count = self.get_sampling_column_count();
 
-            if blob_items.is_some_and(|(_, blobs)| !blobs.is_empty()) {
+        Ok(if self.spec.is_peer_das_enabled_for_epoch(block.epoch()) {
+            let columns = if blob_items.is_some_and(|(_, blobs)| !blobs.is_empty()) {
                 // Note: this method ignores the actual custody columns and just take the first
                 // `sampling_column_count` for testing purpose only, because the chain does not
                 // currently have any knowledge of the columns being custodied.
-                let columns = generate_data_column_sidecars_from_block(&block, &self.spec)
+                generate_data_column_sidecars_from_block(&block, &self.spec)
                     .into_iter()
                     .take(sampling_column_count)
                     .map(CustodyDataColumn::from_asserted_custody)
-                    .collect::<Vec<_>>();
-                let expected_custody_indices =
-                    columns.iter().map(|d| d.index()).collect::<Vec<_>>();
-                RpcBlock::new_with_custody_columns(
-                    Some(block_root),
-                    block,
-                    columns,
-                    expected_custody_indices,
-                    &self.spec,
-                )?
+                    .collect::<Vec<_>>()
             } else {
-                RpcBlock::new_without_blobs(Some(block_root), block, sampling_column_count)
-            }
+                vec![]
+            };
+
+            let expected_custody_indices = columns.iter().map(|d| d.index()).collect::<Vec<_>>();
+            ChainSegmentBlock::new_post_fulu(
+                RpcBlock::new(Some(block_root), block, sampling_column_count),
+                columns,
+                expected_custody_indices,
+                &self.spec,
+            )?
         } else {
             let blobs = blob_items
                 .map(|(proofs, blobs)| {
@@ -2429,7 +2422,10 @@ where
                 })
                 .transpose()
                 .unwrap();
-            RpcBlock::new(Some(block_root), block, blobs)?
+            ChainSegmentBlock::new_post_deneb(
+                RpcBlock::new(Some(block_root), block, sampling_column_count),
+                blobs.unwrap_or_else(|| RuntimeVariableList::empty(0)),
+            )?
         })
     }
 
@@ -3339,4 +3335,13 @@ fn generate_data_column_sidecars_from_block<E: EthSpec>(
         spec,
     )
     .unwrap()
+}
+
+fn chain_segment_result_to_block_err(result: ChainSegmentResult) -> Result<Hash256, BlockError> {
+    match result {
+        ChainSegmentResult::Successful { imported_blocks } => {
+            Ok(imported_blocks.first().expect("should import one block").0)
+        }
+        ChainSegmentResult::Failed { error, .. } => Err(error),
+    }
 }

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -2,7 +2,7 @@ use crate::sync::manager::BlockProcessType;
 use crate::sync::SamplingId;
 use crate::{service::NetworkMessage, sync::manager::SyncMessage};
 use beacon_chain::blob_verification::{GossipBlobError, GossipVerifiedBlob};
-use beacon_chain::block_verification_types::RpcBlock;
+use beacon_chain::block_verification_types::{ChainSegmentBlock, RpcBlock};
 use beacon_chain::data_column_verification::{observe_gossip_data_column, GossipDataColumnError};
 use beacon_chain::fetch_blobs::{
     fetch_and_process_engine_blobs, BlobsOrDataColumns, FetchEngineBlobError,
@@ -590,7 +590,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     pub fn send_chain_segment(
         self: &Arc<Self>,
         process_id: ChainSegmentProcessId,
-        blocks: Vec<RpcBlock<T::EthSpec>>,
+        blocks: Vec<ChainSegmentBlock<T::EthSpec>>,
     ) -> Result<(), Error<T::EthSpec>> {
         let is_backfill = matches!(&process_id, ChainSegmentProcessId::BackSyncBatchId { .. });
         debug!(blocks = blocks.len(), id = ?process_id, "Batch sending for process");

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -5,7 +5,7 @@ use crate::sync::{
     manager::{BlockProcessType, SyncMessage},
     ChainId,
 };
-use beacon_chain::block_verification_types::{AsBlock, RpcBlock};
+use beacon_chain::block_verification_types::{AsBlock, ChainSegmentBlock, RpcBlock};
 use beacon_chain::data_availability_checker::AvailabilityCheckError;
 use beacon_chain::data_column_verification::verify_kzg_for_data_column_list;
 use beacon_chain::{
@@ -490,14 +490,14 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     pub async fn process_chain_segment(
         &self,
         sync_type: ChainSegmentProcessId,
-        downloaded_blocks: Vec<RpcBlock<T::EthSpec>>,
+        downloaded_blocks: Vec<ChainSegmentBlock<T::EthSpec>>,
         notify_execution_layer: NotifyExecutionLayer,
     ) {
         let result = match sync_type {
             // this a request from the range sync
             ChainSegmentProcessId::RangeBatchId(chain_id, epoch) => {
-                let start_slot = downloaded_blocks.first().map(|b| b.slot().as_u64());
-                let end_slot = downloaded_blocks.last().map(|b| b.slot().as_u64());
+                let start_slot = downloaded_blocks.first().map(|b| b.block.slot().as_u64());
+                let end_slot = downloaded_blocks.last().map(|b| b.block.slot().as_u64());
                 let sent_blocks = downloaded_blocks.len();
 
                 match self
@@ -541,17 +541,9 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             }
             // this a request from the Backfill sync
             ChainSegmentProcessId::BackSyncBatchId(epoch) => {
-                let start_slot = downloaded_blocks.first().map(|b| b.slot().as_u64());
-                let end_slot = downloaded_blocks.last().map(|b| b.slot().as_u64());
+                let start_slot = downloaded_blocks.first().map(|b| b.block.slot().as_u64());
+                let end_slot = downloaded_blocks.last().map(|b| b.block.slot().as_u64());
                 let sent_blocks = downloaded_blocks.len();
-                let n_blobs = downloaded_blocks
-                    .iter()
-                    .map(|wrapped| wrapped.n_blobs())
-                    .sum::<usize>();
-                let n_data_columns = downloaded_blocks
-                    .iter()
-                    .map(|wrapped| wrapped.n_data_columns())
-                    .sum::<usize>();
 
                 match self.process_backfill_blocks(downloaded_blocks) {
                     Ok(imported_blocks) => {
@@ -561,8 +553,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             keep_execution_payload = !self.chain.store.get_config().prune_payloads,
                             last_block_slot = end_slot,
                             processed_blocks = sent_blocks,
-                            processed_blobs = n_blobs,
-                            processed_data_columns = n_data_columns,
                             service= "sync",
                             "Backfill batch processed");
                         BatchProcessResult::Success {
@@ -575,7 +565,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             batch_epoch = %epoch,
                             first_block_slot = start_slot,
                             last_block_slot = end_slot,
-                            processed_blobs = n_blobs,
                             error = %e.message,
                             service = "sync",
                             "Backfill batch processing failed"
@@ -599,7 +588,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     /// Helper function to process blocks batches which only consumes the chain and blocks to process.
     async fn process_blocks<'a>(
         &self,
-        downloaded_blocks: impl Iterator<Item = &'a RpcBlock<T::EthSpec>>,
+        downloaded_blocks: impl Iterator<Item = &'a ChainSegmentBlock<T::EthSpec>>,
         notify_execution_layer: NotifyExecutionLayer,
     ) -> (usize, Result<(), ChainSegmentFailed>) {
         let blocks: Vec<_> = downloaded_blocks.cloned().collect();
@@ -641,7 +630,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     /// Helper function to process backfill block batches which only consumes the chain and blocks to process.
     fn process_backfill_blocks(
         &self,
-        downloaded_blocks: Vec<RpcBlock<T::EthSpec>>,
+        downloaded_blocks: Vec<ChainSegmentBlock<T::EthSpec>>,
     ) -> Result<usize, ChainSegmentFailed> {
         match self.chain.import_historical_block_batch(downloaded_blocks) {
             Ok(imported_blocks) => {

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -16,7 +16,7 @@ use crate::sync::network_context::{
 use crate::sync::range_sync::{
     BatchConfig, BatchId, BatchInfo, BatchOperationOutcome, BatchProcessingResult, BatchState,
 };
-use beacon_chain::block_verification_types::RpcBlock;
+use beacon_chain::block_verification_types::{ChainSegmentBlock, RpcBlock};
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use lighthouse_network::service::api_types::Id;
 use lighthouse_network::types::{BackFillState, NetworkGlobals};
@@ -356,7 +356,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
         batch_id: BatchId,
         peer: BatchPeerGroup,
         request_id: Id,
-        blocks: Vec<RpcBlock<T::EthSpec>>,
+        blocks: Vec<ChainSegmentBlock<T::EthSpec>>,
     ) -> Result<ProcessResult, BackFillError> {
         // check if we have this batch
         let Some(batch) = self.batches.get_mut(&batch_id) else {

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -1,5 +1,7 @@
 use beacon_chain::{
-    block_verification_types::RpcBlock, data_column_verification::CustodyDataColumn, get_block_root,
+    block_verification_types::{ChainSegmentBlock, RpcBlock},
+    data_column_verification::CustodyDataColumn,
+    get_block_root,
 };
 use lighthouse_network::{
     service::api_types::{
@@ -126,7 +128,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
     pub fn responses(
         &self,
         spec: &ChainSpec,
-    ) -> Option<Result<(Vec<RpcBlock<E>>, BatchPeerGroup), String>> {
+    ) -> Option<Result<(Vec<ChainSegmentBlock<E>>, BatchPeerGroup), String>> {
         let Some((blocks, &block_peer)) = self.blocks_request.to_finished() else {
             return None;
         };
@@ -178,7 +180,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         blocks: Vec<Arc<SignedBeaconBlock<E>>>,
         blobs: Vec<Arc<BlobSidecar<E>>>,
         spec: &ChainSpec,
-    ) -> Result<Vec<RpcBlock<E>>, String> {
+    ) -> Result<Vec<ChainSegmentBlock<E>>, String> {
         // There can't be more more blobs than blocks. i.e. sending any blob (empty
         // included) for a skipped slot is not permitted.
         let mut responses = Vec::with_capacity(blocks.len());
@@ -213,7 +215,10 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                 max_blobs_per_block,
             )
             .map_err(|_| "Blobs returned exceeds max length".to_string())?;
-            responses.push(RpcBlock::new(None, block, Some(blobs)).map_err(|e| format!("{e:?}"))?)
+            responses.push(
+                ChainSegmentBlock::new_post_deneb(RpcBlock::new(None, block, 0), blobs)
+                    .map_err(|e| format!("{e:?}"))?,
+            )
         }
 
         // if accumulated sidecars is not empty, throw an error.
@@ -229,7 +234,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         data_columns: DataColumnSidecarList<E>,
         expected_custody_columns: HashMap<ColumnIndex, PeerId>,
         spec: &ChainSpec,
-    ) -> Result<Vec<RpcBlock<E>>, String> {
+    ) -> Result<Vec<ChainSegmentBlock<E>>, String> {
         // Group data columns by block_root and index
         let mut custody_columns_by_block = HashMap::<Hash256, Vec<CustodyDataColumn<E>>>::new();
         let mut block_roots_by_slot = HashMap::<Slot, HashSet<Hash256>>::new();
@@ -272,9 +277,8 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                     .remove(&block_root)
                     .unwrap_or_default();
 
-                RpcBlock::new_with_custody_columns(
-                    Some(block_root),
-                    block,
+                ChainSegmentBlock::new_post_fulu(
+                    RpcBlock::new(Some(block_root), block, expected_custody_indices.len()),
                     custody_columns,
                     expected_custody_indices.clone(),
                     spec,

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -13,7 +13,7 @@ use crate::service::NetworkMessage;
 use crate::status::ToStatusMessage;
 use crate::sync::block_lookups::SingleLookupId;
 use crate::sync::network_context::requests::BlobsByRootSingleBlockRequest;
-use beacon_chain::block_verification_types::RpcBlock;
+use beacon_chain::block_verification_types::{ChainSegmentBlock, RpcBlock};
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockProcessStatus, EngineState};
 use custody::CustodyRequestResult;
 use fnv::FnvHashMap;
@@ -571,7 +571,8 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         id: ComponentsByRangeRequestId,
         peer_id: PeerId,
         range_block_component: RangeBlockComponent<T::EthSpec>,
-    ) -> Option<Result<(Vec<RpcBlock<T::EthSpec>>, BatchPeerGroup), RpcResponseError>> {
+    ) -> Option<Result<(Vec<ChainSegmentBlock<T::EthSpec>>, BatchPeerGroup), RpcResponseError>>
+    {
         let Entry::Occupied(mut entry) = self.components_by_range_requests.entry(id) else {
             metrics::inc_counter_vec(&metrics::SYNC_UNKNOWN_NETWORK_REQUESTS, &["range_blocks"]);
             return None;
@@ -1446,7 +1447,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .beacon_processor_if_enabled()
             .ok_or(SendErrorProcessor::ProcessorNotAvailable)?;
 
-        let block = RpcBlock::new_without_blobs(
+        let block = RpcBlock::new(
             Some(block_root),
             block,
             self.network_globals().custody_columns_count() as usize,

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -1,4 +1,4 @@
-use beacon_chain::block_verification_types::RpcBlock;
+use beacon_chain::block_verification_types::{ChainSegmentBlock, RpcBlock};
 use lighthouse_network::rpc::methods::BlocksByRangeRequest;
 use lighthouse_network::service::api_types::Id;
 use lighthouse_network::PeerId;
@@ -161,7 +161,7 @@ pub enum BatchState<E: EthSpec> {
     /// The batch is being downloaded.
     Downloading(Id),
     /// The batch has been completely downloaded and is ready for processing.
-    AwaitingProcessing(BatchPeerGroup, Vec<RpcBlock<E>>, Instant),
+    AwaitingProcessing(BatchPeerGroup, Vec<ChainSegmentBlock<E>>, Instant),
     /// The batch is being processed.
     Processing(Attempt),
     /// The batch was successfully processed and is waiting to be validated.
@@ -297,7 +297,7 @@ impl<E: EthSpec, B: BatchConfig> BatchInfo<E, B> {
     #[must_use = "Batch may have failed"]
     pub fn download_completed(
         &mut self,
-        blocks: Vec<RpcBlock<E>>,
+        blocks: Vec<ChainSegmentBlock<E>>,
         peer: BatchPeerGroup,
     ) -> Result<usize /* Received blocks */, WrongState> {
         match self.state.poison() {
@@ -371,7 +371,9 @@ impl<E: EthSpec, B: BatchConfig> BatchInfo<E, B> {
         }
     }
 
-    pub fn start_processing(&mut self) -> Result<(Vec<RpcBlock<E>>, Duration), WrongState> {
+    pub fn start_processing(
+        &mut self,
+    ) -> Result<(Vec<ChainSegmentBlock<E>>, Duration), WrongState> {
         match self.state.poison() {
             BatchState::AwaitingProcessing(peers, blocks, start_instant) => {
                 self.state = BatchState::Processing(Attempt::new::<B, E>(peers, &blocks));

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -4,7 +4,7 @@ use crate::metrics;
 use crate::network_beacon_processor::ChainSegmentProcessId;
 use crate::sync::network_context::{RangeRequestId, RpcRequestSendError, RpcResponseError};
 use crate::sync::{network_context::SyncNetworkContext, BatchOperationOutcome, BatchProcessResult};
-use beacon_chain::block_verification_types::RpcBlock;
+use beacon_chain::block_verification_types::{ChainSegmentBlock, RpcBlock};
 use beacon_chain::BeaconChainTypes;
 use lighthouse_network::service::api_types::Id;
 use lighthouse_network::{PeerAction, PeerId};
@@ -229,7 +229,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         batch_id: BatchId,
         peer: BatchPeerGroup,
         request_id: Id,
-        blocks: Vec<RpcBlock<T::EthSpec>>,
+        blocks: Vec<ChainSegmentBlock<T::EthSpec>>,
     ) -> ProcessingResult {
         // check if we have this batch
         let batch = match self.batches.get_mut(&batch_id) {

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -47,7 +47,7 @@ use crate::metrics;
 use crate::status::ToStatusMessage;
 use crate::sync::network_context::{RpcResponseError, SyncNetworkContext};
 use crate::sync::BatchProcessResult;
-use beacon_chain::block_verification_types::RpcBlock;
+use beacon_chain::block_verification_types::ChainSegmentBlock;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use lighthouse_network::rpc::GoodbyeReason;
 use lighthouse_network::service::api_types::Id;
@@ -232,7 +232,7 @@ where
         chain_id: ChainId,
         batch_id: BatchId,
         request_id: Id,
-        blocks: Vec<RpcBlock<T::EthSpec>>,
+        blocks: Vec<ChainSegmentBlock<T::EthSpec>>,
     ) {
         // check if this chunk removes the chain
         match self.chains.call_by_id(chain_id, |chain| {

--- a/beacon_node/network/src/sync/tests/range.rs
+++ b/beacon_node/network/src/sync/tests/range.rs
@@ -422,7 +422,6 @@ impl TestRig {
         let block_root = block.canonical_root();
         self.harness.set_current_slot(block.slot());
         let _: SignedBeaconBlockHash = self
-            .harness
             .chain
             .process_block(
                 block_root,

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -318,6 +318,10 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> SignedBeaconBlock<E, Payload> 
             .unwrap_or(0)
     }
 
+    pub fn has_data(&self) -> bool {
+        self.num_expected_blobs() == 0
+    }
+
     /// Used for displaying commitments in logs.
     pub fn commitments_formatted(&self) -> String {
         let Ok(commitments) = self.message().body().blob_kzg_commitments() else {

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -3,7 +3,6 @@ use crate::decode::{ssz_decode_file, ssz_decode_file_with, ssz_decode_state, yam
 use ::fork_choice::{PayloadVerificationStatus, ProposerHeadError};
 use beacon_chain::beacon_proposer_cache::compute_proposer_duties_from_head;
 use beacon_chain::blob_verification::GossipBlobError;
-use beacon_chain::block_verification_types::RpcBlock;
 use beacon_chain::chain_config::{
     DisallowedReOrgOffsets, DEFAULT_RE_ORG_HEAD_THRESHOLD,
     DEFAULT_RE_ORG_MAX_EPOCHS_SINCE_FINALIZATION, DEFAULT_RE_ORG_PARENT_THRESHOLD,
@@ -15,7 +14,7 @@ use beacon_chain::{
     },
     blob_verification::GossipVerifiedBlob,
     test_utils::{BeaconChainHarness, EphemeralHarnessType},
-    AvailabilityProcessingStatus, BeaconChainTypes, CachedHead, ChainConfig, NotifyExecutionLayer,
+    AvailabilityProcessingStatus, BeaconChainTypes, CachedHead, ChainConfig,
 };
 use execution_layer::{json_structures::JsonPayloadStatusV1Status, PayloadStatusV1};
 use serde::Deserialize;
@@ -26,8 +25,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use types::{
     Attestation, AttestationRef, AttesterSlashing, AttesterSlashingRef, BeaconBlock, BeaconState,
-    BlobSidecar, BlobsList, BlockImportSource, Checkpoint, ExecutionBlockHash, Hash256,
-    IndexedAttestation, KzgProof, ProposerPreparationData, SignedBeaconBlock, Slot, Uint256,
+    BlobSidecar, BlobsList, Checkpoint, ExecutionBlockHash, Hash256, IndexedAttestation, KzgProof,
+    ProposerPreparationData, SignedBeaconBlock, Slot, Uint256,
 };
 
 // When set to true, cache any states fetched from the db.
@@ -518,13 +517,7 @@ impl<E: EthSpec> Tester<E> {
 
         let block = Arc::new(block);
         let result: Result<Result<Hash256, ()>, _> = self
-            .block_on_dangerous(self.harness.chain.process_block(
-                block_root,
-                RpcBlock::new_without_blobs(Some(block_root), block.clone(), 0),
-                NotifyExecutionLayer::Yes,
-                BlockImportSource::Lookup,
-                || Ok(()),
-            ))?
+            .block_on_dangerous(self.harness.process_block_result((block.clone(), None)))?
             .map(|avail: AvailabilityProcessingStatus| avail.try_into());
         let success = blob_success && result.as_ref().is_ok_and(|inner| inner.is_ok());
         if success != valid {


### PR DESCRIPTION
Using the same type `RpcBlock` for lookup sync and range sync leads to a bunch of confusing mixed code paths. Given how orthogonal their processing is, using different types makes sense.