### PR TITLE
Gloas checkpoint sync + range sync envelope wiring

### DIFF
--- a/CHECKPOINT_SYNC_PROGRESS.md
+++ b/CHECKPOINT_SYNC_PROGRESS.md
@@ -5,9 +5,10 @@ Make Lighthouse checkpoint sync against epbs-devnet-1 and follow head.
 
 ## Status: CHECKPOINT SYNC WORKS + ENVELOPE LOOKUP WIRED
 - Checkpoint sync initializes correctly, zero block rejections, finalized root matches devnet
-- Cannot test full sync-to-head: our IP (85.10.201.236) is banned by all 3 Prysm peers
-- Prysm ban persists >2.5 hours. Need fresh IP or ethpandaops to clear bans
-- 10-minute wait between attempts did not clear the ban
+- Cannot test full sync-to-head: Prysm collocation limit blocks our IP
+- Root cause: 22 peer IDs stored from our IP 85.10.201.236, exceeds Prysm's CollocationLimit=5
+- Not an IP ban — it's an anti-Sybil measure in `beacon-chain/p2p/peers/status.go:isfromBadIP`
+- Need: fresh IP, Prysm restart (clear peer store), or different machine
 
 ## Devnet State (checked 2026-04-04)
 - Devnet alive, head slot ~25232, synced, not optimistic

--- a/CHECKPOINT_SYNC_PROGRESS.md
+++ b/CHECKPOINT_SYNC_PROGRESS.md
@@ -3,7 +3,11 @@
 ## Goal
 Make Lighthouse checkpoint sync against epbs-devnet-1 and follow head.
 
-## Status: CHECKPOINT SYNC WORKS — peer connectivity issue blocks syncing to head
+## Status: CHECKPOINT SYNC WORKS + ENVELOPE LOOKUP WIRED
+- Checkpoint sync initializes correctly, zero block rejections, finalized root matches devnet
+- Cannot test full sync-to-head: our IP (85.10.201.236) is banned by all 3 Prysm peers
+- Prysm ban persists >2.5 hours. Need fresh IP or ethpandaops to clear bans
+- 10-minute wait between attempts did not clear the ban
 
 ## Devnet State (checked 2026-04-04)
 - Devnet alive, head slot ~25232, synced, not optimistic
@@ -86,7 +90,7 @@ Mutating it changes the root, making our node incompatible. Need a different app
   similar to how `DataColumnsByRange` was integrated. This is a significant change to the
   range sync pipeline and coupling logic.
 
-### Bug 5: Prysm peers send Goodbye:Fault (NETWORKING)
+### Bug 5: Prysm peers IP-banned from previous broken sessions (NETWORKING)
 - Prysm sends `Goodbye: Fault` immediately after status exchange
 - Happens BEFORE any data requests — not caused by rate limiting
 - Our finalized_root and epoch match the devnet's canonical chain

--- a/CHECKPOINT_SYNC_PROGRESS.md
+++ b/CHECKPOINT_SYNC_PROGRESS.md
@@ -1,0 +1,114 @@
+# Checkpoint Sync Progress — epbs-devnet-1
+
+## Goal
+Make Lighthouse checkpoint sync against epbs-devnet-1 and follow head.
+
+## Status: CHECKPOINT SYNC WORKS — peer connectivity issue blocks syncing to head
+
+## Devnet State (checked 2026-04-04)
+- Devnet alive, head slot ~25232, synced, not optimistic
+- Checkpoint sync URL: `https://beacon.epbs-devnet-1.ethpandaops.io/`
+
+## Pre-existing Bugs (from DEVNET_SYNC_STATUS.md)
+
+### Bug 1: MissingHotStateSummary — FIXED (prior work)
+- **File**: `beacon_node/store/src/hot_cold_store.rs`
+- **Fix**: Fall back to Pending when previous state summary missing during checkpoint sync
+
+### Bug 2: Missing Envelope for Parent Block — WORKAROUND ONLY
+- **File**: `beacon_node/beacon_chain/src/block_verification.rs`
+- **Symptom**: `DBInconsistent("Missing envelope for parent block")`
+- **Current workaround**: Falls back to Pending state, causes state root mismatches → validation fails → peers drop → stall
+- **This is the blocking issue**
+
+---
+
+## My Attempts
+
+### Attempt 1: Download envelope during checkpoint sync
+- Downloaded envelope from checkpoint server HTTP API (works, Prysm serves it)
+- Stored envelope in DB for invariant 5 compliance
+- **Problem**: fork choice set `payload_received=true` for anchor (genesis logic), returned `Full` status
+- `get_advanced_hot_state` couldn't find Full state (only Pending stored)
+- **Fix**: Changed `is_genesis` in proto_array to check `slot == 0` not just `parent.is_none()`
+
+### Attempt 2: Snapshot with envelope=None, fallback in load_parent  
+- Snapshot without envelope → fork choice returns Pending → head loads correctly
+- Envelope stored in DB only
+- `load_parent` falls back from Full→Pending when Full state not found
+- **Problem**: Pending state has wrong `latest_block_hash` — hasn't been updated by envelope
+- Child block's `ExecutionPayloadBid.parent_block_hash` doesn't match `state.latest_block_hash`
+- Error: `ExecutionPayloadBidInvalid: ParentBlockHashMismatch`
+
+### Attempt 3: Mutate `latest_block_hash` on Pending state + recompute root
+- Applied minimal mutation: set `state.latest_block_hash = envelope.payload.block_hash`
+- Recomputed state root after mutation and updated split point
+- Stored envelope in DB for invariant 5 compliance
+- Snapshot uses `execution_envelope: None` so fork choice computes correct block root
+- Proto_array fix: `is_genesis = parent_index.is_none() && block.slot == 0` (not just no parent)
+- `load_parent` falls back from Full→Pending when Full state not found (for first child block)
+- **Result**: Zero block rejections, head advances from checkpoint slot to slot+~65
+- **Remaining issue**: Prysm peers rate-limit `data_columns_by_range` requests → peers disconnect → sync stalls
+- This is a networking issue, not a checkpoint sync bug
+
+### Bug 3: Peers disconnect with "Fault" — wrong finalized_root (CRITICAL)
+- Prysm peers send `Goodbye: Fault` immediately after status exchange
+- Our `finalized_root` doesn't match theirs for the same finalized epoch
+- Root cause: mutating `latest_block_hash` on the checkpoint state changes the state root
+- The changed state root cascades: `get_forkchoice_store` computes block header root using
+  the mutated state root → different block root → different finalized_root in status messages
+- Blocks DO import correctly (head advances ~100 slots) but peers disconnect during status
+- **The state mutation approach is fundamentally broken** — can't change state without
+  changing roots, which makes status messages incompatible
+
+### Key insight: Can't mutate the Pending state
+The downloaded Pending state has a specific root that matches what the network expects.
+Mutating it changes the root, making our node incompatible. Need a different approach.
+
+### Attempt 4: Patch in-memory state only, don't mutate stored state (CURRENT)
+- Reverted all stored-state mutations (keeps correct roots for status messages)
+- In `load_parent`, when falling back from Full→Pending, load the envelope from DB and
+  apply `latest_block_hash = envelope.payload.block_hash` on the IN-MEMORY state only
+- The on-disk state retains its original root → correct fork choice and status messages
+- **Result**: Zero block rejections, head advances ~100+ slots from checkpoint
+- **finalized_root matches devnet** — our status messages have correct finalized data
+
+### Bug 4: Range sync doesn't download envelopes (CRITICAL for Gloas)
+- `block_components_by_range_request` sends: BlocksByRange + DataColumnsByRange
+- No `PayloadEnvelopesByRange` requests are made
+- Blocks import successfully as Pending (beacon block processing succeeds without envelope)
+- The chain operates in Pending-only mode — no Full states, no execution payload validation
+- Eventually, child blocks whose parents were Full will fail bid validation:
+  `ExecutionPayloadBidInvalid: ParentBlockHashMismatch`
+- Our `load_parent` in-memory patch covers the checkpoint block's children, but NOT
+  subsequent full blocks whose envelopes were never downloaded
+- **Fix needed**: Add `PayloadEnvelopesByRange` to `block_components_by_range_request`,
+  similar to how `DataColumnsByRange` was integrated. This is a significant change to the
+  range sync pipeline and coupling logic.
+
+### Bug 5: Prysm peers send Goodbye:Fault (NETWORKING)
+- Prysm sends `Goodbye: Fault` immediately after status exchange
+- Happens BEFORE any data requests — not caused by rate limiting
+- Our finalized_root and epoch match the devnet's canonical chain
+- Likely a Prysm interop issue with StatusMessageV2 or some field mismatch
+- Lodestar peers at epoch 3/206 are far behind and correctly disconnected
+- Blocks import correctly when peers are connected (zero rejections)
+- **This is a separate P2P interop issue, not related to checkpoint sync**
+
+### Changes Made (files modified)
+1. `beacon_node/client/src/builder.rs` — Download envelope during Gloas checkpoint sync
+2. `beacon_node/beacon_chain/src/builder.rs` — Accept envelope param, store in DB, no state mutation
+3. `beacon_node/beacon_chain/src/block_verification.rs` — Fallback Full→Pending + in-memory block_hash patch
+4. `beacon_node/beacon_chain/tests/store_tests.rs` — Updated call sites for new signature
+5. `beacon_node/store/src/hot_cold_store.rs` — Bug 1 fix (handle missing previous_state_root)
+6. `consensus/proto_array/src/proto_array.rs` — Fix `is_genesis` for checkpoint sync anchors
+7. `.cargo/config.toml` — Build target dir
+
+### Changes Made (files modified)
+1. `beacon_node/client/src/builder.rs` — Download envelope during Gloas checkpoint sync
+2. `beacon_node/beacon_chain/src/builder.rs` — Accept envelope, mutate `latest_block_hash`, store envelope in DB, recompute state root
+3. `beacon_node/beacon_chain/src/block_verification.rs` — Fallback from Full→Pending in load_parent
+4. `beacon_node/beacon_chain/tests/store_tests.rs` — Updated call sites for new signature
+5. `beacon_node/store/src/hot_cold_store.rs` — Bug 1 fix (handle missing previous_state_root)
+6. `consensus/proto_array/src/proto_array.rs` — Fix `is_genesis` for checkpoint sync anchors
+7. `.cargo/config.toml` — Build target dir

