### PR TITLE
Make ExecutionHash not option

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1805,7 +1805,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             // pre-finalization.
             None => Err(Error::CannotAttestToFinalizedBlock { beacon_block_root }),
             // The attestation references a fully valid `beacon_block_root`.
-            Some(execution_status) if execution_status.is_valid_or_irrelevant() => Ok(attestation),
+            Some(execution_status) if execution_status.is_valid() => Ok(attestation),
             // The attestation references a block that has not been verified by an EL (i.e. it
             // is optimistic or invalid). Don't return the block, return an error instead.
             Some(execution_status) => Err(Error::HeadBlockNotFullyVerified {
@@ -1846,7 +1846,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             // pre-finalization.
             None => Err(Error::SyncContributionDataReferencesFinalizedBlock { beacon_block_root }),
             // The contribution references a fully valid `beacon_block_root`.
-            Some(execution_status) if execution_status.is_valid_or_irrelevant() => Ok(contribution),
+            Some(execution_status) if execution_status.is_valid() => Ok(contribution),
             // The contribution references a block that has not been verified by an EL (i.e. it
             // is optimistic or invalid). Don't return the block, return an error instead.
             Some(execution_status) => Err(Error::HeadBlockNotFullyVerified {
@@ -1998,7 +1998,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .fork_choice_read_lock()
             .get_block_execution_status(&beacon_block_root)
         {
-            Some(execution_status) if execution_status.is_valid_or_irrelevant() => (),
+            Some(execution_status) if execution_status.is_valid() => (),
             Some(execution_status) => {
                 return Err(Error::HeadBlockNotFullyVerified {
                     beacon_block_root,
@@ -4865,10 +4865,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Err(Box::new(DoNotReOrg::HeadNotLate.into()));
         }
 
-        let parent_head_hash = info.parent_node.execution_status.block_hash();
         let forkchoice_update_params = ForkchoiceUpdateParameters {
             head_root: info.parent_node.root,
-            head_hash: parent_head_hash,
+            head_hash: info.parent_node.execution_status.block_hash(),
             justified_hash: canonical_forkchoice_params.justified_hash,
             finalized_hash: canonical_forkchoice_params.finalized_hash,
         };
@@ -6005,7 +6004,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     proposer_index: proposer,
                     parent_block_root: head_root,
                     parent_block_number,
-                    parent_block_hash: forkchoice_update_params.head_hash.unwrap_or_default(),
+                    parent_block_hash: forkchoice_update_params.head_hash,
                     payload_attributes: payload_attributes.into(),
                 },
                 metadata: Default::default(),
@@ -6089,22 +6088,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // `execution_engine_forkchoice_lock` apart from the one here.
         let forkchoice_lock = execution_layer.execution_engine_forkchoice_lock().await;
 
-        let (head_block_root, head_hash, justified_hash, finalized_hash) =
-            if let Some(head_hash) = params.head_hash {
-                (
-                    params.head_root,
-                    head_hash,
-                    params
-                        .justified_hash
-                        .unwrap_or_else(ExecutionBlockHash::zero),
-                    params
-                        .finalized_hash
-                        .unwrap_or_else(ExecutionBlockHash::zero),
-                )
-            } else {
-                // Proposing the block for the merge is no longer supported.
-                return Ok(());
-            };
+        let head_block_root = params.head_root;
+        let head_hash = params.head_hash;
+        let justified_hash = params.justified_hash;
+        let finalized_hash = params.finalized_hash;
 
         let forkchoice_updated_response = execution_layer
             .notify_forkchoice_updated(
@@ -6941,13 +6928,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// account the current slot when accounting for skips.
     pub fn is_healthy(&self, parent_root: &Hash256) -> Result<ChainHealth, Error> {
         let cached_head = self.canonical_head.cached_head();
-        if let Some(head_hash) = cached_head.forkchoice_update_parameters().head_hash {
-            if ExecutionBlockHash::zero() == head_hash {
-                return Ok(ChainHealth::PreMerge);
-            }
-        } else {
+        if ExecutionBlockHash::zero() == cached_head.forkchoice_update_parameters().head_hash {
             return Ok(ChainHealth::PreMerge);
-        };
+        }
 
         // Check that the parent is NOT optimistic.
         if let Some(execution_status) = self

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -773,13 +773,12 @@ where
             slot_clock.now().ok_or("Unable to read slot")?
         };
 
-        let initial_head_block_root = fork_choice
+        let head_block_root = fork_choice
             .get_head(current_slot, &self.spec)
             .map_err(|e| format!("Unable to get fork choice head: {:?}", e))?;
 
-        let head_block_root = initial_head_block_root;
         let head_block = store
-            .get_full_block(&initial_head_block_root)
+            .get_full_block(&head_block_root)
             .map_err(|e| descriptive_db_error("head block", &e))?
             .ok_or("Head block not found in store")?;
 
@@ -911,7 +910,8 @@ where
 
         let genesis_validators_root = head_snapshot.beacon_state.genesis_validators_root();
         let genesis_time = head_snapshot.beacon_state.genesis_time();
-        let canonical_head = CanonicalHead::new(fork_choice, Arc::new(head_snapshot));
+        let canonical_head =
+            CanonicalHead::new(fork_choice, Arc::new(head_snapshot), head_block_root);
         let shuffling_cache_size = self.chain_config.shuffling_cache_size;
         let complete_blob_backfill = self.chain_config.complete_blob_backfill;
 

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -911,7 +911,8 @@ where
         let genesis_validators_root = head_snapshot.beacon_state.genesis_validators_root();
         let genesis_time = head_snapshot.beacon_state.genesis_time();
         let canonical_head =
-            CanonicalHead::new(fork_choice, Arc::new(head_snapshot), head_block_root);
+            CanonicalHead::new(fork_choice, Arc::new(head_snapshot), head_block_root)
+                .map_err(|e| format!("Unable to initialize canonical head: {:?}", e))?;
         let shuffling_cache_size = self.chain_config.shuffling_cache_size;
         let complete_blob_backfill = self.chain_config.complete_blob_backfill;
 

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -263,23 +263,14 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         snapshot: Arc<BeaconSnapshot<T::EthSpec>>,
         head_block_root: Hash256,
     ) -> Result<Self, Error> {
+        let params = forkchoice_update_parameters::<T>(&fork_choice, head_block_root)?;
         let cached_head = CachedHead {
             snapshot,
             justified_checkpoint: fork_choice.justified_checkpoint(),
             finalized_checkpoint: fork_choice.finalized_checkpoint(),
-            head_hash: fork_choice
-                .get_block_execution_block_hash(&head_block_root)
-                .ok_or(Error::HeadBlockMissingFromForkChoice(head_block_root))?,
-            justified_hash: fork_choice
-                .get_block_execution_block_hash(&fork_choice.justified_checkpoint().root)
-                .ok_or(Error::BlockMissingFromForkChoice(
-                    fork_choice.justified_checkpoint().root,
-                ))?,
-            finalized_hash: fork_choice
-                .get_block_execution_block_hash(&fork_choice.finalized_checkpoint().root)
-                .ok_or(Error::BlockMissingFromForkChoice(
-                    fork_choice.finalized_checkpoint().root,
-                ))?,
+            head_hash: params.head_hash,
+            justified_hash: params.justified_hash,
+            finalized_hash: params.finalized_hash,
         };
 
         Ok(Self {
@@ -324,23 +315,14 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
             beacon_state,
         };
 
+        let params = forkchoice_update_parameters::<T>(&fork_choice, beacon_block_root)?;
         let cached_head = CachedHead {
             snapshot: Arc::new(snapshot),
             justified_checkpoint: fork_choice.justified_checkpoint(),
             finalized_checkpoint: fork_choice.finalized_checkpoint(),
-            head_hash: fork_choice
-                .get_block_execution_block_hash(&beacon_block_root)
-                .ok_or(Error::HeadBlockMissingFromForkChoice(beacon_block_root))?,
-            justified_hash: fork_choice
-                .get_block_execution_block_hash(&fork_choice.justified_checkpoint().root)
-                .ok_or(Error::BlockMissingFromForkChoice(
-                    fork_choice.justified_checkpoint().root,
-                ))?,
-            finalized_hash: fork_choice
-                .get_block_execution_block_hash(&fork_choice.finalized_checkpoint().root)
-                .ok_or(Error::BlockMissingFromForkChoice(
-                    fork_choice.finalized_checkpoint().root,
-                ))?,
+            head_hash: params.head_hash,
+            justified_hash: params.justified_hash,
+            finalized_hash: params.finalized_hash,
         };
 
         *fork_choice_write_lock = fork_choice;
@@ -676,22 +658,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Get the parameters to update the execution layer since either the head or some finality
         // parameters have changed.
-        let new_forkchoice_update_parameters = ForkchoiceUpdateParameters {
-            head_root: new_head_root,
-            head_hash: fork_choice_read_lock
-                .get_block_execution_block_hash(&new_head_root)
-                .ok_or(Error::HeadBlockMissingFromForkChoice(new_head_root))?,
-            justified_hash: fork_choice_read_lock
-                .get_block_execution_block_hash(&new_view.justified_checkpoint.root)
-                .ok_or(Error::BlockMissingFromForkChoice(
-                    new_view.justified_checkpoint.root,
-                ))?,
-            finalized_hash: fork_choice_read_lock
-                .get_block_execution_block_hash(&new_view.finalized_checkpoint.root)
-                .ok_or(Error::BlockMissingFromForkChoice(
-                    new_view.finalized_checkpoint.root,
-                ))?,
-        };
+        let new_forkchoice_update_parameters =
+            forkchoice_update_parameters::<T>(&*fork_choice_read_lock, new_head_root)?;
 
         perform_debug_logging::<T>(&old_view, &new_view, &fork_choice_read_lock);
 
@@ -1526,4 +1494,27 @@ fn observe_head_block_delays<E: EthSpec, S: SlotClock>(
             );
         }
     }
+}
+
+/// Look up execution block hashes for the head, justified, and finalized blocks from fork choice.
+fn forkchoice_update_parameters<T: BeaconChainTypes>(
+    fork_choice: &BeaconForkChoice<T>,
+    head_root: Hash256,
+) -> Result<ForkchoiceUpdateParameters, Error> {
+    Ok(ForkchoiceUpdateParameters {
+        head_root,
+        head_hash: fork_choice
+            .get_block_execution_block_hash(&head_root)
+            .ok_or(Error::HeadBlockMissingFromForkChoice(head_root))?,
+        justified_hash: fork_choice
+            .get_block_execution_block_hash(&fork_choice.justified_checkpoint().root)
+            .ok_or(Error::BlockMissingFromForkChoice(
+                fork_choice.justified_checkpoint().root,
+            ))?,
+        finalized_hash: fork_choice
+            .get_block_execution_block_hash(&fork_choice.finalized_checkpoint().root)
+            .ok_or(Error::BlockMissingFromForkChoice(
+                fork_choice.finalized_checkpoint().root,
+            ))?,
+    })
 }

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -262,30 +262,31 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         fork_choice: BeaconForkChoice<T>,
         snapshot: Arc<BeaconSnapshot<T::EthSpec>>,
         head_block_root: Hash256,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         let cached_head = CachedHead {
             snapshot,
             justified_checkpoint: fork_choice.justified_checkpoint(),
             finalized_checkpoint: fork_choice.finalized_checkpoint(),
             head_hash: fork_choice
-                .get_block(&head_block_root)
-                .map(|b| b.execution_status.block_hash())
-                .unwrap_or_default(),
+                .get_block_execution_block_hash(&head_block_root)
+                .ok_or(Error::HeadBlockMissingFromForkChoice(head_block_root))?,
             justified_hash: fork_choice
-                .get_block(&fork_choice.justified_checkpoint().root)
-                .map(|b| b.execution_status.block_hash())
-                .unwrap_or_default(),
+                .get_block_execution_block_hash(&fork_choice.justified_checkpoint().root)
+                .ok_or(Error::BlockMissingFromForkChoice(
+                    fork_choice.justified_checkpoint().root,
+                ))?,
             finalized_hash: fork_choice
-                .get_block(&fork_choice.finalized_checkpoint().root)
-                .map(|b| b.execution_status.block_hash())
-                .unwrap_or_default(),
+                .get_block_execution_block_hash(&fork_choice.finalized_checkpoint().root)
+                .ok_or(Error::BlockMissingFromForkChoice(
+                    fork_choice.finalized_checkpoint().root,
+                ))?,
         };
 
-        Self {
+        Ok(Self {
             fork_choice: CanonicalHeadRwLock::new(fork_choice),
             cached_head: CanonicalHeadRwLock::new(cached_head),
             recompute_head_lock: Mutex::new(()),
-        }
+        })
     }
 
     /// Load a persisted version of `BeaconForkChoice` from the `store` and restore `self` to that
@@ -328,17 +329,18 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
             justified_checkpoint: fork_choice.justified_checkpoint(),
             finalized_checkpoint: fork_choice.finalized_checkpoint(),
             head_hash: fork_choice
-                .get_block(&beacon_block_root)
-                .map(|b| b.execution_status.block_hash())
-                .unwrap_or_default(),
+                .get_block_execution_block_hash(&beacon_block_root)
+                .ok_or(Error::HeadBlockMissingFromForkChoice(beacon_block_root))?,
             justified_hash: fork_choice
-                .get_block(&fork_choice.justified_checkpoint().root)
-                .map(|b| b.execution_status.block_hash())
-                .unwrap_or_default(),
+                .get_block_execution_block_hash(&fork_choice.justified_checkpoint().root)
+                .ok_or(Error::BlockMissingFromForkChoice(
+                    fork_choice.justified_checkpoint().root,
+                ))?,
             finalized_hash: fork_choice
-                .get_block(&fork_choice.finalized_checkpoint().root)
-                .map(|b| b.execution_status.block_hash())
-                .unwrap_or_default(),
+                .get_block_execution_block_hash(&fork_choice.finalized_checkpoint().root)
+                .ok_or(Error::BlockMissingFromForkChoice(
+                    fork_choice.finalized_checkpoint().root,
+                ))?,
         };
 
         *fork_choice_write_lock = fork_choice;
@@ -677,17 +679,18 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let new_forkchoice_update_parameters = ForkchoiceUpdateParameters {
             head_root: new_head_root,
             head_hash: fork_choice_read_lock
-                .get_block(&new_head_root)
-                .map(|b| b.execution_status.block_hash())
-                .unwrap_or_default(),
+                .get_block_execution_block_hash(&new_head_root)
+                .ok_or(Error::HeadBlockMissingFromForkChoice(new_head_root))?,
             justified_hash: fork_choice_read_lock
-                .get_block(&new_view.justified_checkpoint.root)
-                .map(|b| b.execution_status.block_hash())
-                .unwrap_or_default(),
+                .get_block_execution_block_hash(&new_view.justified_checkpoint.root)
+                .ok_or(Error::BlockMissingFromForkChoice(
+                    new_view.justified_checkpoint.root,
+                ))?,
             finalized_hash: fork_choice_read_lock
-                .get_block(&new_view.finalized_checkpoint.root)
-                .map(|b| b.execution_status.block_hash())
-                .unwrap_or_default(),
+                .get_block_execution_block_hash(&new_view.finalized_checkpoint.root)
+                .ok_or(Error::BlockMissingFromForkChoice(
+                    new_view.finalized_checkpoint.root,
+                ))?,
         };
 
         perform_debug_logging::<T>(&old_view, &new_view, &fork_choice_read_lock);

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -108,13 +108,12 @@ pub struct CachedHead<E: EthSpec> {
     /// This value may be distinct to the `self.snapshot.beacon_state.finalized_checkpoint`.
     /// This value should be used over the beacon state value in practically all circumstances.
     finalized_checkpoint: Checkpoint,
-    /// The `execution_payload.block_hash` of the block at the head of the chain. Set to `None`
-    /// before Bellatrix.
-    head_hash: Option<ExecutionBlockHash>,
-    /// The `execution_payload.block_hash` of the justified block. Set to `None` before Bellatrix.
-    justified_hash: Option<ExecutionBlockHash>,
-    /// The `execution_payload.block_hash` of the finalized block. Set to `None` before Bellatrix.
-    finalized_hash: Option<ExecutionBlockHash>,
+    /// The `execution_payload.block_hash` of the block at the head of the chain.
+    head_hash: ExecutionBlockHash,
+    /// The `execution_payload.block_hash` of the justified block.
+    justified_hash: ExecutionBlockHash,
+    /// The `execution_payload.block_hash` of the finalized block.
+    finalized_hash: ExecutionBlockHash,
 }
 
 impl<E: EthSpec> CachedHead<E> {

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1497,6 +1497,16 @@ fn observe_head_block_delays<E: EthSpec, S: SlotClock>(
 }
 
 /// Look up execution block hashes for the head, justified, and finalized blocks from fork choice.
+///
+/// Each lookup can only fail if the block is unknown to fork choice, which should not happen
+/// during normal operation since:
+///
+/// - The head root was just returned by `get_head`, so it must exist.
+/// - The justified and finalized roots are maintained as invariants by fork choice — they always
+///   reference blocks that are ancestors of the head and therefore present in the proto-array.
+///
+/// A missing block indicates a bug (e.g. corruption or a logic error in fork choice pruning).
+/// We return an error rather than panicking so the caller can log the issue and continue.
 fn forkchoice_update_parameters<T: BeaconChainTypes>(
     fork_choice: &BeaconForkChoice<T>,
     head_root: Hash256,

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -261,16 +261,24 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
     pub fn new(
         fork_choice: BeaconForkChoice<T>,
         snapshot: Arc<BeaconSnapshot<T::EthSpec>>,
+        head_block_root: Hash256,
     ) -> Self {
-        let fork_choice_view = fork_choice.cached_fork_choice_view();
-        let forkchoice_update_params = fork_choice.get_forkchoice_update_parameters();
         let cached_head = CachedHead {
             snapshot,
-            justified_checkpoint: fork_choice_view.justified_checkpoint,
-            finalized_checkpoint: fork_choice_view.finalized_checkpoint,
-            head_hash: forkchoice_update_params.head_hash,
-            justified_hash: forkchoice_update_params.justified_hash,
-            finalized_hash: forkchoice_update_params.finalized_hash,
+            justified_checkpoint: fork_choice.justified_checkpoint(),
+            finalized_checkpoint: fork_choice.finalized_checkpoint(),
+            head_hash: fork_choice
+                .get_block(&head_block_root)
+                .map(|b| b.execution_status.block_hash())
+                .unwrap_or_default(),
+            justified_hash: fork_choice
+                .get_block(&fork_choice.justified_checkpoint().root)
+                .map(|b| b.execution_status.block_hash())
+                .unwrap_or_default(),
+            finalized_hash: fork_choice
+                .get_block(&fork_choice.finalized_checkpoint().root)
+                .map(|b| b.execution_status.block_hash())
+                .unwrap_or_default(),
         };
 
         Self {
@@ -295,15 +303,16 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         store: &BeaconStore<T>,
         spec: &ChainSpec,
     ) -> Result<(), Error> {
-        let fork_choice =
+        let mut fork_choice =
             <BeaconChain<T>>::load_fork_choice(store.clone(), reset_payload_statuses, spec)?
                 .ok_or(Error::MissingPersistedForkChoice)?;
-        let fork_choice_view = fork_choice.cached_fork_choice_view();
-        let beacon_block_root = fork_choice_view.head_block_root;
+        let current_slot = fork_choice.fc_store().get_current_slot();
+        let beacon_block_root = fork_choice
+            .get_head(current_slot, spec)
+            .map_err(Error::ForkChoiceError)?;
         let beacon_block = store
             .get_full_block(&beacon_block_root)?
             .ok_or(Error::MissingBeaconBlock(beacon_block_root))?;
-        let current_slot = fork_choice.fc_store().get_current_slot();
         let (_, beacon_state) = store
             .get_advanced_hot_state(beacon_block_root, current_slot, beacon_block.state_root())?
             .ok_or(Error::MissingBeaconState(beacon_block.state_root()))?;
@@ -314,14 +323,22 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
             beacon_state,
         };
 
-        let forkchoice_update_params = fork_choice.get_forkchoice_update_parameters();
         let cached_head = CachedHead {
             snapshot: Arc::new(snapshot),
-            justified_checkpoint: fork_choice_view.justified_checkpoint,
-            finalized_checkpoint: fork_choice_view.finalized_checkpoint,
-            head_hash: forkchoice_update_params.head_hash,
-            justified_hash: forkchoice_update_params.justified_hash,
-            finalized_hash: forkchoice_update_params.finalized_hash,
+            justified_checkpoint: fork_choice.justified_checkpoint(),
+            finalized_checkpoint: fork_choice.finalized_checkpoint(),
+            head_hash: fork_choice
+                .get_block(&beacon_block_root)
+                .map(|b| b.execution_status.block_hash())
+                .unwrap_or_default(),
+            justified_hash: fork_choice
+                .get_block(&fork_choice.justified_checkpoint().root)
+                .map(|b| b.execution_status.block_hash())
+                .unwrap_or_default(),
+            finalized_hash: fork_choice
+                .get_block(&fork_choice.finalized_checkpoint().root)
+                .map(|b| b.execution_status.block_hash())
+                .unwrap_or_default(),
         };
 
         *fork_choice_write_lock = fork_choice;
@@ -596,14 +613,18 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let mut fork_choice_write_lock = self.canonical_head.fork_choice_write_lock();
 
         // Recompute the current head via the fork choice algorithm.
-        fork_choice_write_lock.get_head(current_slot, &self.spec)?;
+        let new_head_root = fork_choice_write_lock.get_head(current_slot, &self.spec)?;
 
         // Downgrade the fork choice write-lock to a read lock, without allowing access to any
         // other writers.
         let fork_choice_read_lock = RwLockWriteGuard::downgrade(fork_choice_write_lock);
 
         // Read the current head value from the fork choice algorithm.
-        let new_view = fork_choice_read_lock.cached_fork_choice_view();
+        let new_view = ForkChoiceView {
+            head_block_root: new_head_root,
+            justified_checkpoint: fork_choice_read_lock.justified_checkpoint(),
+            finalized_checkpoint: fork_choice_read_lock.finalized_checkpoint(),
+        };
 
         // Check to ensure that the finalized block hasn't been marked as invalid. If it has,
         // shut down Lighthouse.
@@ -653,8 +674,21 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Get the parameters to update the execution layer since either the head or some finality
         // parameters have changed.
-        let new_forkchoice_update_parameters =
-            fork_choice_read_lock.get_forkchoice_update_parameters();
+        let new_forkchoice_update_parameters = ForkchoiceUpdateParameters {
+            head_root: new_head_root,
+            head_hash: fork_choice_read_lock
+                .get_block(&new_head_root)
+                .map(|b| b.execution_status.block_hash())
+                .unwrap_or_default(),
+            justified_hash: fork_choice_read_lock
+                .get_block(&new_view.justified_checkpoint.root)
+                .map(|b| b.execution_status.block_hash())
+                .unwrap_or_default(),
+            finalized_hash: fork_choice_read_lock
+                .get_block(&new_view.finalized_checkpoint.root)
+                .map(|b| b.execution_status.block_hash())
+                .unwrap_or_default(),
+        };
 
         perform_debug_logging::<T>(&old_view, &new_view, &fork_choice_read_lock);
 

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -179,7 +179,7 @@ pub enum BeaconChainError {
     InvalidFinalizedPayloadShutdownError(TrySendError<ShutdownReason>),
     JustifiedPayloadInvalid {
         justified_root: Hash256,
-        execution_block_hash: Option<ExecutionBlockHash>,
+        execution_block_hash: ExecutionBlockHash,
     },
     ForkchoiceUpdate(execution_layer::Error),
     InvalidCheckpoint {

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -172,6 +172,7 @@ pub enum BeaconChainError {
     HeadMissingFromForkChoice(Hash256),
     FinalizedBlockMissingFromForkChoice(Hash256),
     HeadBlockMissingFromForkChoice(Hash256),
+    BlockMissingFromForkChoice(Hash256),
     InvalidFinalizedPayload {
         finalized_root: Hash256,
         execution_block_hash: ExecutionBlockHash,

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -16,11 +16,10 @@ use execution_layer::{
     PayloadParameters, PayloadStatus,
 };
 use fork_choice::{InvalidationOperation, PayloadVerificationStatus};
-use proto_array::{Block as ProtoBlock, ExecutionStatus};
+use proto_array::Block as ProtoBlock;
 use slot_clock::SlotClock;
 use state_processing::per_block_processing::{
-    compute_timestamp_at_slot, get_expected_withdrawals, is_execution_enabled,
-    partially_verify_execution_payload,
+    compute_timestamp_at_slot, get_expected_withdrawals, partially_verify_execution_payload,
 };
 use std::sync::Arc;
 use tokio::task::JoinHandle;
@@ -58,8 +57,8 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
     ) -> Result<Self, BlockError> {
         let payload_verification_status = if block.fork_name_unchecked().gloas_enabled() {
             // Gloas blocks don't contain an execution payload.
-            Some(PayloadVerificationStatus::Irrelevant)
-        } else if is_execution_enabled(state, block.message().body()) {
+            Some(PayloadVerificationStatus::Verified)
+        } else {
             // Perform the initial stages of payload verification.
             //
             // We will duplicate these checks again during `per_block_processing`, however these
@@ -94,8 +93,6 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
                 }
                 _ => None,
             }
-        } else {
-            Some(PayloadVerificationStatus::Irrelevant)
         };
 
         Ok(Self {
@@ -231,21 +228,15 @@ pub fn validate_execution_payload_for_gossip<T: BeaconChainTypes>(
         // We use only the execution status of the parent here to avoid loading the parent state
         // during gossip verification.
 
-        let parent_has_execution = match parent_block.execution_status {
-            // Parent has valid or optimistic execution status.
-            ExecutionStatus::Valid(_) | ExecutionStatus::Optimistic(_) => true,
-            // Pre-merge blocks have irrelevant execution status.
-            ExecutionStatus::Irrelevant(_) => false,
-            // If the parent has an invalid payload then it's impossible to build a valid block upon
-            // it. Reject the block.
-            ExecutionStatus::Invalid(_) => {
-                return Err(BlockError::ParentExecutionPayloadInvalid {
-                    parent_root: parent_block.root,
-                });
-            }
-        };
+        // If the parent has an invalid payload then it's impossible to build a valid block upon
+        // it. Reject the block.
+        if parent_block.execution_status.is_invalid() {
+            return Err(BlockError::ParentExecutionPayloadInvalid {
+                parent_root: parent_block.root,
+            });
+        }
 
-        if parent_has_execution || !execution_payload.is_default_with_empty_roots() {
+        {
             let expected_timestamp = chain
                 .slot_clock
                 .start_of(block.slot())

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -58,6 +58,14 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
         let payload_verification_status = if block.fork_name_unchecked().gloas_enabled() {
             // Gloas blocks don't contain an execution payload.
             Some(PayloadVerificationStatus::Verified)
+        } else if block
+            .message()
+            .body()
+            .execution_payload()
+            .is_ok_and(|p| p.is_default_with_empty_roots())
+        {
+            // Pre-merge blocks with default payloads don't need EL verification.
+            Some(PayloadVerificationStatus::Verified)
         } else {
             // Perform the initial stages of payload verification.
             //
@@ -234,6 +242,11 @@ pub fn validate_execution_payload_for_gossip<T: BeaconChainTypes>(
             return Err(BlockError::ParentExecutionPayloadInvalid {
                 parent_root: parent_block.root,
             });
+        }
+
+        if execution_payload.is_default_with_empty_roots() {
+            // Pre-merge blocks with default payloads don't need further validation.
+            return Ok(());
         }
 
         {

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -66,6 +66,9 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
         {
             // Pre-merge blocks with default payloads don't need EL verification.
             Some(PayloadVerificationStatus::Verified)
+        } else if block.message().body().execution_payload().is_err() {
+            // Pre-Bellatrix blocks don't have an execution payload.
+            Some(PayloadVerificationStatus::Verified)
         } else {
             // Perform the initial stages of payload verification.
             //

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -278,7 +278,7 @@ impl InvalidPayloadRig {
 
                 match forkchoice_response {
                     Payload::Syncing => assert!(execution_status.is_strictly_optimistic()),
-                    Payload::Valid => assert!(execution_status.is_valid_and_post_bellatrix()),
+                    Payload::Valid => assert!(execution_status.is_valid()),
                     Payload::Invalid { .. } | Payload::InvalidBlockHash => unreachable!(),
                 }
 
@@ -555,7 +555,7 @@ async fn pre_finalized_latest_valid_hash() {
         let slot = Slot::new(i);
         let root = rig.block_root_at_slot(slot).unwrap();
         if slot == 1 {
-            assert!(rig.execution_status(root).is_valid_and_post_bellatrix());
+            assert!(rig.execution_status(root).is_valid());
         } else {
             assert!(rig.execution_status(root).is_strictly_optimistic());
         }
@@ -604,10 +604,8 @@ async fn latest_valid_hash_will_not_validate() {
 
         if slot > LATEST_VALID_SLOT {
             assert!(execution_status.is_invalid())
-        } else if slot == 0 {
-            assert!(execution_status.is_irrelevant())
-        } else if slot == 1 {
-            assert!(execution_status.is_valid_and_post_bellatrix())
+        } else if slot <= 1 {
+            assert!(execution_status.is_valid())
         } else {
             assert!(execution_status.is_strictly_optimistic())
         }
@@ -650,7 +648,7 @@ async fn latest_valid_hash_is_junk() {
         let slot = Slot::new(i);
         let root = rig.block_root_at_slot(slot).unwrap();
         if slot == 1 {
-            assert!(rig.execution_status(root).is_valid_and_post_bellatrix());
+            assert!(rig.execution_status(root).is_valid());
         } else {
             assert!(rig.execution_status(root).is_strictly_optimistic());
         }
@@ -750,12 +748,9 @@ async fn invalidates_all_descendants() {
         }
 
         let execution_status = rig.execution_status(root);
-        if slot == 0 {
-            // Genesis block is pre-bellatrix.
-            assert!(execution_status.is_irrelevant());
-        } else if slot == 1 {
-            // First slot was imported as valid.
-            assert!(execution_status.is_valid_and_post_bellatrix());
+        if slot <= 1 {
+            // Genesis and first slot were imported as valid.
+            assert!(execution_status.is_valid());
         } else if slot <= latest_valid_slot {
             // Blocks prior to and included the latest valid hash are not marked as valid.
             assert!(execution_status.is_strictly_optimistic());
@@ -856,12 +851,9 @@ async fn switches_heads() {
         }
 
         let execution_status = rig.execution_status(root);
-        if slot == 0 {
-            // Genesis block is pre-bellatrix.
-            assert!(execution_status.is_irrelevant());
-        } else if slot == 1 {
-            // First slot was imported as valid.
-            assert!(execution_status.is_valid_and_post_bellatrix());
+        if slot <= 1 {
+            // Genesis and first slot were imported as valid.
+            assert!(execution_status.is_valid());
         } else if slot <= latest_valid_slot {
             // Blocks prior to and included the latest valid hash are not marked as valid.
             assert!(execution_status.is_strictly_optimistic());
@@ -962,8 +954,8 @@ async fn manually_validate_child() {
 
     rig.validate_manually(child);
 
-    assert!(rig.execution_status(parent).is_valid_and_post_bellatrix());
-    assert!(rig.execution_status(child).is_valid_and_post_bellatrix());
+    assert!(rig.execution_status(parent).is_valid());
+    assert!(rig.execution_status(child).is_valid());
 }
 
 #[tokio::test]
@@ -982,7 +974,7 @@ async fn manually_validate_parent() {
 
     rig.validate_manually(parent);
 
-    assert!(rig.execution_status(parent).is_valid_and_post_bellatrix());
+    assert!(rig.execution_status(parent).is_valid());
     assert!(rig.execution_status(child).is_strictly_optimistic());
 }
 
@@ -1224,7 +1216,7 @@ async fn attesting_to_optimistic_head() {
 
     rig.validate_manually(root);
     assert!(
-        rig.execution_status(root).is_valid_and_post_bellatrix(),
+        rig.execution_status(root).is_valid(),
         "the head should no longer be optimistic"
     );
 

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -725,10 +725,7 @@ where
                         .canonical_head
                         .cached_head()
                         .forkchoice_update_parameters();
-                    if params
-                        .head_hash
-                        .is_some_and(|hash| hash != ExecutionBlockHash::zero())
-                    {
+                    if params.head_hash != ExecutionBlockHash::zero() {
                         // Spawn a new task to update the EE without waiting for it to complete.
                         let inner_chain = beacon_chain.clone();
                         runtime_context.executor.spawn(

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -364,7 +364,6 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                 };
 
                 let block_hash = match beacon_chain.canonical_head.head_execution_status() {
-                    Ok(ExecutionStatus::Irrelevant(_)) => "n/a".to_string(),
                     Ok(ExecutionStatus::Valid(hash)) => {
                         metrics::set_gauge(&metrics::IS_OPTIMISTIC_SYNC, 0);
                         format!("{} (verified)", hash)

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1324,12 +1324,8 @@ impl<E: EthSpec> ExecutionLayer<E> {
                     );
                     let fork_choice_state = ForkchoiceState {
                         head_block_hash: parent_hash,
-                        safe_block_hash: forkchoice_update_params
-                            .justified_hash
-                            .unwrap_or_else(ExecutionBlockHash::zero),
-                        finalized_block_hash: forkchoice_update_params
-                            .finalized_hash
-                            .unwrap_or_else(ExecutionBlockHash::zero),
+                        safe_block_hash: forkchoice_update_params.justified_hash,
+                        finalized_block_hash: forkchoice_update_params.finalized_hash,
                     };
 
                     let response = engine

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -930,9 +930,9 @@ impl<E: EthSpec> MockBuilder<E> {
             .await;
 
         let forkchoice_update_params = ForkchoiceUpdateParameters {
-            head_hash: Some(head_execution_hash),
-            finalized_hash: Some(finalized_execution_hash),
-            justified_hash: Some(justified_execution_hash),
+            head_hash: head_execution_hash,
+            finalized_hash: finalized_execution_hash,
+            justified_hash: justified_execution_hash,
             head_root: head_block_root,
         };
 

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -92,9 +92,9 @@ impl<E: EthSpec> MockExecutionLayer<E> {
         let head_block_root = Hash256::repeat_byte(42);
         let forkchoice_update_params = ForkchoiceUpdateParameters {
             head_root: head_block_root,
-            head_hash: Some(parent_hash),
-            justified_hash: None,
-            finalized_hash: None,
+            head_hash: parent_hash,
+            justified_hash: ExecutionBlockHash::zero(),
+            finalized_hash: ExecutionBlockHash::zero(),
         };
         let payload_attributes =
             PayloadAttributes::new(timestamp, prev_randao, Address::repeat_byte(42), None, None);

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2078,11 +2078,7 @@ pub fn serve<T: BeaconChainTypes>(
                         .nodes
                         .iter()
                         .map(|node| {
-                            let execution_status = if node.execution_status.is_execution_enabled() {
-                                Some(node.execution_status.to_string())
-                            } else {
-                                None
-                            };
+                            let execution_status = Some(node.execution_status.to_string());
 
                             ForkChoiceNode {
                                 slot: node.slot,
@@ -2098,7 +2094,7 @@ pub fn serve<T: BeaconChainTypes>(
                                 execution_block_hash: node
                                     .execution_status
                                     .block_hash()
-                                    .map(|block_hash| block_hash.into_root()),
+                                    .into_root(),
                                 extra_data: ForkChoiceExtraData {
                                     target_root: node.target_root,
                                     justified_root: node.justified_checkpoint.root,

--- a/beacon_node/http_api/src/state_id.rs
+++ b/beacon_node/http_api/src/state_id.rs
@@ -104,10 +104,7 @@ impl StateId {
                     .map_err(warp_utils::reject::unhandled_error)?
                 {
                     let fork_choice = chain.canonical_head.fork_choice_read_lock();
-                    let finalized_root = fork_choice
-                        .cached_fork_choice_view()
-                        .finalized_checkpoint
-                        .root;
+                    let finalized_root = fork_choice.finalized_checkpoint().root;
                     let execution_optimistic = fork_choice
                         .is_optimistic_or_invalid_block_no_fallback(&finalized_root)
                         .map_err(BeaconChainError::ForkChoiceError)
@@ -262,7 +259,7 @@ pub fn checkpoint_slot_and_execution_optimistic<T: BeaconChainTypes>(
 ) -> Result<(Slot, ExecutionOptimistic), warp::reject::Rejection> {
     let slot = checkpoint.epoch.start_slot(T::EthSpec::slots_per_epoch());
     let fork_choice = chain.canonical_head.fork_choice_read_lock();
-    let finalized_checkpoint = fork_choice.cached_fork_choice_view().finalized_checkpoint;
+    let finalized_checkpoint = fork_choice.finalized_checkpoint();
 
     // If the checkpoint is pre-finalization, just use the optimistic status of the finalized
     // block.

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -3063,11 +3063,7 @@ impl ApiTester {
             .nodes
             .iter()
             .map(|node| {
-                let execution_status = if node.execution_status.is_execution_enabled() {
-                    Some(node.execution_status.to_string())
-                } else {
-                    None
-                };
+                let execution_status = Some(node.execution_status.to_string());
                 ForkChoiceNode {
                     slot: node.slot,
                     block_root: node.root,
@@ -3079,10 +3075,7 @@ impl ApiTester {
                     finalized_epoch: node.finalized_checkpoint.epoch,
                     weight: node.weight,
                     validity: execution_status,
-                    execution_block_hash: node
-                        .execution_status
-                        .block_hash()
-                        .map(|block_hash| block_hash.into_root()),
+                    execution_block_hash: node.execution_status.block_hash().into_root(),
                     extra_data: ForkChoiceExtraData {
                         target_root: node.target_root,
                         justified_root: node.justified_checkpoint.root,

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1546,7 +1546,7 @@ pub struct ForkChoiceNode {
     #[serde(with = "serde_utils::quoted_u64")]
     pub weight: u64,
     pub validity: Option<String>,
-    pub execution_block_hash: Option<Hash256>,
+    pub execution_block_hash: Hash256,
     pub extra_data: ForkChoiceExtraData,
 }
 

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -358,13 +358,13 @@ where
             AttestationShufflingId::new(anchor_block_root, anchor_state, RelativeEpoch::Next)
                 .map_err(Error::BeaconStateError)?;
 
-        // All post-merge blocks have execution payloads. Assume the anchor payload is valid,
-        // since the anchor should be a trusted block and state.
+        // Assume the anchor payload is valid, since the anchor should be a trusted block and
+        // state. Pre-merge blocks without execution payloads use a zero block hash.
         let execution_status = anchor_block
             .message()
             .execution_payload()
             .map(|execution_payload| ExecutionStatus::Valid(execution_payload.block_hash()))
-            .map_err(|_| Error::MissingExecutionPayload)?;
+            .unwrap_or(ExecutionStatus::Valid(ExecutionBlockHash::zero()));
 
         // If the current slot is not provided, use the value that was last provided to the store.
         let current_slot = current_slot.unwrap_or_else(|| fc_store.get_current_slot());

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -790,17 +790,18 @@ where
             .on_verified_block(block, block_root, state)
             .map_err(Error::AfterBlockFailed)?;
 
-        let execution_status = {
-            let execution_payload = block
-                .body()
-                .execution_payload()
-                .map_err(|_| Error::MissingExecutionPayload)?;
-            let block_hash = execution_payload.block_hash();
-
-            match payload_verification_status {
-                PayloadVerificationStatus::Verified => ExecutionStatus::Valid(block_hash),
-                PayloadVerificationStatus::Optimistic => ExecutionStatus::Optimistic(block_hash),
+        let execution_status = match block.body().execution_payload() {
+            Ok(execution_payload) => {
+                let block_hash = execution_payload.block_hash();
+                match payload_verification_status {
+                    PayloadVerificationStatus::Verified => ExecutionStatus::Valid(block_hash),
+                    PayloadVerificationStatus::Optimistic => {
+                        ExecutionStatus::Optimistic(block_hash)
+                    }
+                }
             }
+            // Pre-Bellatrix blocks don't have an execution payload.
+            Err(_) => ExecutionStatus::Valid(ExecutionBlockHash::zero()),
         };
 
         // This does not apply a vote to the block, it just makes fork choice aware of the block so

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -1173,6 +1173,15 @@ where
         }
     }
 
+    /// Returns the execution block hash for a block, if known.
+    pub fn get_block_execution_block_hash(
+        &self,
+        block_root: &Hash256,
+    ) -> Option<ExecutionBlockHash> {
+        self.get_block(block_root)
+            .map(|b| b.execution_status.block_hash())
+    }
+
     /// Returns an `ExecutionStatus` if the block is known **and** a descendant of the finalized root.
     pub fn get_block_execution_status(&self, block_root: &Hash256) -> Option<ExecutionStatus> {
         if self.is_finalized_checkpoint_or_descendant(*block_root) {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -56,11 +56,7 @@ pub enum Error<T> {
         block_slot: Slot,
         state_slot: Slot,
     },
-    InvalidPayloadStatus {
-        block_slot: Slot,
-        block_root: Hash256,
-        payload_verification_status: PayloadVerificationStatus,
-    },
+    MissingExecutionPayload,
     MissingJustifiedBlock {
         justified_checkpoint: Checkpoint,
     },
@@ -194,8 +190,6 @@ pub enum PayloadVerificationStatus {
     Verified,
     /// An EL has not yet made a determination about the execution payload.
     Optimistic,
-    /// The block is either pre-merge-fork, or prior to the terminal PoW block.
-    Irrelevant,
 }
 
 impl PayloadVerificationStatus {
@@ -204,7 +198,6 @@ impl PayloadVerificationStatus {
         match self {
             PayloadVerificationStatus::Verified => false,
             PayloadVerificationStatus::Optimistic => true,
-            PayloadVerificationStatus::Irrelevant => false,
         }
     }
 }
@@ -290,9 +283,9 @@ pub enum AttestationFromBlock {
 pub struct ForkchoiceUpdateParameters {
     /// The most recent result of running `ForkChoice::get_head`.
     pub head_root: Hash256,
-    pub head_hash: Option<ExecutionBlockHash>,
-    pub justified_hash: Option<ExecutionBlockHash>,
-    pub finalized_hash: Option<ExecutionBlockHash>,
+    pub head_hash: ExecutionBlockHash,
+    pub justified_hash: ExecutionBlockHash,
+    pub finalized_hash: ExecutionBlockHash,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -367,21 +360,13 @@ where
             AttestationShufflingId::new(anchor_block_root, anchor_state, RelativeEpoch::Next)
                 .map_err(Error::BeaconStateError)?;
 
-        let execution_status = anchor_block.message().execution_payload().map_or_else(
-            // If the block doesn't have an execution payload then it can't have
-            // execution enabled.
-            |_| ExecutionStatus::irrelevant(),
-            |execution_payload| {
-                if execution_payload.is_default_with_empty_roots() {
-                    // A default payload does not have execution enabled.
-                    ExecutionStatus::irrelevant()
-                } else {
-                    // Assume that this payload is valid, since the anchor should be a trusted block and
-                    // state.
-                    ExecutionStatus::Valid(execution_payload.block_hash())
-                }
-            },
-        );
+        // All post-merge blocks have execution payloads. Assume the anchor payload is valid,
+        // since the anchor should be a trusted block and state.
+        let execution_status = anchor_block
+            .message()
+            .execution_payload()
+            .map(|execution_payload| ExecutionStatus::Valid(execution_payload.block_hash()))
+            .map_err(|_| Error::MissingExecutionPayload)?;
 
         // If the current slot is not provided, use the value that was last provided to the store.
         let current_slot = current_slot.unwrap_or_else(|| fc_store.get_current_slot());
@@ -403,16 +388,15 @@ where
             queued_attestations: vec![],
             // This will be updated during the next call to `Self::get_head`.
             forkchoice_update_parameters: ForkchoiceUpdateParameters {
-                head_hash: None,
-                justified_hash: None,
-                finalized_hash: None,
-                // This will be updated during the next call to `Self::get_head`.
                 head_root: Hash256::zero(),
+                head_hash: ExecutionBlockHash::zero(),
+                justified_hash: ExecutionBlockHash::zero(),
+                finalized_hash: ExecutionBlockHash::zero(),
             },
             _phantom: PhantomData,
         };
 
-        // Ensure that `fork_choice.forkchoice_update_parameters.head_root` is updated.
+        // Ensure that `fork_choice.forkchoice_update_parameters` is updated.
         fork_choice.get_head(current_slot, spec)?;
 
         Ok(fork_choice)
@@ -501,20 +485,20 @@ where
         // Cache some values for the next forkchoiceUpdate call to the execution layer.
         let head_hash = self
             .get_block(&head_root)
-            .and_then(|b| b.execution_status.block_hash());
+            .and_then(|b| Some(b.execution_status.block_hash()));
         let justified_root = self.justified_checkpoint().root;
         let finalized_root = self.finalized_checkpoint().root;
         let justified_hash = self
             .get_block(&justified_root)
-            .and_then(|b| b.execution_status.block_hash());
+            .and_then(|b| Some(b.execution_status.block_hash()));
         let finalized_hash = self
             .get_block(&finalized_root)
-            .and_then(|b| b.execution_status.block_hash());
+            .and_then(|b| Some(b.execution_status.block_hash()));
         self.forkchoice_update_parameters = ForkchoiceUpdateParameters {
             head_root,
-            head_hash,
-            justified_hash,
-            finalized_hash,
+            head_hash: head_hash.unwrap_or(ExecutionBlockHash::zero()),
+            justified_hash: justified_hash.unwrap_or(ExecutionBlockHash::zero()),
+            finalized_hash: finalized_hash.unwrap_or(ExecutionBlockHash::zero()),
         };
 
         Ok(head_root)
@@ -853,33 +837,17 @@ where
             .on_verified_block(block, block_root, state)
             .map_err(Error::AfterBlockFailed)?;
 
-        let execution_status = if let Ok(execution_payload) = block.body().execution_payload() {
+        let execution_status = {
+            let execution_payload = block
+                .body()
+                .execution_payload()
+                .map_err(|_| Error::MissingExecutionPayload)?;
             let block_hash = execution_payload.block_hash();
 
-            if block_hash == ExecutionBlockHash::zero() {
-                // The block is post-merge-fork, but pre-terminal-PoW block. We don't need to verify
-                // the payload.
-                ExecutionStatus::irrelevant()
-            } else {
-                match payload_verification_status {
-                    PayloadVerificationStatus::Verified => ExecutionStatus::Valid(block_hash),
-                    PayloadVerificationStatus::Optimistic => {
-                        ExecutionStatus::Optimistic(block_hash)
-                    }
-                    // It would be a logic error to declare a block irrelevant if it has an
-                    // execution payload with a non-zero block hash.
-                    PayloadVerificationStatus::Irrelevant => {
-                        return Err(Error::InvalidPayloadStatus {
-                            block_slot: block.slot(),
-                            block_root,
-                            payload_verification_status,
-                        });
-                    }
-                }
+            match payload_verification_status {
+                PayloadVerificationStatus::Verified => ExecutionStatus::Valid(block_hash),
+                PayloadVerificationStatus::Optimistic => ExecutionStatus::Optimistic(block_hash),
             }
-        } else {
-            // There is no payload to verify.
-            ExecutionStatus::irrelevant()
         };
 
         // This does not apply a vote to the block, it just makes fork choice aware of the block so
@@ -1476,11 +1444,10 @@ where
             queued_attestations: persisted.queued_attestations,
             // Will be updated in the following call to `Self::get_head`.
             forkchoice_update_parameters: ForkchoiceUpdateParameters {
-                head_hash: None,
-                justified_hash: None,
-                finalized_hash: None,
-                // Will be updated in the following call to `Self::get_head`.
                 head_root: Hash256::zero(),
+                head_hash: ExecutionBlockHash::zero(),
+                justified_hash: ExecutionBlockHash::zero(),
+                finalized_hash: ExecutionBlockHash::zero(),
             },
             _phantom: PhantomData,
         };

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -312,8 +312,6 @@ pub struct ForkChoice<T, E> {
     proto_array: ProtoArrayForkChoice,
     /// Attestations that arrived at the current slot and must be queued for later processing.
     queued_attestations: Vec<QueuedAttestation>,
-    /// Stores a cache of the values required to be sent to the execution layer.
-    forkchoice_update_parameters: ForkchoiceUpdateParameters,
     _phantom: PhantomData<E>,
 }
 
@@ -386,28 +384,12 @@ where
             fc_store,
             proto_array,
             queued_attestations: vec![],
-            // This will be updated during the next call to `Self::get_head`.
-            forkchoice_update_parameters: ForkchoiceUpdateParameters {
-                head_root: Hash256::zero(),
-                head_hash: ExecutionBlockHash::zero(),
-                justified_hash: ExecutionBlockHash::zero(),
-                finalized_hash: ExecutionBlockHash::zero(),
-            },
             _phantom: PhantomData,
         };
 
-        // Ensure that `fork_choice.forkchoice_update_parameters` is updated.
         fork_choice.get_head(current_slot, spec)?;
 
         Ok(fork_choice)
-    }
-
-    /// Returns cached information that can be used to issue a `forkchoiceUpdated` message to an
-    /// execution engine.
-    ///
-    /// These values are updated each time `Self::get_head` is called.
-    pub fn get_forkchoice_update_parameters(&self) -> ForkchoiceUpdateParameters {
-        self.forkchoice_update_parameters
     }
 
     /// Returns the block root of an ancestor of `block_root` at the given `slot`. (Note: `slot` refers
@@ -481,25 +463,6 @@ where
             current_slot,
             spec,
         )?;
-
-        // Cache some values for the next forkchoiceUpdate call to the execution layer.
-        let head_hash = self
-            .get_block(&head_root)
-            .and_then(|b| Some(b.execution_status.block_hash()));
-        let justified_root = self.justified_checkpoint().root;
-        let finalized_root = self.finalized_checkpoint().root;
-        let justified_hash = self
-            .get_block(&justified_root)
-            .and_then(|b| Some(b.execution_status.block_hash()));
-        let finalized_hash = self
-            .get_block(&finalized_root)
-            .and_then(|b| Some(b.execution_status.block_hash()));
-        self.forkchoice_update_parameters = ForkchoiceUpdateParameters {
-            head_root,
-            head_hash: head_hash.unwrap_or(ExecutionBlockHash::zero()),
-            justified_hash: justified_hash.unwrap_or(ExecutionBlockHash::zero()),
-            finalized_hash: finalized_hash.unwrap_or(ExecutionBlockHash::zero()),
-        };
 
         Ok(head_root)
     }
@@ -586,16 +549,6 @@ where
     /// ## Notes
     ///
     /// The finalized/justified checkpoints are determined from the fork choice store. Therefore,
-    /// it's possible that the state corresponding to `get_state(get_block(head_block_root))` will
-    /// have *differing* finalized and justified information.
-    pub fn cached_fork_choice_view(&self) -> ForkChoiceView {
-        ForkChoiceView {
-            head_block_root: self.forkchoice_update_parameters.head_root,
-            justified_checkpoint: self.justified_checkpoint(),
-            finalized_checkpoint: self.finalized_checkpoint(),
-        }
-    }
-
     /// See `ProtoArrayForkChoice::process_execution_payload_validation` for documentation.
     pub fn on_valid_execution_payload(
         &mut self,
@@ -1442,13 +1395,6 @@ where
             fc_store,
             proto_array,
             queued_attestations: persisted.queued_attestations,
-            // Will be updated in the following call to `Self::get_head`.
-            forkchoice_update_parameters: ForkchoiceUpdateParameters {
-                head_root: Hash256::zero(),
-                head_hash: ExecutionBlockHash::zero(),
-                justified_hash: ExecutionBlockHash::zero(),
-                finalized_hash: ExecutionBlockHash::zero(),
-            },
             _phantom: PhantomData,
         };
 

--- a/consensus/proto_array/src/error.rs
+++ b/consensus/proto_array/src/error.rs
@@ -45,9 +45,6 @@ pub enum Error {
         block_root: Hash256,
         latest_valid_ancestor_hash: Option<ExecutionBlockHash>,
     },
-    IrrelevantDescendant {
-        block_root: Hash256,
-    },
     ParentExecutionStatusIsInvalid {
         block_root: Hash256,
         parent_root: Hash256,

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -406,10 +406,6 @@ impl ProtoArray {
                 // We have reached a node that we already know is valid. No need to iterate further
                 // since we assume an ancestors have already been set to valid.
                 ExecutionStatus::Valid(_) => return Ok(()),
-                // We have reached an irrelevant node, this node is prior to a terminal execution
-                // block. There's no need to iterate further, it's impossible for this block to have
-                // any relevant ancestors.
-                ExecutionStatus::Irrelevant(_) => return Ok(()),
                 // The block has an unknown status, set it to valid since any ancestor of a valid
                 // payload can be considered valid.
                 ExecutionStatus::Optimistic(payload_block_hash) => {
@@ -522,7 +518,6 @@ impl ProtoArray {
                         break;
                     }
                 }
-                ExecutionStatus::Irrelevant(_) => break,
             }
 
             // Only invalidate the head block if either:
@@ -557,9 +552,6 @@ impl ProtoArray {
                     // The block is already invalid, but keep going backwards to ensure all ancestors
                     // are updated.
                     ExecutionStatus::Invalid(_) => (),
-                    // This block is pre-merge, therefore it has no execution status. Nor do its
-                    // ancestors.
-                    ExecutionStatus::Irrelevant(_) => break,
                 }
             }
 
@@ -609,11 +601,6 @@ impl ProtoArray {
                     }
                     ExecutionStatus::Optimistic(hash) | ExecutionStatus::Invalid(hash) => {
                         node.execution_status = ExecutionStatus::Invalid(*hash)
-                    }
-                    ExecutionStatus::Irrelevant(_) => {
-                        return Err(Error::IrrelevantDescendant {
-                            block_root: node.root,
-                        });
                     }
                 }
 
@@ -1076,11 +1063,7 @@ impl ProtoArray {
         self.nodes
             .iter()
             .rev()
-            .find(|node| {
-                node.execution_status
-                    .block_hash()
-                    .is_some_and(|node_block_hash| node_block_hash == *block_hash)
-            })
+            .find(|node| node.execution_status.block_hash() == *block_hash)
             .map(|node| node.root)
     }
 

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -39,73 +39,28 @@ pub enum ExecutionStatus {
     Invalid(ExecutionBlockHash),
     /// An EL has not yet verified the execution payload.
     Optimistic(ExecutionBlockHash),
-    /// The block is either prior to the merge fork, or after the merge fork but before the terminal
-    /// PoW block has been found.
-    ///
-    /// # Note:
-    ///
-    /// This `bool` only exists to satisfy our SSZ implementation which requires all variants
-    /// to have a value. It can be set to anything.
-    Irrelevant(bool),
 }
 
 impl ExecutionStatus {
-    pub fn is_execution_enabled(&self) -> bool {
-        !matches!(self, ExecutionStatus::Irrelevant(_))
-    }
-
-    pub fn irrelevant() -> Self {
-        ExecutionStatus::Irrelevant(false)
-    }
-
-    pub fn block_hash(&self) -> Option<ExecutionBlockHash> {
+    pub fn block_hash(&self) -> ExecutionBlockHash {
         match self {
             ExecutionStatus::Valid(hash)
             | ExecutionStatus::Invalid(hash)
-            | ExecutionStatus::Optimistic(hash) => Some(*hash),
-            ExecutionStatus::Irrelevant(_) => None,
+            | ExecutionStatus::Optimistic(hash) => *hash,
         }
     }
 
-    /// Returns `true` if the block:
-    ///
-    /// - Has a valid payload, OR
-    /// - Does not have execution enabled.
-    ///
-    /// Whenever this function returns `true`, the block is *fully valid*.
-    pub fn is_valid_or_irrelevant(&self) -> bool {
-        matches!(
-            self,
-            ExecutionStatus::Valid(_) | ExecutionStatus::Irrelevant(_)
-        )
-    }
-
-    /// Returns `true` if the block:
-    ///
-    /// - Has execution enabled, AND
-    /// - Has a valid payload
-    ///
-    /// This function will return `false` for any block from a slot prior to the Bellatrix fork.
-    /// This means that some blocks that are perfectly valid will still receive a `false` response.
-    /// See `Self::is_valid_or_irrelevant` for a function that will always return `true` given any
-    /// perfectly valid block.
-    pub fn is_valid_and_post_bellatrix(&self) -> bool {
+    /// Returns `true` if the payload has been verified as valid by an EL.
+    pub fn is_valid(&self) -> bool {
         matches!(self, ExecutionStatus::Valid(_))
     }
 
-    /// Returns `true` if the block:
-    ///
-    /// - Has execution enabled, AND
-    /// - Has a payload that has not yet been verified by an EL.
+    /// Returns `true` if the EL has not yet verified the execution payload.
     pub fn is_strictly_optimistic(&self) -> bool {
         matches!(self, ExecutionStatus::Optimistic(_))
     }
 
-    /// Returns `true` if the block:
-    ///
-    /// - Has execution enabled, AND
-    ///     - Has a payload that has not yet been verified by an EL, OR.
-    ///     - Has a payload that has been deemed invalid by an EL.
+    /// Returns `true` if the payload is either unverified or invalid.
     pub fn is_optimistic_or_invalid(&self) -> bool {
         matches!(
             self,
@@ -113,19 +68,9 @@ impl ExecutionStatus {
         )
     }
 
-    /// Returns `true` if the block:
-    ///
-    /// - Has execution enabled, AND
-    /// - Has an invalid payload.
+    /// Returns `true` if the payload has been deemed invalid by an EL.
     pub fn is_invalid(&self) -> bool {
         matches!(self, ExecutionStatus::Invalid(_))
-    }
-
-    /// Returns `true` if the block:
-    ///
-    /// - Does not have execution enabled (before or after Bellatrix fork)
-    pub fn is_irrelevant(&self) -> bool {
-        matches!(self, ExecutionStatus::Irrelevant(_))
     }
 }
 
@@ -135,7 +80,6 @@ impl fmt::Display for ExecutionStatus {
             ExecutionStatus::Valid(_) => write!(f, "valid"),
             ExecutionStatus::Invalid(_) => write!(f, "invalid"),
             ExecutionStatus::Optimistic(_) => write!(f, "optimistic"),
-            ExecutionStatus::Irrelevant(_) => write!(f, "irrelevant"),
         }
     }
 }
@@ -818,8 +762,6 @@ impl ProtoArrayForkChoice {
                 ExecutionStatus::Valid(block_hash) | ExecutionStatus::Optimistic(block_hash) => {
                     node.execution_status = ExecutionStatus::Optimistic(block_hash)
                 }
-                // An irrelevant node cannot become optimistic, this is a no-op.
-                ExecutionStatus::Irrelevant(_) => (),
             }
         }
 
@@ -1116,7 +1058,7 @@ mod test_compute_deltas {
         let unknown = Hash256::from_low_u64_be(4);
         let junk_shuffling_id =
             AttestationShufflingId::from_components(Epoch::new(0), Hash256::zero());
-        let execution_status = ExecutionStatus::irrelevant();
+        let execution_status = ExecutionStatus::Valid(ExecutionBlockHash::zero());
 
         let genesis_checkpoint = Checkpoint {
             epoch: genesis_epoch,
@@ -1264,7 +1206,7 @@ mod test_compute_deltas {
         let junk_state_root = Hash256::zero();
         let junk_shuffling_id =
             AttestationShufflingId::from_components(Epoch::new(0), Hash256::zero());
-        let execution_status = ExecutionStatus::irrelevant();
+        let execution_status = ExecutionStatus::Valid(ExecutionBlockHash::zero());
 
         let genesis_checkpoint = Checkpoint {
             epoch: Epoch::new(0),

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -744,7 +744,7 @@ impl<E: EthSpec> Tester<E> {
                     block_root,
                     block_delay,
                     &state,
-                    PayloadVerificationStatus::Irrelevant,
+                    PayloadVerificationStatus::Verified,
                     &self.harness.chain.spec,
                 );
 

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -294,9 +294,9 @@ impl<Engine: GenericExecutionEngine> TestRig<Engine> {
         let finalized_block_hash = ExecutionBlockHash::zero();
         let forkchoice_update_params = ForkchoiceUpdateParameters {
             head_root,
-            head_hash: Some(parent_hash),
-            justified_hash: Some(justified_block_hash),
-            finalized_hash: Some(finalized_block_hash),
+            head_hash: parent_hash,
+            justified_hash: justified_block_hash,
+            finalized_hash: finalized_block_hash,
         };
         let proposer_index = 0;
 


### PR DESCRIPTION
  Summary

  Builds on #8761. Now that merge transition code is being removed, execution block hashes no longer need to be Option types throughout the fork choice and beacon chain.

  - Remove ExecutionStatus::Irrelevant variant and PayloadVerificationStatus::Irrelevant — all blocks now have an execution payload with a real block hash
  - Change ExecutionStatus::block_hash() to return ExecutionBlockHash directly instead of Option<ExecutionBlockHash>
  - Make ForkchoiceUpdateParameters fields (head_hash, justified_hash, finalized_hash) non-optional
  - Make CachedHead execution hash fields non-optional
  - Make ForkChoiceNode::execution_block_hash non-optional (Hash256 instead of Option<Hash256>)
  - Simplify callers that previously had to unwrap/match on these options

  Net result: -270 lines, +107 lines across 19 files.

  Notes

  - Spec-level functions like is_execution_enabled() and execution_payload() returning Result are intentionally left unchanged — archive nodes still need to sync through the merge and produce post-states for pre-merge blocks
  - ChainHealth::PreMerge is kept for now as it guards against a zero execution block hash at head
  - ForkChoiceNode::validity remains Option<String> to preserve the existing debug API JSON shape

  Test plan

  - cargo check passes
  - make lint-full passes
  - cargo nextest run -p proto_array
  - cargo nextest run -p fork_choice
  - cargo nextest run -p beacon_chain (payload invalidation tests updated)
  - cargo nextest run -p http_api