--- a/DEVNET_SYNC_STATUS.md
+++ b/DEVNET_SYNC_STATUS.md
@@ -1,0 +1,158 @@
+# Lighthouse ePBS Devnet-1 Checkpoint Sync — Status & Handoff
+
+## Goal
+Get Lighthouse to checkpoint sync against epbs-devnet-1 and follow head.
+
+## Branch
+- **Location**: `/root/.openclaw/workspace/lighthouse-devnet-test`
+- **Branch**: `devnet-test-combined` (local only, not pushed)
+- **Base**: `sigp/unstable` @ `99f5a92b9`
+- **Merged in**: sigp/lighthouse PR #9025 (Gloas fork choice redux, commit `68f18efbe`)
+- **Merged in**: dapplion/lighthouse PR #68 (gloas-lookup-sync-fixes, branch `gloas-lookup-sync-fixes` @ `8f4a5f0a4`)
+- **Local fixes**: 2 patches applied on top (see below)
+- **Cargo target-dir**: `/mnt/ssd/builds/lighthouse-devnet-test`
+
+## Devnet Config
+- **Network**: epbs-devnet-1
+- **Config files**: `/tmp/epbs-devnet-1/` (config.yaml, genesis.ssz, jwt.hex, boot_enrs.txt, el_bootnodes.txt, genesis.json)
+- **Checkpoint sync URL**: `https://beacon.epbs-devnet-1.ethpandaops.io/`
+- **Beacon API**: `https://beacon.epbs-devnet-1.ethpandaops.io/`
+- **Ports used**: CL 9200/udp+tcp, HTTP 5053, EL authrpc 18551
+- **Data dirs**: CL `/mnt/ssd/lighthouse-devnet-1`, EL `/mnt/ssd/geth-devnet-1`
+
+## EL Setup
+- **Image**: `ethpandaops/geth:epbs-devnet-0` (Docker)
+- **Container name**: `geth-devnet-1`
+- **Network ID**: 7070339337
+- **Start command**:
+```bash
+EL_BOOTNODES=$(cat /tmp/epbs-devnet-1/el_bootnodes.txt | tr '\n' ',' | sed 's/,$//')
+docker run -d --name geth-devnet-1 --network host \
+  -v /mnt/ssd/geth-devnet-1:/data -v /tmp/epbs-devnet-1/jwt.hex:/jwt.hex \
+  ethpandaops/geth:epbs-devnet-0 \
+  --datadir /data --networkid 7070339337 --bootnodes "$EL_BOOTNODES" \
+  --port 30304 --discovery.port 30304 \
+  --http --http.port 8546 --http.api eth,net,web3,txpool \
+  --authrpc.port 18551 --authrpc.jwtsecret /jwt.hex \
+  --syncmode full --verbosity 3
+```
+- **Init**: Must run `docker run --rm ... geth init --datadir /data /genesis.json` first with the EL genesis
+
+## CL Start Command
+Script at `/tmp/start-lh-devnet.sh`:
+```bash
+BOOT_ENRS=$(cat /tmp/epbs-devnet-1/boot_enrs.txt | paste -sd,)
+exec /mnt/ssd/builds/lighthouse-devnet-test/release/lighthouse bn \
+  --testnet-dir /tmp/epbs-devnet-1 \
+  --datadir /mnt/ssd/lighthouse-devnet-1 \
+  --checkpoint-sync-url https://beacon.epbs-devnet-1.ethpandaops.io \
+  --boot-nodes "$BOOT_ENRS" \
+  --target-peers 50 --port 9200 --discovery-port 9200 \
+  --http --http-port 5053 \
+  --execution-endpoint http://localhost:18551 \
+  --execution-jwt /tmp/epbs-devnet-1/jwt.hex \
+  --subscribe-all-subnets --import-all-attestations
+```
+
+## Bugs Found & Fixed
+
+### Bug 1: MissingHotStateSummary (FIXED)
+- **File**: `beacon_node/store/src/hot_cold_store.rs` ~line 1897
+- **Symptom**: `CRIT Failed to start beacon node: MissingHotStateSummary(0xe8ee...)`
+- **Root cause**: During checkpoint sync, only ONE state is stored (the checkpoint state). `HotStateSummary::new` computes a `previous_state_root` pointing to slot-1's state root, but that state was never stored. When `get_hot_state_summary_payload_status()` tries to load it, it fails.
+- **Fix applied**: In `get_hot_state_summary_payload_status()`, when `load_hot_state_summary(&previous_state_root)` returns `None`, instead of erroring, fall back to determining payload status from the current summary alone:
+  - If `summary.slot == summary.latest_block_slot` → Pending (block state)
+  - Otherwise → Pending (safe default for checkpoint boundary states)
+- **This is a correct fix** — checkpoint states at epoch boundaries are always Pending.
+
+### Bug 2: Missing Envelope for Parent Block (PARTIALLY FIXED — NEEDS PROPER FIX)
+- **File**: `beacon_node/beacon_chain/src/block_verification.rs` ~line 1976
+- **Symptom**: `BlockProcessingFailure: DBInconsistent("Missing envelope for parent block 0xfd97...")`
+- **Root cause**: During checkpoint sync, only the block and state are downloaded — NOT the execution payload envelope. When child blocks arrive and reference the checkpoint block as parent with `is_parent_block_full()=true`, the code needs the parent's envelope to get the Full state root. The envelope isn't in the DB.
+- **Current workaround**: Falls back to `(Pending, parent_block.state_root())` when envelope is missing. This allows processing to proceed but **causes state root mismatches** → block validation fails → peers disconnect.
+- **Result**: Node starts, briefly connects to peers, fails to validate blocks, loses all peers, stalls.
+
+## What Needs to Happen (Priority Order)
+
+### 1. Fix the envelope problem (BLOCKING)
+The core issue: checkpoint sync doesn't download/store the execution payload envelope for the checkpoint block. Three approaches:
+
+**Option A — Download envelope during checkpoint sync (RECOMMENDED)**
+- Extend `weak_subjectivity_state()` in `beacon_node/beacon_chain/src/builder.rs` (~line 425) to also download and store the checkpoint block's envelope
+- The checkpoint sync server at `https://beacon.epbs-devnet-1.ethpandaops.io/` serves blocks via `/eth/v2/beacon/blocks/{slot}` which contains `signed_execution_payload_bid`
+- BUT the envelope itself may need a separate endpoint. Check if `/eth/v1/beacon/execution_payload_envelopes/{block_root}` exists (it 404'd when I tried)
+- If the envelope isn't available via HTTP, you'd need to either:
+  - Add envelope support to the checkpoint sync protocol
+  - Or compute it: fetch the execution payload from geth for that block hash and construct the envelope
+
+**Option B — Trigger P2P envelope lookup when missing**
+- When `get_payload_envelope(&root)` returns `None`, instead of erroring or falling back, queue an envelope lookup via P2P (similar to how block lookups work)
+- PR #68's lookup sync code may already have infrastructure for this — check `single_block_lookup.rs` and `network_context.rs` for envelope request methods
+- `request_single_envelope()` exists at `network_context.rs` — this may be usable
+
+**Option C — Compute Full state from Pending state + payload**
+- Load the Pending state, execute the payload against it to produce the Full state
+- This requires having the execution payload data and running a state transition
+- Complex and not ideal for the sync hot path
+
+### 2. Peer connectivity issues
+- Node connects to 2-7 peers initially but drops to 0 quickly
+- This happens even before block processing (the checkpoint sync instance lost peers before any blocks were processed)
+- Might be related to: fork digest mismatch, status message incompatibility, or rate limiting
+- The genesis sync test (with vibehouse) maintained peers better — investigate why checkpoint sync loses them
+- Could also be a gossip subnet issue — the devnet only has ~10 nodes total
+
+### 3. EL sync coordination
+- Geth starts and imports ~157 blocks but then stalls waiting for forkchoice updates from the CL
+- Once the CL can process blocks, it will send forkchoice updates and geth will follow
+- This is expected and not a bug — it's just downstream of fixing the envelope issue
+
+## Key Code Locations
+
+| What | File | Line |
+|------|------|------|
+| Checkpoint sync init | `beacon_node/beacon_chain/src/builder.rs` | ~425 (`weak_subjectivity_state`) |
+| State storage | `beacon_node/store/src/hot_cold_store.rs` | ~1077 (`put_state`) |
+| Hot state summary | `beacon_node/store/src/hot_cold_store.rs` | ~4220 (`HotStateSummary::new`) |
+| Payload status check | `beacon_node/store/src/hot_cold_store.rs` | ~1864 (`get_hot_state_summary_payload_status`) |
+| Parent state loading | `beacon_node/beacon_chain/src/block_verification.rs` | ~1960 (`load_parent`) |
+| Envelope storage | `beacon_node/store/src/hot_cold_store.rs` | ~1064 (`put_payload_envelope`) |
+| Envelope retrieval | `beacon_node/store/src/hot_cold_store.rs` | ~741 (`get_payload_envelope`) |
+| Envelope P2P request | `beacon_node/network/src/sync/network_context.rs` | search for `request_single_envelope` |
+
+## Files Modified (uncommitted)
+
+1. **`beacon_node/store/src/hot_cold_store.rs`** — Bug 1 fix: handle missing previous_state_root summary in `get_hot_state_summary_payload_status`
+2. **`beacon_node/beacon_chain/src/block_verification.rs`** — Bug 2 workaround: fallback to Pending when envelope missing + added `warn` to tracing imports
+
+## What's NOT the Problem
+- Build: compiles fine in release (~2-4 min incremental)
+- EL: geth syncs and connects, authrpc works
+- P2P boot ENRs: correct, 11 entries, work for genesis sync
+- Checkpoint sync download: block and state download fine
+- Config: correct network config, fork schedule, genesis state
+
+## Useful Commands
+```bash
+# Check sync status
+curl -s http://127.0.0.1:5053/eth/v1/node/syncing | jq .
+
+# Check devnet head
+curl -s "https://beacon.epbs-devnet-1.ethpandaops.io/eth/v1/beacon/headers/head" | jq '.data.header.message.slot'
+
+# Check geth
+docker logs geth-devnet-1 2>&1 | tail -20
+
+# Check CL logs
+tail -50 /tmp/lh-devnet.log
+
+# Rebuild after changes
+export PATH="$HOME/.cargo/bin:$PATH"
+cd /root/.openclaw/workspace/lighthouse-devnet-test
+cargo build --release --bin lighthouse
+
+# Restart clean
+pkill -f "lighthouse-devnet-test" 2>/dev/null; sleep 2
+rm -rf /mnt/ssd/lighthouse-devnet-1
+nohup /tmp/start-lh-devnet.sh > /tmp/lh-devnet.log 2>&1 &
+```

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2894,6 +2894,24 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }
         }
 
+        // Pre-store payload envelopes in the DB before block processing.
+        // Blocks from post-Gloas epochs may carry an envelope that must be
+        // available in the store when the block is imported.
+        for block in &chain_segment {
+            if let Some(envelope) = block.envelope() {
+                let block_root = block.block_root();
+                if let Err(e) = self
+                    .store
+                    .put_payload_envelope(&block_root, envelope.as_ref().clone())
+                {
+                    return ChainSegmentResult::Failed {
+                        imported_blocks: vec![],
+                        error: BlockError::BeaconChainError(Box::new(Error::DBError(e))),
+                    };
+                }
+            }
+        }
+
         let mut imported_blocks = vec![];
 
         // Filter uninteresting blocks from the chain segment in a blocking task.

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -95,7 +95,7 @@ use std::sync::Arc;
 use store::{Error as DBError, KeyValueStore};
 use strum::AsRefStr;
 use task_executor::JoinHandle;
-use tracing::{Instrument, Span, debug, debug_span, error, info_span, instrument};
+use tracing::{Instrument, Span, debug, debug_span, error, info_span, instrument, warn};
 use types::{
     BeaconBlockRef, BeaconState, BeaconStateError, BlobsList, ChainSpec, DataColumnSidecarList,
     Epoch, EthSpec, FullPayload, Hash256, InconsistentFork, KzgProofs, RelativeEpoch,
@@ -1973,26 +1973,74 @@ fn load_parent<T: BeaconChainTypes, B: AsBlock<T::EthSpec>>(
         {
             // Post-Gloas Full block case.
             // TODO(gloas): loading the envelope here is not very efficient
-            let Some(envelope) = chain.store.get_payload_envelope(&root)? else {
-                return Err(BeaconChainError::DBInconsistent(format!(
-                    "Missing envelope for parent block {root:?}",
-                ))
-                .into());
-            };
-            let state_root = envelope.message.state_root;
-            (StatePayloadStatus::Full, state_root)
+            match chain.store.get_payload_envelope(&root)? {
+                Some(envelope) => {
+                    let state_root = envelope.message.state_root;
+                    (StatePayloadStatus::Full, state_root)
+                }
+                None => {
+                    // Envelope not found - this can happen during checkpoint sync.
+                    // The checkpoint block envelope wasn't downloaded.
+                    // Fall back to using the Pending state - this may cause state root
+                    // mismatches but allows sync to attempt to proceed.
+                    warn!(
+                        %root,
+                        block_slot = %parent_block.slot(),
+                        "Missing envelope for parent block, using Pending state as fallback"
+                    );
+                    (StatePayloadStatus::Pending, parent_block.state_root())
+                }
+            }
         } else {
             // Post-Gloas empty block case (also covers the Gloas fork transition).
             (StatePayloadStatus::Pending, parent_block.state_root())
         };
-        let (parent_state_root, state) = chain
+        let (parent_state_root, mut state) = chain
             .store
             .get_advanced_hot_state(root, payload_status, block.slot(), parent_state_root)?
+            .or_else(|| {
+                // During checkpoint sync, the Full state may not exist — only the Pending
+                // (epoch boundary) state is available. Fall back to loading as Pending.
+                if payload_status == StatePayloadStatus::Full {
+                    warn!(
+                        %root,
+                        "Full state not found for parent block, falling back to Pending"
+                    );
+                    chain
+                        .store
+                        .get_advanced_hot_state(
+                            root,
+                            StatePayloadStatus::Pending,
+                            block.slot(),
+                            parent_block.state_root(),
+                        )
+                        .ok()
+                        .flatten()
+                } else {
+                    None
+                }
+            })
             .ok_or_else(|| {
                 BeaconChainError::DBInconsistent(
                     format!("Missing state for parent block {root:?}",),
                 )
             })?;
+
+        // If we needed the Full state but fell back to Pending (checkpoint sync case),
+        // apply the envelope's block_hash to the in-memory state so child block bid
+        // validation passes (ParentBlockHashMismatch). This only mutates the in-memory
+        // state, not the stored one — the on-disk state keeps its correct root.
+        if payload_status == StatePayloadStatus::Full
+            && let Ok(Some(envelope)) = chain.store.get_payload_envelope(&root)
+            && let Ok(hash_mut) = state.latest_block_hash_mut()
+        {
+            debug!(
+                %root,
+                block_hash = %envelope.message.payload.block_hash,
+                "Patching in-memory state latest_block_hash from envelope"
+            );
+            *hash_mut = envelope.message.payload.block_hash;
+        }
 
         if !state.all_caches_built() {
             debug!(

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -82,8 +82,11 @@ use ssz_derive::{Decode, Encode};
 use state_processing::per_block_processing::errors::IntoWithIndex;
 use state_processing::{
     AllCaches, BlockProcessingError, BlockSignatureStrategy, ConsensusContext, SlotProcessingError,
-    VerifyBlockRoot,
+    VerifyBlockRoot, VerifySignatures,
     block_signature_verifier::{BlockSignatureVerifier, Error as BlockSignatureVerifierError},
+    envelope_processing::{
+        VerifyStateRoot as VerifyEnvelopeStateRoot, process_execution_payload_envelope,
+    },
     per_block_processing, per_slot_processing,
     state_advance::partial_state_advance,
 };
@@ -2026,20 +2029,32 @@ fn load_parent<T: BeaconChainTypes, B: AsBlock<T::EthSpec>>(
                 )
             })?;
 
-        // If we needed the Full state but fell back to Pending (checkpoint sync case),
-        // apply the envelope's block_hash to the in-memory state so child block bid
-        // validation passes (ParentBlockHashMismatch). This only mutates the in-memory
-        // state, not the stored one — the on-disk state keeps its correct root.
+        // If we needed the Full state but fell back to Pending (checkpoint sync / range sync),
+        // apply the full envelope processing to transform Pending → Full in-memory.
+        // This is necessary because the Full state differs from Pending in many fields
+        // (deposits, withdrawals, builder payments, execution availability, block hash).
         if payload_status == StatePayloadStatus::Full
             && let Ok(Some(envelope)) = chain.store.get_payload_envelope(&root)
-            && let Ok(hash_mut) = state.latest_block_hash_mut()
         {
             debug!(
                 %root,
                 block_hash = %envelope.message.payload.block_hash,
-                "Patching in-memory state latest_block_hash from envelope"
+                "Applying envelope to Pending state to derive Full state"
             );
-            *hash_mut = envelope.message.payload.block_hash;
+            if let Err(e) = process_execution_payload_envelope(
+                &mut state,
+                Some(parent_state_root),
+                &envelope,
+                VerifySignatures::False,
+                VerifyEnvelopeStateRoot::False,
+                &chain.spec,
+            ) {
+                warn!(
+                    %root,
+                    error = ?e,
+                    "Failed to apply envelope to derive Full state, proceeding with Pending"
+                );
+            }
         }
 
         if !state.all_caches_built() {

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1998,64 +1998,76 @@ fn load_parent<T: BeaconChainTypes, B: AsBlock<T::EthSpec>>(
             // Post-Gloas empty block case (also covers the Gloas fork transition).
             (StatePayloadStatus::Pending, parent_block.state_root())
         };
-        let (parent_state_root, mut state) = chain
-            .store
-            .get_advanced_hot_state(root, payload_status, block.slot(), parent_state_root)?
-            .or_else(|| {
-                // During checkpoint sync, the Full state may not exist — only the Pending
-                // (epoch boundary) state is available. Fall back to loading as Pending.
-                if payload_status == StatePayloadStatus::Full {
-                    warn!(
-                        %root,
-                        "Full state not found for parent block, falling back to Pending"
-                    );
-                    chain
+        let (parent_state_root, state) = if payload_status == StatePayloadStatus::Full {
+            // For Full state: try cache/DB first, then derive from Pending + envelope.
+            chain
+                .store
+                .get_advanced_hot_state(root, payload_status, block.slot(), parent_state_root)?
+                .or_else(|| {
+                    warn!(%root, "Full state not found, deriving from Pending + envelope");
+                    let envelope = chain.store.get_payload_envelope(&root).ok().flatten()?;
+                    // Load Pending state at parent's slot (not advanced)
+                    let (_, mut pending_state) = chain
                         .store
                         .get_advanced_hot_state(
                             root,
                             StatePayloadStatus::Pending,
-                            block.slot(),
+                            parent_block.slot(),
                             parent_block.state_root(),
                         )
                         .ok()
-                        .flatten()
-                } else {
-                    None
-                }
-            })
-            .ok_or_else(|| {
-                BeaconChainError::DBInconsistent(
-                    format!("Missing state for parent block {root:?}",),
-                )
-            })?;
-
-        // If we needed the Full state but fell back to Pending (checkpoint sync / range sync),
-        // apply the full envelope processing to transform Pending → Full in-memory.
-        // This is necessary because the Full state differs from Pending in many fields
-        // (deposits, withdrawals, builder payments, execution availability, block hash).
-        if payload_status == StatePayloadStatus::Full
-            && let Ok(Some(envelope)) = chain.store.get_payload_envelope(&root)
-        {
-            debug!(
-                %root,
-                block_hash = %envelope.message.payload.block_hash,
-                "Applying envelope to Pending state to derive Full state"
-            );
-            if let Err(e) = process_execution_payload_envelope(
-                &mut state,
-                Some(parent_state_root),
-                &envelope,
-                VerifySignatures::False,
-                VerifyEnvelopeStateRoot::False,
-                &chain.spec,
-            ) {
-                warn!(
-                    %root,
-                    error = ?e,
-                    "Failed to apply envelope to derive Full state, proceeding with Pending"
-                );
-            }
+                        .flatten()?;
+                    // Skip if already Full (checkpoint state downloaded as finalized/Full)
+                    let already_full = pending_state
+                        .latest_block_hash()
+                        .ok()
+                        .map(|h| *h == envelope.message.payload.block_hash)
+                        .unwrap_or(false);
+                    if !already_full {
+                        let pending_root = pending_state.canonical_root().ok()?;
+                        if let Err(e) = process_execution_payload_envelope(
+                            &mut pending_state,
+                            Some(pending_root),
+                            &envelope,
+                            VerifySignatures::False,
+                            VerifyEnvelopeStateRoot::True,
+                            &chain.spec,
+                        ) {
+                            warn!(%root, ?e, "Envelope state root verification FAILED");
+                            return None;
+                        }
+                    }
+                    // Use the envelope's state_root as the Full state root
+                    // (avoids canonical_root() tree hash cache issues).
+                    let full_state_root = if already_full {
+                        pending_state.canonical_root().ok()?
+                    } else {
+                        envelope.message.state_root
+                    };
+                    // Advance to child block's slot
+                    if pending_state.slot() < block.slot() {
+                        partial_state_advance(
+                            &mut pending_state,
+                            Some(full_state_root),
+                            block.slot(),
+                            &chain.spec,
+                        )
+                        .ok()?;
+                    }
+                    let advanced_root = pending_state.canonical_root().ok()?;
+                    Some((advanced_root, pending_state))
+                })
+        } else {
+            chain.store.get_advanced_hot_state(
+                root,
+                payload_status,
+                block.slot(),
+                parent_state_root,
+            )?
         }
+        .ok_or_else(|| {
+            BeaconChainError::DBInconsistent(format!("Missing state for parent block {root:?}",))
+        })?;
 
         if !state.all_caches_built() {
             debug!(

--- a/beacon_node/beacon_chain/src/block_verification_types.rs
+++ b/beacon_node/beacon_chain/src/block_verification_types.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use types::data::BlobIdentifier;
 use types::{
     BeaconBlockRef, BeaconState, BlindedPayload, ChainSpec, Epoch, EthSpec, Hash256,
-    SignedBeaconBlock, SignedBeaconBlockHeader, Slot,
+    SignedBeaconBlock, SignedBeaconBlockHeader, SignedExecutionPayloadEnvelope, Slot,
 };
 
 /// A wrapper around a `SignedBeaconBlock`. This varaint is constructed
@@ -49,6 +49,9 @@ impl<E: EthSpec> LookupBlock<E> {
 #[educe(Hash(bound(E: EthSpec)))]
 pub struct RangeSyncBlock<E: EthSpec> {
     block: AvailableBlock<E>,
+    /// Optional payload envelope for post-Gloas blocks, to be stored in DB before processing.
+    #[educe(Hash(ignore))]
+    envelope: Option<Arc<SignedExecutionPayloadEnvelope<E>>>,
 }
 
 impl<E: EthSpec> Debug for RangeSyncBlock<E> {
@@ -96,12 +99,34 @@ impl<E: EthSpec> RangeSyncBlock<E> {
         let available_block = AvailableBlock::new(block, block_data, da_checker, spec)?;
         Ok(Self {
             block: available_block,
+            envelope: None,
         })
     }
 
+    pub fn with_envelope(
+        mut self,
+        envelope: Option<Arc<SignedExecutionPayloadEnvelope<E>>>,
+    ) -> Self {
+        self.envelope = envelope;
+        self
+    }
+
+    pub fn envelope(&self) -> Option<&Arc<SignedExecutionPayloadEnvelope<E>>> {
+        self.envelope.as_ref()
+    }
+
     #[allow(clippy::type_complexity)]
-    pub fn deconstruct(self) -> (Hash256, Arc<SignedBeaconBlock<E>>, AvailableBlockData<E>) {
-        self.block.deconstruct()
+    pub fn deconstruct(
+        self,
+    ) -> (
+        Hash256,
+        Arc<SignedBeaconBlock<E>>,
+        AvailableBlockData<E>,
+        Option<Arc<SignedExecutionPayloadEnvelope<E>>>,
+    ) {
+        let envelope = self.envelope;
+        let (root, block, data) = self.block.deconstruct();
+        (root, block, data, envelope)
     }
 
     pub fn n_blobs(&self) -> usize {

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -45,7 +45,7 @@ use tree_hash::TreeHash;
 use types::data::CustodyIndex;
 use types::{
     BeaconBlock, BeaconState, BlobSidecarList, ChainSpec, ColumnIndex, DataColumnSidecarList,
-    Epoch, EthSpec, Hash256, SignedBeaconBlock, Slot,
+    Epoch, EthSpec, Hash256, SignedBeaconBlock, SignedExecutionPayloadEnvelope, Slot,
 };
 
 /// An empty struct used to "witness" all the `BeaconChainTypes` traits. It has no user-facing
@@ -426,6 +426,7 @@ where
         mut weak_subj_state: BeaconState<E>,
         weak_subj_block: SignedBeaconBlock<E>,
         weak_subj_blobs: Option<BlobSidecarList<E>>,
+        weak_subj_envelope: Option<SignedExecutionPayloadEnvelope<E>>,
         genesis_state: BeaconState<E>,
     ) -> Result<Self, String> {
         let store = self
@@ -617,7 +618,25 @@ where
                 .map_err(|e| format!("Failed to initialize data column info: {:?}", e))?,
         );
 
-        // TODO(gloas): add check that checkpoint state is Pending
+        // Store execution payload envelope if provided (Gloas checkpoint sync).
+        // Also apply the envelope's key state mutation: update `latest_block_hash`
+        // so that child blocks can pass bid validation (ParentBlockHashMismatch).
+        if let Some(ref envelope) = weak_subj_envelope {
+            debug!(
+                block_root = ?weak_subj_block_root,
+                envelope_slot = %envelope.message.slot,
+                "Storing checkpoint sync execution payload envelope"
+            );
+            store
+                .put_payload_envelope(&weak_subj_block_root, envelope.clone())
+                .map_err(|e| {
+                    format!("Failed to store weak subjectivity payload envelope: {e:?}")
+                })?;
+        }
+
+        // The snapshot uses execution_envelope=None so that fork choice computes the
+        // correct block root (using block.state_root(), not envelope.state_root).
+        // The state has been mutated with the envelope's block_hash for child validation.
         let snapshot = BeaconSnapshot {
             beacon_block_root: weak_subj_block_root,
             execution_envelope: None,
@@ -781,10 +800,20 @@ where
             .map_err(|e| format!("Unable to get fork choice head: {:?}", e))?;
 
         let head_block_root = initial_head_block_root;
+        debug!(
+            ?head_block_root,
+            ?head_payload_status,
+            "Loading head block from store"
+        );
         let head_block = store
             .get_full_block(&initial_head_block_root)
             .map_err(|e| descriptive_db_error("head block", &e))?
-            .ok_or("Head block not found in store")?;
+            .ok_or_else(|| {
+                format!(
+                    "Head block not found in store: root={:?}, payload_status={:?}",
+                    initial_head_block_root, head_payload_status
+                )
+            })?;
 
         let state_payload_status = head_payload_status.as_state_payload_status();
 

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -874,12 +874,13 @@ where
                     It is highly recommended to purge your db and checkpoint sync. For more information please \
                     read this blog post: https://blog.ethereum.org/2014/11/25/proof-stake-learned-love-weak-subjectivity"
                 )
-            }
-            return Err(
+            } else {
+                return Err(
                 "The current head state is outside the weak subjectivity period. A node in this state is susceptible to long range attacks. You should purge your db and \
                 checkpoint sync. For more information please read this blog post: https://blog.ethereum.org/2014/11/25/proof-stake-learned-love-weak-subjectivity \
                 If you understand the risks, it is possible to ignore this error with the --ignore-ws-check flag.".to_string()
             );
+            }
         }
 
         let validator_pubkey_cache = self

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -2975,6 +2975,7 @@ async fn reproduction_unaligned_checkpoint_sync_pruned_payload() {
             wss_state,
             wss_block.clone(),
             wss_blobs_opt.clone(),
+            None,
             genesis_state,
         )
         .unwrap()
@@ -3129,6 +3130,7 @@ async fn weak_subjectivity_sync_test(
             } else {
                 None
             },
+            None,
             genesis_state,
         )
         .unwrap()

--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -416,6 +416,9 @@ pub enum Work<E: EthSpec> {
     RpcBlobs {
         process_fn: AsyncFn,
     },
+    RpcPayloadEnvelope {
+        process_fn: AsyncFn,
+    },
     RpcCustodyColumn(AsyncFn),
     ColumnReconstruction(AsyncFn),
     IgnoredRpcBlock {
@@ -481,6 +484,7 @@ pub enum WorkType {
     GossipLightClientOptimisticUpdate,
     RpcBlock,
     RpcBlobs,
+    RpcPayloadEnvelope,
     RpcCustodyColumn,
     ColumnReconstruction,
     IgnoredRpcBlock,
@@ -542,6 +546,7 @@ impl<E: EthSpec> Work<E> {
             Work::GossipProposerPreferences(_) => WorkType::GossipProposerPreferences,
             Work::RpcBlock { .. } => WorkType::RpcBlock,
             Work::RpcBlobs { .. } => WorkType::RpcBlobs,
+            Work::RpcPayloadEnvelope { .. } => WorkType::RpcPayloadEnvelope,
             Work::RpcCustodyColumn { .. } => WorkType::RpcCustodyColumn,
             Work::ColumnReconstruction(_) => WorkType::ColumnReconstruction,
             Work::IgnoredRpcBlock { .. } => WorkType::IgnoredRpcBlock,
@@ -1173,7 +1178,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
                             Work::GossipLightClientOptimisticUpdate { .. } => work_queues
                                 .lc_gossip_optimistic_update_queue
                                 .push(work, work_id),
-                            Work::RpcBlock { .. } | Work::IgnoredRpcBlock { .. } => {
+                            Work::RpcBlock { .. }
+                            | Work::IgnoredRpcBlock { .. }
+                            | Work::RpcPayloadEnvelope { .. } => {
                                 work_queues.rpc_block_queue.push(work, work_id)
                             }
                             Work::RpcBlobs { .. } => work_queues.rpc_blob_queue.push(work, work_id),
@@ -1305,7 +1312,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
                         WorkType::GossipLightClientOptimisticUpdate => {
                             work_queues.lc_gossip_optimistic_update_queue.len()
                         }
-                        WorkType::RpcBlock => work_queues.rpc_block_queue.len(),
+                        WorkType::RpcBlock | WorkType::RpcPayloadEnvelope => {
+                            work_queues.rpc_block_queue.len()
+                        }
                         WorkType::RpcBlobs | WorkType::IgnoredRpcBlock => {
                             work_queues.rpc_blob_queue.len()
                         }
@@ -1500,6 +1509,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
                 beacon_block_root: _,
             }
             | Work::RpcBlobs { process_fn }
+            | Work::RpcPayloadEnvelope { process_fn }
             | Work::RpcCustodyColumn(process_fn)
             | Work::ColumnReconstruction(process_fn) => task_spawner.spawn_async(process_fn),
             Work::IgnoredRpcBlock { process_fn } => task_spawner.spawn_blocking(process_fn),

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -372,6 +372,7 @@ where
                     anchor_state,
                     anchor_block,
                     anchor_blobs,
+                    None,
                     genesis_state,
                 )?
             }
@@ -445,16 +446,54 @@ where
                     None
                 };
 
+                // Download execution payload envelope for Gloas blocks.
+                // The checkpoint server returns the Pending state (before envelope),
+                // so we can't check is_parent_block_full() — it will always be false.
+                // Instead, try to download the envelope unconditionally for Gloas blocks.
+                // If the server returns 404, the block was empty (no envelope delivered).
+                let is_gloas = spec
+                    .fork_name_at_slot::<E>(finalized_block_slot)
+                    .gloas_enabled();
+                let envelope = if is_gloas {
+                    debug!("Downloading finalized execution payload envelope");
+                    match remote
+                        .get_beacon_execution_payload_envelope_ssz::<E>(BlockId::Root(block_root))
+                        .await
+                    {
+                        Ok(Some(env)) => {
+                            info!("Downloaded finalized execution payload envelope");
+                            Some(env)
+                        }
+                        Ok(None) => {
+                            info!(
+                                "No execution payload envelope for checkpoint block (empty block)"
+                            );
+                            None
+                        }
+                        Err(e) => {
+                            warn!(
+                                block_root = %block_root,
+                                error = %e,
+                                "Error fetching execution payload envelope, continuing without it"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
                 let genesis_state = genesis_state(&runtime_context, &config).await?;
 
                 info!(
                     block_slot = %block.slot(),
                     state_slot = %state.slot(),
                     block_root = ?block_root,
+                    has_envelope = envelope.is_some(),
                     "Loaded checkpoint block and state"
                 );
 
-                builder.weak_subjectivity_state(state, block, blobs, genesis_state)?
+                builder.weak_subjectivity_state(state, block, blobs, envelope, genesis_state)?
             }
             ClientGenesis::DepositContract => {
                 return Err("Loading genesis from deposit contract no longer supported".to_string());

--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -31,6 +31,8 @@ pub enum SyncRequestId {
     BlobsByRange(BlobsByRangeRequestId),
     /// Data columns by range request
     DataColumnsByRange(DataColumnsByRangeRequestId),
+    /// Payload envelopes by range request
+    PayloadEnvelopesByRange(PayloadEnvelopesByRangeRequestId),
     /// Request searching for an execution payload envelope given a block root.
     SinglePayloadEnvelope { id: SingleLookupReqId },
 }
@@ -56,6 +58,12 @@ pub struct BlobsByRangeRequestId {
     /// Id to identify this attempt at a blobs_by_range request for `parent_request_id`
     pub id: Id,
     /// The Id of the overall By Range request for block components.
+    pub parent_request_id: ComponentsByRangeRequestId,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub struct PayloadEnvelopesByRangeRequestId {
+    pub id: Id,
     pub parent_request_id: ComponentsByRangeRequestId,
 }
 
@@ -253,6 +261,12 @@ macro_rules! impl_display {
 // not losing information
 impl_display!(BlocksByRangeRequestId, "{}/{}", id, parent_request_id);
 impl_display!(BlobsByRangeRequestId, "{}/{}", id, parent_request_id);
+impl_display!(
+    PayloadEnvelopesByRangeRequestId,
+    "{}/{}",
+    id,
+    parent_request_id
+);
 impl_display!(DataColumnsByRangeRequestId, "{}/{}", id, parent_request_id);
 impl_display!(ComponentsByRangeRequestId, "{}/{}", id, requester);
 impl_display!(DataColumnsByRootRequestId, "{}/{}", id, requester);

--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -31,6 +31,8 @@ pub enum SyncRequestId {
     BlobsByRange(BlobsByRangeRequestId),
     /// Data columns by range request
     DataColumnsByRange(DataColumnsByRangeRequestId),
+    /// Request searching for an execution payload envelope given a block root.
+    SinglePayloadEnvelope { id: SingleLookupReqId },
 }
 
 /// Request ID for data_columns_by_root requests. Block lookups do not issue this request directly.

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -541,6 +541,22 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         })
     }
 
+    /// Create a new `Work` event for an RPC payload envelope.
+    pub fn send_rpc_payload_envelope(
+        self: &Arc<Self>,
+        envelope: Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>,
+        seen_timestamp: Duration,
+        process_type: BlockProcessType,
+    ) -> Result<(), Error<T::EthSpec>> {
+        let process_fn =
+            self.clone()
+                .generate_rpc_envelope_process_fn(envelope, seen_timestamp, process_type);
+        self.try_send(BeaconWorkEvent {
+            drop_during_sync: false,
+            work: Work::RpcPayloadEnvelope { process_fn },
+        })
+    }
+
     /// Create a new `Work` event for some blobs, where the result from computation (if any) is
     /// sent to the other side of `result_tx`.
     pub fn send_rpc_blobs(

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -4,7 +4,7 @@ use crate::sync::BatchProcessResult;
 use crate::sync::manager::CustodyBatchProcessResult;
 use crate::sync::{
     ChainId,
-    manager::{BlockProcessType, SyncMessage},
+    manager::{BlockProcessType, BlockProcessingResult, SyncMessage},
 };
 use beacon_chain::block_verification_types::LookupBlock;
 use beacon_chain::block_verification_types::{AsBlock, RangeSyncBlock};
@@ -28,7 +28,9 @@ use store::KzgCommitment;
 use tracing::{debug, debug_span, error, info, instrument, warn};
 use types::data::FixedBlobSidecarList;
 use types::kzg_ext::format_kzg_commitments;
-use types::{BlockImportSource, DataColumnSidecarList, Epoch, Hash256};
+use types::{
+    BlockImportSource, DataColumnSidecarList, Epoch, Hash256, SignedExecutionPayloadEnvelope,
+};
 
 /// Id associated to a batch processing request, either a sync batch or a parent lookup.
 #[derive(Clone, Debug, PartialEq)]
@@ -71,6 +73,81 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             .await;
         };
         Box::pin(process_fn)
+    }
+
+    /// Returns an async closure which processes a payload envelope received via RPC.
+    pub fn generate_rpc_envelope_process_fn(
+        self: Arc<Self>,
+        envelope: Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>,
+        seen_timestamp: Duration,
+        process_type: BlockProcessType,
+    ) -> AsyncFn {
+        let process_fn = async move {
+            self.process_rpc_envelope(envelope, seen_timestamp, process_type)
+                .await;
+        };
+        Box::pin(process_fn)
+    }
+
+    /// Process an execution payload envelope received via RPC.
+    async fn process_rpc_envelope(
+        self: Arc<Self>,
+        envelope: Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>,
+        _seen_timestamp: Duration,
+        process_type: BlockProcessType,
+    ) {
+        let beacon_block_root = envelope.beacon_block_root();
+
+        // Verify the envelope using the gossip verification path (same checks apply to RPC)
+        let verified_envelope = match self.chain.verify_envelope_for_gossip(envelope).await {
+            Ok(verified) => verified,
+            Err(e) => {
+                debug!(
+                    error = ?e,
+                    ?beacon_block_root,
+                    "RPC payload envelope failed verification"
+                );
+                self.send_sync_message(SyncMessage::BlockComponentProcessed {
+                    process_type,
+                    result: BlockProcessingResult::Err(BlockError::InternalError(format!(
+                        "Envelope verification failed: {e:?}"
+                    ))),
+                });
+                return;
+            }
+        };
+
+        // Process the verified envelope
+        let result = self
+            .chain
+            .process_execution_payload_envelope(
+                beacon_block_root,
+                verified_envelope,
+                NotifyExecutionLayer::Yes,
+                BlockImportSource::Lookup,
+                #[allow(clippy::result_large_err)]
+                || Ok(()),
+            )
+            .await;
+
+        let processing_result = match result {
+            Ok(status) => BlockProcessingResult::Ok(status),
+            Err(e) => {
+                debug!(
+                    error = ?e,
+                    ?beacon_block_root,
+                    "RPC payload envelope processing failed"
+                );
+                BlockProcessingResult::Err(BlockError::InternalError(format!(
+                    "Envelope processing failed: {e:?}"
+                )))
+            }
+        };
+
+        self.send_sync_message(SyncMessage::BlockComponentProcessed {
+            process_type,
+            result: processing_result,
+        });
     }
 
     /// Returns the `process_fn` and `ignore_fn` required when requeuing an RPC block.

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -24,7 +24,10 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, trace, warn};
-use types::{BlobSidecar, DataColumnSidecar, EthSpec, ForkContext, SignedBeaconBlock};
+use types::{
+    BlobSidecar, DataColumnSidecar, EthSpec, ForkContext, SignedBeaconBlock,
+    SignedExecutionPayloadEnvelope,
+};
 
 /// Handles messages from the network and routes them to the appropriate service to be handled.
 pub struct Router<T: BeaconChainTypes> {
@@ -327,10 +330,13 @@ impl<T: BeaconChainTypes> Router<T> {
             Response::DataColumnsByRange(data_column) => {
                 self.on_data_columns_by_range_response(peer_id, app_request_id, data_column);
             }
-            // TODO(EIP-7732): implement outgoing payload envelopes by range and root
-            // responses once sync manager requests them.
-            Response::PayloadEnvelopesByRoot(_) | Response::PayloadEnvelopesByRange(_) => {
-                debug!("Requesting envelopes by root and by range not supported yet");
+            Response::PayloadEnvelopesByRoot(envelope) => {
+                self.on_payload_envelopes_by_root_response(peer_id, app_request_id, envelope);
+            }
+            // TODO(EIP-7732): implement outgoing payload envelopes by range responses once
+            // range sync requests them.
+            Response::PayloadEnvelopesByRange(_) => {
+                error!(%peer_id, "Unexpected PayloadEnvelopesByRange response");
             }
             // Light client responses should not be received
             Response::LightClientBootstrap(_)
@@ -699,6 +705,40 @@ impl<T: BeaconChainTypes> Router<T> {
             peer_id,
             sync_request_id,
             beacon_block,
+            seen_timestamp: timestamp_now(),
+        });
+    }
+
+    /// Handle a `PayloadEnvelopesByRoot` response from the peer.
+    pub fn on_payload_envelopes_by_root_response(
+        &mut self,
+        peer_id: PeerId,
+        app_request_id: AppRequestId,
+        envelope: Option<Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>>,
+    ) {
+        let sync_request_id = match app_request_id {
+            AppRequestId::Sync(sync_id) => match sync_id {
+                id @ SyncRequestId::SinglePayloadEnvelope { .. } => id,
+                other => {
+                    crit!(request = ?other, "PayloadEnvelopesByRoot response on incorrect request");
+                    return;
+                }
+            },
+            AppRequestId::Router => {
+                crit!(%peer_id, "All PayloadEnvelopesByRoot requests belong to sync");
+                return;
+            }
+            AppRequestId::Internal => unreachable!("Handled internally"),
+        };
+
+        trace!(
+            %peer_id,
+            "Received PayloadEnvelopesByRoot Response"
+        );
+        self.send_to_sync(SyncMessage::RpcPayloadEnvelope {
+            peer_id,
+            sync_request_id,
+            envelope,
             seen_timestamp: timestamp_now(),
         });
     }

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -333,10 +333,8 @@ impl<T: BeaconChainTypes> Router<T> {
             Response::PayloadEnvelopesByRoot(envelope) => {
                 self.on_payload_envelopes_by_root_response(peer_id, app_request_id, envelope);
             }
-            // TODO(EIP-7732): implement outgoing payload envelopes by range responses once
-            // range sync requests them.
-            Response::PayloadEnvelopesByRange(_) => {
-                error!(%peer_id, "Unexpected PayloadEnvelopesByRange response");
+            Response::PayloadEnvelopesByRange(envelope) => {
+                self.on_payload_envelopes_by_range_response(peer_id, app_request_id, envelope);
             }
             // Light client responses should not be received
             Response::LightClientBootstrap(_)
@@ -831,6 +829,29 @@ impl<T: BeaconChainTypes> Router<T> {
             });
         } else {
             crit!("All data columns by range responses should belong to sync");
+        }
+    }
+
+    pub fn on_payload_envelopes_by_range_response(
+        &mut self,
+        peer_id: PeerId,
+        app_request_id: AppRequestId,
+        envelope: Option<Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>>,
+    ) {
+        trace!(
+            %peer_id,
+            "Received PayloadEnvelopesByRange Response"
+        );
+
+        if let AppRequestId::Sync(sync_request_id) = app_request_id {
+            self.send_to_sync(SyncMessage::RpcPayloadEnvelope {
+                peer_id,
+                sync_request_id,
+                envelope,
+                seen_timestamp: timestamp_now(),
+            });
+        } else {
+            crit!("All payload envelopes by range responses should belong to sync");
         }
     }
 

--- a/beacon_node/network/src/status.rs
+++ b/beacon_node/network/src/status.rs
@@ -23,6 +23,16 @@ pub(crate) fn status_message<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>)
     let cached_head = beacon_chain.canonical_head.cached_head();
     let mut finalized_checkpoint = cached_head.finalized_checkpoint();
 
+    // During checkpoint sync, the fork choice's finalized checkpoint is set to the anchor
+    // block's epoch, which may be ahead of the network-agreed finalized epoch stored in the
+    // state. Other clients (e.g. Prysm) reject peers whose finalized_root doesn't match
+    // their IsFinalized check. Use the state's finalized checkpoint when it's behind the
+    // fork choice value, as it reflects the actual network consensus.
+    let state_finalized = cached_head.snapshot.beacon_state.finalized_checkpoint();
+    if state_finalized.epoch < finalized_checkpoint.epoch {
+        finalized_checkpoint = state_finalized;
+    }
+
     // Alias the genesis checkpoint root to `0x00`.
     let spec = &beacon_chain.spec;
     let genesis_epoch = spec.genesis_slot.epoch(T::EthSpec::slots_per_epoch());

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -45,7 +45,9 @@ use std::time::Duration;
 use store::Hash256;
 use tracing::{debug, error, warn};
 use types::data::FixedBlobSidecarList;
-use types::{BlobSidecar, DataColumnSidecar, EthSpec, SignedBeaconBlock};
+use types::{
+    BlobSidecar, DataColumnSidecar, EthSpec, SignedBeaconBlock, SignedExecutionPayloadEnvelope,
+};
 
 pub mod parent_chain;
 mod single_block_lookup;
@@ -82,6 +84,8 @@ type BlobDownloadResponse<E> =
     Result<(FixedBlobSidecarList<E>, PeerGroup, Duration), RpcResponseError>;
 type CustodyDownloadResponse<E> =
     Result<(types::DataColumnSidecarList<E>, PeerGroup, Duration), RpcResponseError>;
+type EnvelopeDownloadResponse<E> =
+    Result<(Arc<SignedExecutionPayloadEnvelope<E>>, PeerGroup, Duration), RpcResponseError>;
 
 pub enum BlockComponent<E: EthSpec> {
     Block(DownloadResult<Arc<SignedBeaconBlock<E>>>),
@@ -579,6 +583,29 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         self.on_lookup_result(id.lookup_id, result, "custody_download_response", cx);
     }
 
+    pub fn on_payload_envelope_download_response(
+        &mut self,
+        id: SingleLookupReqId,
+        response: EnvelopeDownloadResponse<T::EthSpec>,
+        cx: &mut SyncNetworkContext<T>,
+    ) {
+        let Some(lookup) = self.single_block_lookups.get_mut(&id.lookup_id) else {
+            debug!(?id, "Envelope returned for single block lookup not present");
+            return;
+        };
+        let block_root = lookup.block_root();
+        debug!(
+            ?block_root,
+            ?id,
+            is_ok = response.is_ok(),
+            "Payload envelope download response"
+        );
+
+        let result =
+            lookup.on_payload_envelope_download_response(id.req_id, response.map_err(|_| ()), cx);
+        self.on_lookup_result(id.lookup_id, result, "envelope_download_response", cx);
+    }
+
     /* Error responses */
 
     pub fn peer_disconnected(&mut self, peer_id: &PeerId) {
@@ -605,6 +632,9 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             }
             BlockProcessType::SingleBlob { .. } | BlockProcessType::SingleCustodyColumn(_) => {
                 self.on_data_processing_result(lookup_id, result, cx)
+            }
+            BlockProcessType::SinglePayloadEnvelope { .. } => {
+                self.on_payload_processing_result(lookup_id, result, cx)
             }
         };
         self.on_lookup_result(lookup_id, lookup_result, "processing_result", cx);
@@ -766,6 +796,50 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
 
                 // Data processing failed — retry data download only
                 lookup.on_data_processing_result(false, cx)
+            }
+        }
+    }
+
+    /// Handle payload envelope processing result.
+    fn on_payload_processing_result(
+        &mut self,
+        lookup_id: SingleLookupId,
+        result: BlockProcessingResult,
+        cx: &mut SyncNetworkContext<T>,
+    ) -> Result<LookupResult, LookupRequestError> {
+        let Some(lookup) = self.single_block_lookups.get_mut(&lookup_id) else {
+            debug!(id = lookup_id, "Unknown single block lookup");
+            return Err(LookupRequestError::UnknownLookup);
+        };
+
+        let block_root = lookup.block_root();
+
+        debug!(
+            ?block_root,
+            id = lookup_id,
+            ?result,
+            "Received payload processing result"
+        );
+
+        match result {
+            BlockProcessingResult::Ok(AvailabilityProcessingStatus::Imported(_))
+            | BlockProcessingResult::Ok(AvailabilityProcessingStatus::MissingComponents {
+                ..
+            })
+            | BlockProcessingResult::Err(BlockError::DuplicateFullyImported(..))
+            | BlockProcessingResult::Err(BlockError::GenesisBlock) => {
+                lookup.on_payload_processing_result(true, cx)
+            }
+            BlockProcessingResult::Ignored => {
+                warn!("Payload processing ignored, cpu might be overloaded");
+                Err(LookupRequestError::Failed(
+                    "Payload processing ignored".to_owned(),
+                ))
+            }
+            BlockProcessingResult::Err(e) => {
+                debug!(?block_root, error = ?e, "Payload processing error, retrying");
+                // Payload processing failed — retry payload download
+                lookup.on_payload_processing_result(false, cx)
             }
         }
     }

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -360,6 +360,8 @@ enum PayloadRequest<E: EthSpec> {
         state: SingleLookupRequestState<Arc<SignedExecutionPayloadEnvelope<E>>>,
     },
     Downloaded {
+        envelope: Arc<SignedExecutionPayloadEnvelope<E>>,
+        seen_timestamp: Duration,
         peer_group: PeerGroup,
     },
     Processing {
@@ -756,18 +758,29 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
                     }
                     if let Some(result) = state.take_download_result() {
                         self.payload_request = PayloadRequest::Downloaded {
+                            envelope: result.value,
+                            seen_timestamp: result.seen_timestamp,
                             peer_group: result.peer_group,
                         };
                     } else {
                         break;
                     }
                 }
-                PayloadRequest::Downloaded { peer_group } => {
+                PayloadRequest::Downloaded {
+                    envelope,
+                    seen_timestamp,
+                    peer_group,
+                } => {
                     if !self.block_request.is_done() {
                         break;
                     }
-                    // TODO(gloas): send payload for processing
-                    // cx.send_payload_for_processing(...)
+                    cx.send_envelope_for_processing(
+                        id,
+                        envelope.clone(),
+                        *seen_timestamp,
+                        self.block_root,
+                    )
+                    .map_err(LookupRequestError::SendFailedProcessor)?;
                     let peer_group = peer_group.clone();
                     self.payload_request = PayloadRequest::Processing { peer_group };
                 }
@@ -1006,6 +1019,30 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         else {
             return Err(LookupRequestError::BadState(
                 "custody response but not downloading columns".to_owned(),
+            ));
+        };
+        state.on_download_response(req_id, self.block_root, result)?;
+        self.continue_requests(cx)
+    }
+
+    /// Handle a payload envelope download response. Updates download state and advances the lookup.
+    #[allow(clippy::type_complexity)]
+    pub fn on_payload_envelope_download_response(
+        &mut self,
+        req_id: ReqId,
+        result: Result<
+            (
+                Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>,
+                PeerGroup,
+                Duration,
+            ),
+            (),
+        >,
+        cx: &mut SyncNetworkContext<T>,
+    ) -> Result<LookupResult, LookupRequestError> {
+        let PayloadRequest::Downloading { state, .. } = &mut self.payload_request else {
+            return Err(LookupRequestError::BadState(
+                "envelope response but not downloading".to_owned(),
             ));
         };
         state.on_download_response(req_id, self.block_root, result)?;

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -1,6 +1,6 @@
 use beacon_chain::{
     BeaconChainTypes,
-    block_verification_types::{AvailableBlockData, RangeSyncBlock},
+    block_verification_types::{AsBlock, AvailableBlockData, RangeSyncBlock},
     data_availability_checker::DataAvailabilityChecker,
     data_column_verification::CustodyDataColumn,
     get_block_root,
@@ -9,6 +9,7 @@ use lighthouse_network::{
     PeerId,
     service::api_types::{
         BlobsByRangeRequestId, BlocksByRangeRequestId, DataColumnsByRangeRequestId,
+        PayloadEnvelopesByRangeRequestId,
     },
 };
 use ssz_types::RuntimeVariableList;
@@ -16,7 +17,7 @@ use std::{collections::HashMap, sync::Arc};
 use tracing::{Span, debug};
 use types::{
     BlobSidecar, ChainSpec, ColumnIndex, DataColumnSidecar, DataColumnSidecarList, EthSpec,
-    Hash256, SignedBeaconBlock,
+    Hash256, SignedBeaconBlock, SignedExecutionPayloadEnvelope,
 };
 
 use crate::sync::network_context::MAX_COLUMN_RETRIES;
@@ -37,6 +38,13 @@ pub struct RangeBlockComponentsRequest<E: EthSpec> {
     blocks_request: ByRangeRequest<BlocksByRangeRequestId, Vec<Arc<SignedBeaconBlock<E>>>>,
     /// Sidecars we have received awaiting for their corresponding block.
     block_data_request: RangeBlockDataRequest<E>,
+    /// Optional payload envelopes request (post-Gloas).
+    envelopes_request: Option<
+        ByRangeRequest<
+            PayloadEnvelopesByRangeRequestId,
+            Vec<Arc<SignedExecutionPayloadEnvelope<E>>>,
+        >,
+    >,
     /// Span to track the range request and all children range requests.
     pub(crate) request_span: Span,
 }
@@ -88,6 +96,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             Vec<(DataColumnsByRangeRequestId, Vec<ColumnIndex>)>,
             Vec<ColumnIndex>,
         )>,
+        envelopes_req_id: Option<PayloadEnvelopesByRangeRequestId>,
         request_span: Span,
     ) -> Self {
         let block_data_request = if let Some(blobs_req_id) = blobs_req_id {
@@ -110,6 +119,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         Self {
             blocks_request: ByRangeRequest::Active(blocks_req_id),
             block_data_request,
+            envelopes_request: envelopes_req_id.map(ByRangeRequest::Active),
             request_span,
         }
     }
@@ -166,6 +176,21 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         }
     }
 
+    /// Adds received payload envelopes to the request.
+    ///
+    /// Returns an error if this request doesn't expect envelopes,
+    /// or if the request ID doesn't match.
+    pub fn add_payload_envelopes(
+        &mut self,
+        req_id: PayloadEnvelopesByRangeRequestId,
+        envelopes: Vec<Arc<SignedExecutionPayloadEnvelope<E>>>,
+    ) -> Result<(), String> {
+        match &mut self.envelopes_request {
+            None => Err("received envelopes but none were expected".to_owned()),
+            Some(req) => req.finish(req_id, envelopes),
+        }
+    }
+
     /// Adds received custody columns to the request.
     ///
     /// Returns an error if this request expects blobs instead of data columns,
@@ -208,8 +233,19 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             return None;
         };
 
+        // If envelopes are expected, wait for them to complete before coupling
+        let envelopes = match &self.envelopes_request {
+            Some(req) => {
+                let Some(envelopes) = req.to_finished() else {
+                    return None;
+                };
+                Some(envelopes.clone())
+            }
+            None => None,
+        };
+
         // Increment the attempt once this function returns the response or errors
-        match &mut self.block_data_request {
+        let result = match &mut self.block_data_request {
             RangeBlockDataRequest::NoData => Some(Self::responses_with_blobs(
                 blocks.to_vec(),
                 vec![],
@@ -280,7 +316,26 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
 
                 Some(resp)
             }
-        }
+        };
+
+        // Attach envelopes to the coupled blocks by matching on slot
+        result.map(|res| {
+            res.map(|mut range_blocks| {
+                if let Some(envelopes) = envelopes {
+                    let mut envelopes_by_slot: HashMap<_, _> = envelopes
+                        .into_iter()
+                        .map(|env| (env.message.slot, env))
+                        .collect();
+                    for block in &mut range_blocks {
+                        let slot = block.as_block().slot();
+                        if let Some(envelope) = envelopes_by_slot.remove(&slot) {
+                            *block = block.clone().with_envelope(Some(envelope));
+                        }
+                    }
+                }
+                range_blocks
+            })
+        })
     }
 
     fn responses_with_blobs<T>(
@@ -560,7 +615,7 @@ mod tests {
 
         let blocks_req_id = blocks_id(components_id());
         let mut info =
-            RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, None, Span::none());
+            RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, None, None, Span::none());
 
         // Send blocks and complete terminate response
         info.add_blocks(blocks_req_id, blocks).unwrap();
@@ -590,6 +645,7 @@ mod tests {
         let mut info = RangeBlockComponentsRequest::<E>::new(
             blocks_req_id,
             Some(blobs_req_id),
+            None,
             None,
             Span::none(),
         );
@@ -650,6 +706,7 @@ mod tests {
             blocks_req_id,
             None,
             Some((columns_req_id.clone(), expects_custody_columns.clone())),
+            None,
             Span::none(),
         );
         // Send blocks and complete terminate response
@@ -726,6 +783,7 @@ mod tests {
             blocks_req_id,
             None,
             Some((columns_req_id.clone(), expected_sampling_columns.clone())),
+            None,
             Span::none(),
         );
 
@@ -818,6 +876,7 @@ mod tests {
             blocks_req_id,
             None,
             Some((columns_req_id.clone(), expected_sampling_columns.clone())),
+            None,
             Span::none(),
         );
 
@@ -915,6 +974,7 @@ mod tests {
             blocks_req_id,
             None,
             Some((columns_req_id.clone(), expected_sampling_columns.clone())),
+            None,
             Span::none(),
         );
 
@@ -1030,6 +1090,7 @@ mod tests {
             blocks_req_id,
             None,
             Some((columns_req_id.clone(), expected_sampling_columns.clone())),
+            None,
             Span::none(),
         );
 

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -72,7 +72,8 @@ use strum::IntoStaticStr;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace};
 use types::{
-    BlobSidecar, DataColumnSidecar, EthSpec, ForkContext, Hash256, SignedBeaconBlock, Slot,
+    BlobSidecar, DataColumnSidecar, EthSpec, ForkContext, Hash256, SignedBeaconBlock,
+    SignedExecutionPayloadEnvelope, Slot,
 };
 
 /// The number of slots ahead of us that is allowed before requesting a long-range (batch)  Sync
@@ -131,6 +132,14 @@ pub enum SyncMessage<E: EthSpec> {
         seen_timestamp: Duration,
     },
 
+    /// An execution payload envelope has been received from the RPC.
+    RpcPayloadEnvelope {
+        sync_request_id: SyncRequestId,
+        peer_id: PeerId,
+        envelope: Option<Arc<SignedExecutionPayloadEnvelope<E>>>,
+        seen_timestamp: Duration,
+    },
+
     /// A block with an unknown parent has been received.
     UnknownParentBlock(PeerId, Arc<SignedBeaconBlock<E>>, Hash256),
 
@@ -182,6 +191,7 @@ pub enum BlockProcessType {
     SingleBlock { id: Id },
     SingleBlob { id: Id },
     SingleCustodyColumn(Id),
+    SinglePayloadEnvelope { id: Id, block_root: Hash256 },
 }
 
 impl BlockProcessType {
@@ -189,7 +199,8 @@ impl BlockProcessType {
         match self {
             BlockProcessType::SingleBlock { id }
             | BlockProcessType::SingleBlob { id }
-            | BlockProcessType::SingleCustodyColumn(id) => *id,
+            | BlockProcessType::SingleCustodyColumn(id)
+            | BlockProcessType::SinglePayloadEnvelope { id, .. } => *id,
         }
     }
 }
@@ -502,6 +513,9 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             }
             SyncRequestId::DataColumnsByRange(req_id) => {
                 self.on_data_columns_by_range_response(req_id, peer_id, RpcEvent::RPCError(error))
+            }
+            SyncRequestId::SinglePayloadEnvelope { id } => {
+                self.on_single_envelope_response(id, peer_id, RpcEvent::RPCError(error))
             }
         }
     }
@@ -837,6 +851,17 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             } => {
                 self.rpc_data_column_received(sync_request_id, peer_id, data_column, seen_timestamp)
             }
+            SyncMessage::RpcPayloadEnvelope {
+                sync_request_id,
+                peer_id,
+                envelope,
+                seen_timestamp,
+            } => self.rpc_payload_envelope_received(
+                sync_request_id,
+                peer_id,
+                envelope,
+                seen_timestamp,
+            ),
             SyncMessage::UnknownParentBlock(peer_id, block, block_root) => {
                 let block_slot = block.slot();
                 let parent_root = block.parent_root();
@@ -1229,6 +1254,45 @@ impl<T: BeaconChainTypes> SyncManager<T> {
     ) {
         if let Some(resp) = self.network.on_single_blob_response(id, peer_id, blob) {
             self.block_lookups.on_blob_download_response(
+                id,
+                resp.map(|(value, seen_timestamp)| {
+                    (value, PeerGroup::from_single(peer_id), seen_timestamp)
+                }),
+                &mut self.network,
+            )
+        }
+    }
+
+    fn rpc_payload_envelope_received(
+        &mut self,
+        sync_request_id: SyncRequestId,
+        peer_id: PeerId,
+        envelope: Option<Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>>,
+        seen_timestamp: Duration,
+    ) {
+        match sync_request_id {
+            SyncRequestId::SinglePayloadEnvelope { id } => self.on_single_envelope_response(
+                id,
+                peer_id,
+                RpcEvent::from_chunk(envelope, seen_timestamp),
+            ),
+            _ => {
+                crit!(%peer_id, "bad request id for payload envelope");
+            }
+        }
+    }
+
+    fn on_single_envelope_response(
+        &mut self,
+        id: SingleLookupReqId,
+        peer_id: PeerId,
+        rpc_event: RpcEvent<Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>>,
+    ) {
+        if let Some(resp) = self
+            .network
+            .on_single_envelope_response(id, peer_id, rpc_event)
+        {
+            self.block_lookups.on_payload_envelope_download_response(
                 id,
                 resp.map(|(value, seen_timestamp)| {
                     (value, PeerGroup::from_single(peer_id), seen_timestamp)

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -58,7 +58,8 @@ use lighthouse_network::service::api_types::{
     BlobsByRangeRequestId, BlocksByRangeRequestId, ComponentsByRangeRequestId,
     CustodyBackFillBatchRequestId, CustodyBackfillBatchId, CustodyRequester,
     DataColumnsByRangeRequestId, DataColumnsByRangeRequester, DataColumnsByRootRequestId,
-    DataColumnsByRootRequester, Id, SingleLookupReqId, SyncRequestId,
+    DataColumnsByRootRequester, Id, PayloadEnvelopesByRangeRequestId, SingleLookupReqId,
+    SyncRequestId,
 };
 use lighthouse_network::types::{NetworkGlobals, SyncState};
 use lighthouse_network::{PeerAction, PeerId};
@@ -514,6 +515,8 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             SyncRequestId::DataColumnsByRange(req_id) => {
                 self.on_data_columns_by_range_response(req_id, peer_id, RpcEvent::RPCError(error))
             }
+            SyncRequestId::PayloadEnvelopesByRange(req_id) => self
+                .on_payload_envelopes_by_range_response(req_id, peer_id, RpcEvent::RPCError(error)),
             SyncRequestId::SinglePayloadEnvelope { id } => {
                 self.on_single_envelope_response(id, peer_id, RpcEvent::RPCError(error))
             }
@@ -1276,6 +1279,12 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 peer_id,
                 RpcEvent::from_chunk(envelope, seen_timestamp),
             ),
+            SyncRequestId::PayloadEnvelopesByRange(id) => self
+                .on_payload_envelopes_by_range_response(
+                    id,
+                    peer_id,
+                    RpcEvent::from_chunk(envelope, seen_timestamp),
+                ),
             _ => {
                 crit!(%peer_id, "bad request id for payload envelope");
             }
@@ -1381,6 +1390,24 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         resp,
                     ),
             }
+        }
+    }
+
+    fn on_payload_envelopes_by_range_response(
+        &mut self,
+        id: PayloadEnvelopesByRangeRequestId,
+        peer_id: PeerId,
+        envelope: RpcEvent<Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>>,
+    ) {
+        if let Some(resp) = self
+            .network
+            .on_payload_envelopes_by_range_response(id, peer_id, envelope)
+        {
+            self.on_range_components_response(
+                id.parent_request_id,
+                peer_id,
+                RangeBlockComponent::PayloadEnvelopes(id, resp),
+            );
         }
     }
 

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -22,14 +22,17 @@ use beacon_chain::block_verification_types::{AsBlock, RangeSyncBlock};
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockProcessStatus, EngineState};
 use custody::CustodyRequestResult;
 use fnv::FnvHashMap;
-use lighthouse_network::rpc::methods::{BlobsByRangeRequest, DataColumnsByRangeRequest};
+use lighthouse_network::rpc::methods::{
+    BlobsByRangeRequest, DataColumnsByRangeRequest, PayloadEnvelopesByRangeRequest,
+};
 use lighthouse_network::rpc::{BlocksByRangeRequest, GoodbyeReason, RPCError, RequestType};
 pub use lighthouse_network::service::api_types::RangeRequestId;
 use lighthouse_network::service::api_types::{
     AppRequestId, BlobsByRangeRequestId, BlocksByRangeRequestId, ComponentsByRangeRequestId,
     CustodyBackFillBatchRequestId, CustodyBackfillBatchId, CustodyId, CustodyRequester,
     DataColumnsByRangeRequestId, DataColumnsByRangeRequester, DataColumnsByRootRequestId,
-    DataColumnsByRootRequester, Id, SingleLookupReqId, SyncRequestId,
+    DataColumnsByRootRequester, Id, PayloadEnvelopesByRangeRequestId, SingleLookupReqId,
+    SyncRequestId,
 };
 use lighthouse_network::{Client, NetworkGlobals, PeerAction, PeerId, ReportSource};
 use parking_lot::RwLock;
@@ -37,7 +40,8 @@ pub use requests::LookupVerifyError;
 use requests::{
     ActiveRequests, BlobsByRangeRequestItems, BlobsByRootRequestItems, BlocksByRangeRequestItems,
     BlocksByRootRequestItems, DataColumnsByRangeRequestItems, DataColumnsByRootRequestItems,
-    PayloadEnvelopesByRootRequestItems, PayloadEnvelopesByRootSingleRequest,
+    PayloadEnvelopesByRangeRequestItems, PayloadEnvelopesByRootRequestItems,
+    PayloadEnvelopesByRootSingleRequest,
 };
 #[cfg(test)]
 use slot_clock::SlotClock;
@@ -214,6 +218,11 @@ pub struct SyncNetworkContext<T: BeaconChainTypes> {
     /// A mapping of active DataColumnsByRange requests
     data_columns_by_range_requests:
         ActiveRequests<DataColumnsByRangeRequestId, DataColumnsByRangeRequestItems<T::EthSpec>>,
+    /// A mapping of active PayloadEnvelopesByRange requests
+    payload_envelopes_by_range_requests: ActiveRequests<
+        PayloadEnvelopesByRangeRequestId,
+        PayloadEnvelopesByRangeRequestItems<T::EthSpec>,
+    >,
     /// A mapping of active PayloadEnvelopesByRoot requests
     payload_envelopes_by_root_requests:
         ActiveRequests<SingleLookupReqId, PayloadEnvelopesByRootRequestItems<T::EthSpec>>,
@@ -253,6 +262,10 @@ pub enum RangeBlockComponent<E: EthSpec> {
     CustodyColumns(
         DataColumnsByRangeRequestId,
         RpcResponseResult<Vec<Arc<DataColumnSidecar<E>>>>,
+    ),
+    PayloadEnvelopes(
+        PayloadEnvelopesByRangeRequestId,
+        RpcResponseResult<Vec<Arc<SignedExecutionPayloadEnvelope<E>>>>,
     ),
 }
 
@@ -302,6 +315,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             blocks_by_range_requests: ActiveRequests::new("blocks_by_range"),
             blobs_by_range_requests: ActiveRequests::new("blobs_by_range"),
             data_columns_by_range_requests: ActiveRequests::new("data_columns_by_range"),
+            payload_envelopes_by_range_requests: ActiveRequests::new("payload_envelopes_by_range"),
             payload_envelopes_by_root_requests: ActiveRequests::new("payload_envelopes_by_root"),
             custody_by_root_requests: <_>::default(),
             components_by_range_requests: FnvHashMap::default(),
@@ -331,6 +345,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             blocks_by_range_requests,
             blobs_by_range_requests,
             data_columns_by_range_requests,
+            payload_envelopes_by_range_requests,
             payload_envelopes_by_root_requests,
             // custody_by_root_requests is a meta request of data_columns_by_root_requests
             custody_by_root_requests: _,
@@ -367,6 +382,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .active_requests_of_peer(peer_id)
             .into_iter()
             .map(|req_id| SyncRequestId::DataColumnsByRange(*req_id));
+        let envelope_by_range_ids = payload_envelopes_by_range_requests
+            .active_requests_of_peer(peer_id)
+            .into_iter()
+            .map(|req_id| SyncRequestId::PayloadEnvelopesByRange(*req_id));
         let envelope_by_root_ids = payload_envelopes_by_root_requests
             .active_requests_of_peer(peer_id)
             .into_iter()
@@ -377,6 +396,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .chain(blocks_by_range_ids)
             .chain(blobs_by_range_ids)
             .chain(data_column_by_range_ids)
+            .chain(envelope_by_range_ids)
             .chain(envelope_by_root_ids)
             .collect()
     }
@@ -434,6 +454,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             blocks_by_range_requests,
             blobs_by_range_requests,
             data_columns_by_range_requests,
+            payload_envelopes_by_range_requests,
             payload_envelopes_by_root_requests,
             // custody_by_root_requests is a meta request of data_columns_by_root_requests
             custody_by_root_requests: _,
@@ -457,6 +478,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .chain(blocks_by_range_requests.iter_request_peers())
             .chain(blobs_by_range_requests.iter_request_peers())
             .chain(data_columns_by_range_requests.iter_request_peers())
+            .chain(payload_envelopes_by_range_requests.iter_request_peers())
             .chain(payload_envelopes_by_root_requests.iter_request_peers())
         {
             *active_request_count_by_peer.entry(peer_id).or_default() += 1;
@@ -672,6 +694,26 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .transpose()?;
 
         let epoch = Slot::new(*request.start_slot()).epoch(T::EthSpec::slots_per_epoch());
+
+        let envelopes_req_id = if self.chain.spec.fork_name_at_epoch(epoch).gloas_enabled() {
+            Some(self.send_payload_envelopes_by_range_request(
+                block_peer,
+                PayloadEnvelopesByRangeRequest {
+                    start_slot: *request.start_slot(),
+                    count: *request.count(),
+                },
+                id,
+                new_range_request_span!(
+                    self,
+                    "outgoing_envelopes_by_range",
+                    range_request_span.clone(),
+                    block_peer
+                ),
+            )?)
+        } else {
+            None
+        };
+
         let info = RangeBlockComponentsRequest::new(
             blocks_req_id,
             blobs_req_id,
@@ -681,6 +723,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                     self.chain.sampling_columns_for_epoch(epoch).to_vec(),
                 )
             }),
+            envelopes_req_id,
             range_request_span,
         );
         self.components_by_range_requests.insert(id, info);
@@ -776,6 +819,17 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                     resp.and_then(|(custody_columns, _)| {
                         request
                             .add_custody_columns(req_id, custody_columns)
+                            .map_err(|e| {
+                                RpcResponseError::BlockComponentCouplingError(
+                                    CouplingError::InternalError(e),
+                                )
+                            })
+                    })
+                }
+                RangeBlockComponent::PayloadEnvelopes(req_id, resp) => {
+                    resp.and_then(|(envelopes, _)| {
+                        request
+                            .add_payload_envelopes(req_id, envelopes)
                             .map_err(|e| {
                                 RpcResponseError::BlockComponentCouplingError(
                                     CouplingError::InternalError(e),
@@ -1369,6 +1423,47 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         Ok((id, requested_columns))
     }
 
+    fn send_payload_envelopes_by_range_request(
+        &mut self,
+        peer_id: PeerId,
+        request: PayloadEnvelopesByRangeRequest,
+        parent_request_id: ComponentsByRangeRequestId,
+        request_span: Span,
+    ) -> Result<PayloadEnvelopesByRangeRequestId, RpcRequestSendError> {
+        let id = PayloadEnvelopesByRangeRequestId {
+            id: self.next_id(),
+            parent_request_id,
+        };
+
+        self.network_send
+            .send(NetworkMessage::SendRequest {
+                peer_id,
+                request: RequestType::PayloadEnvelopesByRange(request.clone()),
+                app_request_id: AppRequestId::Sync(SyncRequestId::PayloadEnvelopesByRange(id)),
+            })
+            .map_err(|_| RpcRequestSendError::InternalError("network send error".to_owned()))?;
+
+        debug!(
+            method = "PayloadEnvelopesByRange",
+            slots = request.count,
+            epoch = %Slot::new(request.start_slot).epoch(T::EthSpec::slots_per_epoch()),
+            peer = %peer_id,
+            %id,
+            "Sync RPC request sent"
+        );
+
+        self.payload_envelopes_by_range_requests.insert(
+            id,
+            peer_id,
+            // false = do not enforce max_requests are returned for *_by_range methods. We don't
+            // know if there are missed blocks / envelopes.
+            false,
+            PayloadEnvelopesByRangeRequestItems::new(request),
+            request_span,
+        );
+        Ok(id)
+    }
+
     pub fn is_execution_engine_online(&self) -> bool {
         self.execution_engine_state == EngineState::Online
     }
@@ -1610,6 +1705,19 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     ) -> Option<RpcResponseResult<DataColumnSidecarList<T::EthSpec>>> {
         let resp = self
             .data_columns_by_range_requests
+            .on_response(id, rpc_event);
+        self.on_rpc_response_result(resp, peer_id)
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn on_payload_envelopes_by_range_response(
+        &mut self,
+        id: PayloadEnvelopesByRangeRequestId,
+        peer_id: PeerId,
+        rpc_event: RpcEvent<Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>>,
+    ) -> Option<RpcResponseResult<Vec<Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>>>> {
+        let resp = self
+            .payload_envelopes_by_range_requests
             .on_response(id, rpc_event);
         self.on_rpc_response_result(resp, peer_id)
     }

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -37,6 +37,7 @@ pub use requests::LookupVerifyError;
 use requests::{
     ActiveRequests, BlobsByRangeRequestItems, BlobsByRootRequestItems, BlocksByRangeRequestItems,
     BlocksByRootRequestItems, DataColumnsByRangeRequestItems, DataColumnsByRootRequestItems,
+    PayloadEnvelopesByRootRequestItems, PayloadEnvelopesByRootSingleRequest,
 };
 #[cfg(test)]
 use slot_clock::SlotClock;
@@ -52,7 +53,7 @@ use tracing::{Span, debug, debug_span, error, warn};
 use types::data::FixedBlobSidecarList;
 use types::{
     BlobSidecar, BlockImportSource, ColumnIndex, DataColumnSidecar, DataColumnSidecarList, EthSpec,
-    ForkContext, Hash256, SignedBeaconBlock, Slot,
+    ForkContext, Hash256, SignedBeaconBlock, SignedExecutionPayloadEnvelope, Slot,
 };
 
 pub mod custody;
@@ -213,6 +214,9 @@ pub struct SyncNetworkContext<T: BeaconChainTypes> {
     /// A mapping of active DataColumnsByRange requests
     data_columns_by_range_requests:
         ActiveRequests<DataColumnsByRangeRequestId, DataColumnsByRangeRequestItems<T::EthSpec>>,
+    /// A mapping of active PayloadEnvelopesByRoot requests
+    payload_envelopes_by_root_requests:
+        ActiveRequests<SingleLookupReqId, PayloadEnvelopesByRootRequestItems<T::EthSpec>>,
     /// Mapping of active custody column requests for a block root
     custody_by_root_requests: FnvHashMap<CustodyRequester, ActiveCustodyRequest<T>>,
 
@@ -298,6 +302,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             blocks_by_range_requests: ActiveRequests::new("blocks_by_range"),
             blobs_by_range_requests: ActiveRequests::new("blobs_by_range"),
             data_columns_by_range_requests: ActiveRequests::new("data_columns_by_range"),
+            payload_envelopes_by_root_requests: ActiveRequests::new("payload_envelopes_by_root"),
             custody_by_root_requests: <_>::default(),
             components_by_range_requests: FnvHashMap::default(),
             custody_backfill_data_column_batch_requests: FnvHashMap::default(),
@@ -326,6 +331,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             blocks_by_range_requests,
             blobs_by_range_requests,
             data_columns_by_range_requests,
+            payload_envelopes_by_root_requests,
             // custody_by_root_requests is a meta request of data_columns_by_root_requests
             custody_by_root_requests: _,
             // components_by_range_requests is a meta request of various _by_range requests
@@ -361,12 +367,17 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .active_requests_of_peer(peer_id)
             .into_iter()
             .map(|req_id| SyncRequestId::DataColumnsByRange(*req_id));
+        let envelope_by_root_ids = payload_envelopes_by_root_requests
+            .active_requests_of_peer(peer_id)
+            .into_iter()
+            .map(|id| SyncRequestId::SinglePayloadEnvelope { id: *id });
         blocks_by_root_ids
             .chain(blobs_by_root_ids)
             .chain(data_column_by_root_ids)
             .chain(blocks_by_range_ids)
             .chain(blobs_by_range_ids)
             .chain(data_column_by_range_ids)
+            .chain(envelope_by_root_ids)
             .collect()
     }
 
@@ -423,6 +434,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             blocks_by_range_requests,
             blobs_by_range_requests,
             data_columns_by_range_requests,
+            payload_envelopes_by_root_requests,
             // custody_by_root_requests is a meta request of data_columns_by_root_requests
             custody_by_root_requests: _,
             // components_by_range_requests is a meta request of various _by_range requests
@@ -445,6 +457,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .chain(blocks_by_range_requests.iter_request_peers())
             .chain(blobs_by_range_requests.iter_request_peers())
             .chain(data_columns_by_range_requests.iter_request_peers())
+            .chain(payload_envelopes_by_root_requests.iter_request_peers())
         {
             *active_request_count_by_peer.entry(peer_id).or_default() += 1;
         }
@@ -927,18 +940,72 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         Ok(LookupRequestResult::RequestSent(id.req_id))
     }
 
-    /// Placeholder for payload envelope lookup requests.
-    ///
-    /// This intentionally returns `NoRequestNeeded` until payload-by-root RPC is wired.
+    /// Request a payload envelope for `block_root` from a peer.
     pub fn payload_lookup_request(
         &mut self,
-        _lookup_id: SingleLookupId,
-        _lookup_peers: Arc<RwLock<HashSet<PeerId>>>,
-        _block_root: Hash256,
+        lookup_id: SingleLookupId,
+        lookup_peers: Arc<RwLock<HashSet<PeerId>>>,
+        block_root: Hash256,
     ) -> Result<LookupRequestResult, RpcRequestSendError> {
-        Ok(LookupRequestResult::NoRequestNeeded(
-            "payload lookup rpc not wired",
-        ))
+        let active_request_count_by_peer = self.active_request_count_by_peer();
+        let Some(peer_id) = lookup_peers
+            .read()
+            .iter()
+            .map(|peer| {
+                (
+                    active_request_count_by_peer.get(peer).copied().unwrap_or(0),
+                    rand::random::<u32>(),
+                    peer,
+                )
+            })
+            .min()
+            .map(|(_, _, peer)| *peer)
+        else {
+            return Ok(LookupRequestResult::Pending("no peers"));
+        };
+
+        let id = SingleLookupReqId {
+            lookup_id,
+            req_id: self.next_id(),
+        };
+
+        let request = PayloadEnvelopesByRootSingleRequest(block_root);
+
+        let network_request = RequestType::PayloadEnvelopesByRoot(
+            request
+                .into_request(&self.fork_context)
+                .map_err(RpcRequestSendError::InternalError)?,
+        );
+        self.network_send
+            .send(NetworkMessage::SendRequest {
+                peer_id,
+                request: network_request,
+                app_request_id: AppRequestId::Sync(SyncRequestId::SinglePayloadEnvelope { id }),
+            })
+            .map_err(|_| RpcRequestSendError::InternalError("network send error".to_owned()))?;
+
+        debug!(
+            method = "PayloadEnvelopesByRoot",
+            ?block_root,
+            peer = %peer_id,
+            %id,
+            "Sync RPC request sent"
+        );
+
+        let request_span = debug_span!(
+            parent: Span::current(),
+            "lh_outgoing_envelope_by_root_request",
+            %block_root,
+        );
+        self.payload_envelopes_by_root_requests.insert(
+            id,
+            peer_id,
+            true,
+            PayloadEnvelopesByRootRequestItems::new(request),
+            request_span,
+        );
+
+        Ok(LookupRequestResult::RequestSent(id.req_id))
     }
 
     /// Request necessary blobs for `block_root`. Requests only the necessary blobs by checking:
@@ -1449,6 +1516,27 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         self.on_rpc_response_result(resp, peer_id)
     }
 
+    pub(crate) fn on_single_envelope_response(
+        &mut self,
+        id: SingleLookupReqId,
+        peer_id: PeerId,
+        rpc_event: RpcEvent<Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>>,
+    ) -> Option<RpcResponseResult<Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>>> {
+        let resp = self
+            .payload_envelopes_by_root_requests
+            .on_response(id, rpc_event);
+        let resp = resp.map(|res| {
+            res.and_then(|(mut envelopes, seen_timestamp)| {
+                match envelopes.pop() {
+                    Some(envelope) => Ok((envelope, seen_timestamp)),
+                    // Should never happen, request items enforces at least 1 chunk.
+                    None => Err(LookupVerifyError::NotEnoughResponsesReturned { actual: 0 }.into()),
+                }
+            })
+        });
+        self.on_rpc_response_result(resp, peer_id)
+    }
+
     pub(crate) fn on_single_blob_response(
         &mut self,
         id: SingleLookupReqId,
@@ -1654,6 +1742,33 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             })
     }
 
+    pub fn send_envelope_for_processing(
+        &self,
+        id: Id,
+        envelope: Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>,
+        seen_timestamp: Duration,
+        block_root: Hash256,
+    ) -> Result<(), SendErrorProcessor> {
+        let beacon_processor = self
+            .beacon_processor_if_enabled()
+            .ok_or(SendErrorProcessor::ProcessorNotAvailable)?;
+
+        debug!(?block_root, ?id, "Sending payload envelope for processing");
+        beacon_processor
+            .send_rpc_payload_envelope(
+                envelope,
+                seen_timestamp,
+                BlockProcessType::SinglePayloadEnvelope { id, block_root },
+            )
+            .map_err(|e| {
+                error!(
+                    error = ?e,
+                    "Failed to send sync envelope to processor"
+                );
+                SendErrorProcessor::SendError
+            })
+    }
+
     pub fn send_custody_columns_for_processing(
         &self,
         _id: Id,
@@ -1801,6 +1916,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             (
                 "data_columns_by_range",
                 self.data_columns_by_range_requests.len(),
+            ),
+            (
+                "payload_envelopes_by_root",
+                self.payload_envelopes_by_root_requests.len(),
             ),
             ("custody_by_root", self.custody_by_root_requests.len()),
             (

--- a/beacon_node/network/src/sync/network_context/requests.rs
+++ b/beacon_node/network/src/sync/network_context/requests.rs
@@ -16,6 +16,9 @@ pub use data_columns_by_range::DataColumnsByRangeRequestItems;
 pub use data_columns_by_root::{
     DataColumnsByRootRequestItems, DataColumnsByRootSingleBlockRequest,
 };
+pub use payload_envelopes_by_root::{
+    PayloadEnvelopesByRootRequestItems, PayloadEnvelopesByRootSingleRequest,
+};
 
 use crate::metrics;
 
@@ -27,6 +30,7 @@ mod blocks_by_range;
 mod blocks_by_root;
 mod data_columns_by_range;
 mod data_columns_by_root;
+mod payload_envelopes_by_root;
 
 #[derive(Debug, PartialEq, Eq, IntoStaticStr)]
 pub enum LookupVerifyError {

--- a/beacon_node/network/src/sync/network_context/requests.rs
+++ b/beacon_node/network/src/sync/network_context/requests.rs
@@ -16,6 +16,7 @@ pub use data_columns_by_range::DataColumnsByRangeRequestItems;
 pub use data_columns_by_root::{
     DataColumnsByRootRequestItems, DataColumnsByRootSingleBlockRequest,
 };
+pub use payload_envelopes_by_range::PayloadEnvelopesByRangeRequestItems;
 pub use payload_envelopes_by_root::{
     PayloadEnvelopesByRootRequestItems, PayloadEnvelopesByRootSingleRequest,
 };
@@ -30,6 +31,7 @@ mod blocks_by_range;
 mod blocks_by_root;
 mod data_columns_by_range;
 mod data_columns_by_root;
+mod payload_envelopes_by_range;
 mod payload_envelopes_by_root;
 
 #[derive(Debug, PartialEq, Eq, IntoStaticStr)]

--- a/beacon_node/network/src/sync/network_context/requests/payload_envelopes_by_range.rs
+++ b/beacon_node/network/src/sync/network_context/requests/payload_envelopes_by_range.rs
@@ -1,0 +1,47 @@
+use super::{ActiveRequestItems, LookupVerifyError};
+use lighthouse_network::rpc::methods::PayloadEnvelopesByRangeRequest;
+use std::sync::Arc;
+use types::{EthSpec, SignedExecutionPayloadEnvelope};
+
+/// Accumulates results of a payload_envelopes_by_range request.
+pub struct PayloadEnvelopesByRangeRequestItems<E: EthSpec> {
+    request: PayloadEnvelopesByRangeRequest,
+    items: Vec<Arc<SignedExecutionPayloadEnvelope<E>>>,
+}
+
+impl<E: EthSpec> PayloadEnvelopesByRangeRequestItems<E> {
+    pub fn new(request: PayloadEnvelopesByRangeRequest) -> Self {
+        Self {
+            request,
+            items: vec![],
+        }
+    }
+}
+
+impl<E: EthSpec> ActiveRequestItems for PayloadEnvelopesByRangeRequestItems<E> {
+    type Item = Arc<SignedExecutionPayloadEnvelope<E>>;
+
+    fn add(&mut self, envelope: Self::Item) -> Result<bool, LookupVerifyError> {
+        let slot = envelope.message.slot;
+        if slot < self.request.start_slot || slot >= self.request.start_slot + self.request.count {
+            return Err(LookupVerifyError::UnrequestedSlot(slot));
+        }
+        // Check for duplicate envelopes at the same slot (only one envelope per slot)
+        if self
+            .items
+            .iter()
+            .any(|existing| existing.message.slot == slot)
+        {
+            return Err(LookupVerifyError::DuplicatedData(slot, 0));
+        }
+
+        self.items.push(envelope);
+
+        // Don't check for completion — not every slot has an envelope
+        Ok(false)
+    }
+
+    fn consume(&mut self) -> Vec<Self::Item> {
+        std::mem::take(&mut self.items)
+    }
+}

--- a/beacon_node/network/src/sync/network_context/requests/payload_envelopes_by_root.rs
+++ b/beacon_node/network/src/sync/network_context/requests/payload_envelopes_by_root.rs
@@ -1,0 +1,53 @@
+use lighthouse_network::rpc::methods::PayloadEnvelopesByRootRequest;
+use std::sync::Arc;
+use types::{EthSpec, ForkContext, Hash256, SignedExecutionPayloadEnvelope};
+
+use super::{ActiveRequestItems, LookupVerifyError};
+
+#[derive(Debug, Copy, Clone)]
+pub struct PayloadEnvelopesByRootSingleRequest(pub Hash256);
+
+impl PayloadEnvelopesByRootSingleRequest {
+    pub fn into_request(
+        self,
+        fork_context: &ForkContext,
+    ) -> Result<PayloadEnvelopesByRootRequest, String> {
+        PayloadEnvelopesByRootRequest::new(vec![self.0], fork_context)
+    }
+}
+
+pub struct PayloadEnvelopesByRootRequestItems<E: EthSpec> {
+    request: PayloadEnvelopesByRootSingleRequest,
+    items: Vec<Arc<SignedExecutionPayloadEnvelope<E>>>,
+}
+
+impl<E: EthSpec> PayloadEnvelopesByRootRequestItems<E> {
+    pub fn new(request: PayloadEnvelopesByRootSingleRequest) -> Self {
+        Self {
+            request,
+            items: vec![],
+        }
+    }
+}
+
+impl<E: EthSpec> ActiveRequestItems for PayloadEnvelopesByRootRequestItems<E> {
+    type Item = Arc<SignedExecutionPayloadEnvelope<E>>;
+
+    /// Append a response to the single chunk request. If the chunk is valid, the request is
+    /// resolved immediately.
+    /// The active request SHOULD be dropped after `add_response` returns an error
+    fn add(&mut self, envelope: Self::Item) -> Result<bool, LookupVerifyError> {
+        let beacon_block_root = envelope.beacon_block_root();
+        if self.request.0 != beacon_block_root {
+            return Err(LookupVerifyError::UnrequestedBlockRoot(beacon_block_root));
+        }
+
+        self.items.push(envelope);
+        // Always returns true, payload envelopes by root expects a single response
+        Ok(true)
+    }
+
+    fn consume(&mut self) -> Vec<Self::Item> {
+        std::mem::take(&mut self.items)
+    }
+}

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1910,9 +1910,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         // far in the case of a long skip. We could optimise this in future using the
         // `diff_base_state` (like in `get_ancestor_state_root`), or by doing a proper DB
         // migration.
-        let previous_state_summary = self
-            .load_hot_state_summary(&previous_state_root)?
-            .ok_or(Error::MissingHotStateSummary(previous_state_root))?;
+        let Some(previous_state_summary) = self.load_hot_state_summary(&previous_state_root)?
+        else {
+            // During checkpoint sync we only store a single state, so the previous state
+            // summary may not exist. Default to Pending — checkpoint states are always
+            // at epoch boundaries which are Pending states.
+            return Ok(StatePayloadStatus::Pending);
+        };
 
         if previous_state_summary.slot == summary.slot {
             Ok(StatePayloadStatus::Full)

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -593,7 +593,11 @@ impl ProtoArray {
             // Without `payload_received = true` on genesis, the FULL virtual
             // child doesn't exist in the spec's `get_node_children`, making all
             // Full concrete children of genesis unreachable in `get_head`.
-            let is_genesis = parent_index.is_none();
+            //
+            // Use slot == 0 to distinguish actual genesis from checkpoint sync anchors.
+            // Checkpoint sync anchors also have no parent, but their state is Pending
+            // (we don't download the Full state), so payload_received must be false.
+            let is_genesis = parent_index.is_none() && block.slot == 0;
 
             ProtoNode::V29(ProtoNodeV29 {
                 slot: block.slot,

--- a/epbs-local-devnet.yaml
+++ b/epbs-local-devnet.yaml
@@ -1,0 +1,37 @@
+# Local ePBS devnet - mainnet preset but with 4s slots for speed
+# 32 slots/epoch * 4s/slot = 128s/epoch. Gloas at epoch 2 = ~4.3min. Finalized ~8.5min.
+
+participants:
+  - el_type: geth
+    el_image: ethpandaops/geth:epbs-devnet-1
+    cl_type: prysm
+    cl_image: ethpandaops/prysm-beacon-chain:epbs-devnet-1
+    vc_type: prysm
+    vc_image: ethpandaops/prysm-validator:epbs-devnet-1
+    count: 2
+    supernode: true
+
+network_params:
+  deneb_fork_epoch: 0
+  electra_fork_epoch: 0
+  fulu_fork_epoch: 0
+  gloas_fork_epoch: 2
+  genesis_delay: 20
+  seconds_per_slot: 4
+  num_validator_keys_per_node: 32
+
+additional_services:
+  - checkpointz
+
+checkpointz_params:
+  image: "ethpandaops/checkpointz:0.0.15-gloas-debian"
+
+port_publisher:
+  cl:
+    enabled: true
+  el:
+    enabled: true
+  additional_services:
+    enabled: true
+
+disable_peer_scoring: true

--- a/epbs-local-devnet.yaml
+++ b/epbs-local-devnet.yaml
@@ -5,7 +5,11 @@ participants:
   - el_type: geth
     el_image: ethpandaops/geth:epbs-devnet-1
     cl_type: prysm
-    cl_image: ethpandaops/prysm-beacon-chain:epbs-devnet-1
+    cl_image: prysm-beacon-patched
+    cl_extra_params:
+      - --p2p-colocation-whitelist=0.0.0.0/0
+      - --block-batch-limit=128
+      - --block-batch-limit-burst-factor=8
     vc_type: prysm
     vc_image: ethpandaops/prysm-validator:epbs-devnet-1
     count: 2


### PR DESCRIPTION
## Summary

Makes Lighthouse checkpoint sync and range sync work with ePBS/Gloas by downloading and applying execution payload envelopes.

### Changes

- **Checkpoint sync**: Download envelope from checkpoint server, store in DB, patch state for child validation
- **PayloadEnvelopesByRoot**: Wire single block lookup envelope requests through the sync layer
- **PayloadEnvelopesByRange**: Download envelopes alongside blocks during range sync, couple them in the batch pipeline, pre-store in DB before block processing
- **load_parent Full state derivation**: When Full state isn't cached, derive it from Pending + envelope via `process_execution_payload_envelope`
- **Status message fix**: Use state's finalized checkpoint (not fork choice's inflated anchor epoch) during checkpoint sync
- **--ignore-ws-check fix**: Actually skip the WS period error when flag is set

### Test results (local Kurtosis ePBS devnet, 2 Prysm + 2 Geth, 4s slots)

- Checkpoint sync initializes correctly with envelope
- Range sync imports blocks with zero `StateRootMismatch` errors
- Envelope state root verification passes
- Peers drop due to Prysm rate limiting (only 2 peers) before reaching head
- Lookup sync wired but untested (needs to reach head first)

### Known issues

- Prysm's `CollocationLimit=5` blocks connections from IPs with >5 stored peer IDs (use `--p2p-colocation-whitelist=0.0.0.0/0`)
- Rate limiting with few peers causes disconnections during range sync