### PR TITLE
Add fast_confirmation SSE event (beacon-APIs#598)

### DIFF
--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -763,14 +763,35 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     metrics::set_gauge(&metrics::FCR_CONFIRMATION_DELAY_SLOTS, delay as i64);
                 }
                 if confirmed_root_changed
-                    && let Some(confirmed_slot) = confirmed_slot_opt
+                    && confirmed_slot_opt.is_some()
                     && let Some(event_handler) = self.event_handler.as_ref()
                     && event_handler.has_fast_confirmation_subscribers()
                 {
-                    event_handler.register(EventKind::FastConfirmation(SseFastConfirmation {
-                        block: fcr.confirmed_root,
-                        slot: confirmed_slot,
-                    }));
+                    // Emit one event per newly-confirmed block, oldest-to-newest, so
+                    // consumers see every slot FCR advanced over (not just the tip). The
+                    // depth cap bounds the rare case where old_confirmed is not in
+                    // proto_array (e.g., pruned across a restart).
+                    const MAX_CHAIN_DEPTH: usize = 4096;
+                    let old_confirmed_slot = proto_array
+                        .indices
+                        .get(&old_confirmed)
+                        .and_then(|&idx| proto_array.nodes.get(idx))
+                        .map(|n| n.slot());
+                    let mut newly_confirmed: Vec<(Hash256, Slot)> = proto_array
+                        .iter_block_roots(&fcr.confirmed_root)
+                        .take(MAX_CHAIN_DEPTH)
+                        .take_while(|(root, slot)| match old_confirmed_slot {
+                            Some(old_slot) => *slot > old_slot,
+                            None => *root != old_confirmed,
+                        })
+                        .collect();
+                    newly_confirmed.reverse();
+                    for (block, slot) in newly_confirmed {
+                        event_handler.register(EventKind::FastConfirmation(SseFastConfirmation {
+                            block,
+                            slot,
+                        }));
+                    }
                 }
                 let balance_epoch = fcr.current_balance_source.checkpoint.epoch;
                 let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -46,8 +46,7 @@ use crate::{
     validator_monitor::get_slot_delay_ms,
 };
 use eth2::types::{
-    EventKind, SseChainReorg, SseFastConfirmation, SseFastConfirmationBlock,
-    SseFinalizedCheckpoint, SseLateHead,
+    EventKind, SseChainReorg, SseFastConfirmation, SseFinalizedCheckpoint, SseLateHead,
 };
 use fork_choice::{
     ExecutionStatus, ForkChoiceStore, ForkChoiceView, ForkchoiceUpdateParameters, PayloadStatus,
@@ -768,29 +767,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     && let Some(event_handler) = self.event_handler.as_ref()
                     && event_handler.has_fast_confirmation_subscribers()
                 {
-                    // Walk back through ancestors of the new confirmed_root, taking blocks
-                    // newer than old_confirmed. The cap bounds the rare case where
-                    // old_confirmed is not in proto_array (e.g., pruned across a restart).
-                    const MAX_CHAIN_DEPTH: usize = 4096;
-                    let old_confirmed_slot = proto_array
-                        .indices
-                        .get(&old_confirmed)
-                        .and_then(|&idx| proto_array.nodes.get(idx))
-                        .map(|n| n.slot());
-                    let mut chain: Vec<SseFastConfirmationBlock> = proto_array
-                        .iter_block_roots(&fcr.confirmed_root)
-                        .take(MAX_CHAIN_DEPTH)
-                        .take_while(|(root, slot)| match old_confirmed_slot {
-                            Some(old_slot) => *slot > old_slot,
-                            None => *root != old_confirmed,
-                        })
-                        .map(|(block, slot)| SseFastConfirmationBlock { block, slot })
-                        .collect();
-                    chain.reverse();
                     event_handler.register(EventKind::FastConfirmation(SseFastConfirmation {
                         block: fcr.confirmed_root,
                         slot: confirmed_slot,
-                        chain,
                     }));
                 }
                 let balance_epoch = fcr.current_balance_source.checkpoint.epoch;

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -46,7 +46,8 @@ use crate::{
     validator_monitor::get_slot_delay_ms,
 };
 use eth2::types::{
-    EventKind, SseChainReorg, SseFastConfirmation, SseFinalizedCheckpoint, SseLateHead,
+    EventKind, SseChainReorg, SseFastConfirmation, SseFastConfirmationBlock,
+    SseFinalizedCheckpoint, SseLateHead,
 };
 use fork_choice::{
     ExecutionStatus, ForkChoiceStore, ForkChoiceView, ForkchoiceUpdateParameters, PayloadStatus,
@@ -767,9 +768,29 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     && let Some(event_handler) = self.event_handler.as_ref()
                     && event_handler.has_fast_confirmation_subscribers()
                 {
+                    // Walk back through ancestors of the new confirmed_root, taking blocks
+                    // newer than old_confirmed. The cap bounds the rare case where
+                    // old_confirmed is not in proto_array (e.g., pruned across a restart).
+                    const MAX_CHAIN_DEPTH: usize = 4096;
+                    let old_confirmed_slot = proto_array
+                        .indices
+                        .get(&old_confirmed)
+                        .and_then(|&idx| proto_array.nodes.get(idx))
+                        .map(|n| n.slot());
+                    let mut chain: Vec<SseFastConfirmationBlock> = proto_array
+                        .iter_block_roots(&fcr.confirmed_root)
+                        .take(MAX_CHAIN_DEPTH)
+                        .take_while(|(root, slot)| match old_confirmed_slot {
+                            Some(old_slot) => *slot > old_slot,
+                            None => *root != old_confirmed,
+                        })
+                        .map(|(block, slot)| SseFastConfirmationBlock { block, slot })
+                        .collect();
+                    chain.reverse();
                     event_handler.register(EventKind::FastConfirmation(SseFastConfirmation {
                         block: fcr.confirmed_root,
                         slot: confirmed_slot,
+                        chain,
                     }));
                 }
                 let balance_epoch = fcr.current_balance_source.checkpoint.epoch;

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -45,7 +45,9 @@ use crate::{
     metrics,
     validator_monitor::get_slot_delay_ms,
 };
-use eth2::types::{EventKind, SseChainReorg, SseFinalizedCheckpoint, SseLateHead};
+use eth2::types::{
+    EventKind, SseChainReorg, SseFastConfirmation, SseFinalizedCheckpoint, SseLateHead,
+};
 use fork_choice::{
     ExecutionStatus, ForkChoiceStore, ForkChoiceView, ForkchoiceUpdateParameters, PayloadStatus,
     ProtoBlock, ResetPayloadStatuses,
@@ -741,15 +743,16 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 let label: &'static str = (&e).into();
                 metrics::inc_counter_vec(&metrics::FCR_ERRORS, &[label]);
             } else {
-                if fcr.confirmed_root != old_confirmed {
+                let confirmed_root_changed = fcr.confirmed_root != old_confirmed;
+                if confirmed_root_changed {
                     metrics::inc_counter(&metrics::FCR_CONFIRMED_ROOT_CHANGES);
                 }
-                if let Some(confirmed_slot) = proto_array
+                let confirmed_slot_opt = proto_array
                     .indices
                     .get(&fcr.confirmed_root)
                     .and_then(|&idx| proto_array.nodes.get(idx))
-                    .map(|n| n.slot())
-                {
+                    .map(|n| n.slot());
+                if let Some(confirmed_slot) = confirmed_slot_opt {
                     metrics::set_gauge(
                         &metrics::FCR_CONFIRMED_ROOT_SLOT,
                         confirmed_slot.as_u64() as i64,
@@ -758,6 +761,16 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                         .as_u64()
                         .saturating_sub(confirmed_slot.as_u64());
                     metrics::set_gauge(&metrics::FCR_CONFIRMATION_DELAY_SLOTS, delay as i64);
+                }
+                if confirmed_root_changed
+                    && let Some(confirmed_slot) = confirmed_slot_opt
+                    && let Some(event_handler) = self.event_handler.as_ref()
+                    && event_handler.has_fast_confirmation_subscribers()
+                {
+                    event_handler.register(EventKind::FastConfirmation(SseFastConfirmation {
+                        block: fcr.confirmed_root,
+                        slot: confirmed_slot,
+                    }));
                 }
                 let balance_epoch = fcr.current_balance_source.checkpoint.epoch;
                 let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());

--- a/beacon_node/beacon_chain/src/events.rs
+++ b/beacon_node/beacon_chain/src/events.rs
@@ -30,6 +30,7 @@ pub struct ServerSentEventHandler<E: EthSpec> {
     execution_payload_available_tx: Sender<EventKind<E>>,
     execution_payload_bid_tx: Sender<EventKind<E>>,
     payload_attestation_message_tx: Sender<EventKind<E>>,
+    fast_confirmation_tx: Sender<EventKind<E>>,
 }
 
 impl<E: EthSpec> ServerSentEventHandler<E> {
@@ -61,6 +62,7 @@ impl<E: EthSpec> ServerSentEventHandler<E> {
         let (execution_payload_available_tx, _) = broadcast::channel(capacity);
         let (execution_payload_bid_tx, _) = broadcast::channel(capacity);
         let (payload_attestation_message_tx, _) = broadcast::channel(capacity);
+        let (fast_confirmation_tx, _) = broadcast::channel(capacity);
 
         Self {
             attestation_tx,
@@ -86,6 +88,7 @@ impl<E: EthSpec> ServerSentEventHandler<E> {
             execution_payload_available_tx,
             execution_payload_bid_tx,
             payload_attestation_message_tx,
+            fast_confirmation_tx,
         }
     }
 
@@ -190,6 +193,10 @@ impl<E: EthSpec> ServerSentEventHandler<E> {
                 .payload_attestation_message_tx
                 .send(kind)
                 .map(|count| log_count("payload attestation message", count)),
+            EventKind::FastConfirmation(_) => self
+                .fast_confirmation_tx
+                .send(kind)
+                .map(|count| log_count("fast confirmation", count)),
         };
         if let Err(SendError(event)) = result {
             trace!(?event, "No receivers registered to listen for event");
@@ -288,6 +295,10 @@ impl<E: EthSpec> ServerSentEventHandler<E> {
         self.payload_attestation_message_tx.subscribe()
     }
 
+    pub fn subscribe_fast_confirmation(&self) -> Receiver<EventKind<E>> {
+        self.fast_confirmation_tx.subscribe()
+    }
+
     pub fn has_attestation_subscribers(&self) -> bool {
         self.attestation_tx.receiver_count() > 0
     }
@@ -370,5 +381,9 @@ impl<E: EthSpec> ServerSentEventHandler<E> {
 
     pub fn has_payload_attestation_message_subscribers(&self) -> bool {
         self.payload_attestation_message_tx.receiver_count() > 0
+    }
+
+    pub fn has_fast_confirmation_subscribers(&self) -> bool {
+        self.fast_confirmation_tx.receiver_count() > 0
     }
 }

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -3244,6 +3244,9 @@ pub fn serve<T: BeaconChainTypes>(
                                 api_types::EventTopic::PayloadAttestationMessage => {
                                     event_handler.subscribe_payload_attestation_message()
                                 }
+                                api_types::EventTopic::FastConfirmation => {
+                                    event_handler.subscribe_fast_confirmation()
+                                }
                             };
 
                             receivers.push(

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1073,6 +1073,12 @@ pub struct BlockGossip {
     pub slot: Slot,
     pub block: Hash256,
 }
+
+#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+pub struct SseFastConfirmation {
+    pub block: Hash256,
+    pub slot: Slot,
+}
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
 pub struct SseExecutionPayload {
     pub slot: Slot,
@@ -1245,6 +1251,7 @@ pub enum EventKind<E: EthSpec> {
     ExecutionPayloadAvailable(SseExecutionPayloadAvailable),
     ExecutionPayloadBid(Box<VersionedSseExecutionPayloadBid<E>>),
     PayloadAttestationMessage(Box<VersionedSsePayloadAttestationMessage>),
+    FastConfirmation(SseFastConfirmation),
 }
 
 impl<E: EthSpec> EventKind<E> {
@@ -1273,6 +1280,7 @@ impl<E: EthSpec> EventKind<E> {
             EventKind::ExecutionPayloadAvailable(_) => "execution_payload_available",
             EventKind::ExecutionPayloadBid(_) => "execution_payload_bid",
             EventKind::PayloadAttestationMessage(_) => "payload_attestation_message",
+            EventKind::FastConfirmation(_) => "fast_confirmation",
         }
     }
 
@@ -1396,6 +1404,11 @@ impl<E: EthSpec> EventKind<E> {
                     ))
                 })?,
             ))),
+            "fast_confirmation" => Ok(EventKind::FastConfirmation(
+                serde_json::from_str(data).map_err(|e| {
+                    ServerError::InvalidServerSentEvent(format!("Fast Confirmation: {:?}", e))
+                })?,
+            )),
             _ => Err(ServerError::InvalidServerSentEvent(
                 "Could not parse event tag".to_string(),
             )),
@@ -1436,6 +1449,7 @@ pub enum EventTopic {
     ExecutionPayloadAvailable,
     ExecutionPayloadBid,
     PayloadAttestationMessage,
+    FastConfirmation,
 }
 
 impl FromStr for EventTopic {
@@ -1466,6 +1480,7 @@ impl FromStr for EventTopic {
             "execution_payload_available" => Ok(EventTopic::ExecutionPayloadAvailable),
             "execution_payload_bid" => Ok(EventTopic::ExecutionPayloadBid),
             "payload_attestation_message" => Ok(EventTopic::PayloadAttestationMessage),
+            "fast_confirmation" => Ok(EventTopic::FastConfirmation),
             _ => Err("event topic cannot be parsed.".to_string()),
         }
     }
@@ -1501,6 +1516,7 @@ impl fmt::Display for EventTopic {
             EventTopic::PayloadAttestationMessage => {
                 write!(f, "payload_attestation_message")
             }
+            EventTopic::FastConfirmation => write!(f, "fast_confirmation"),
         }
     }
 }

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1075,20 +1075,9 @@ pub struct BlockGossip {
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
-pub struct SseFastConfirmationBlock {
-    pub block: Hash256,
-    pub slot: Slot,
-}
-
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
 pub struct SseFastConfirmation {
     pub block: Hash256,
     pub slot: Slot,
-    /// Blocks newly confirmed by this advancement, ordered oldest-to-newest.
-    /// The last entry equals `{block, slot}`; the first entry's parent is the
-    /// previous confirmed root (or the finalized root on FCR reset).
-    #[serde(default)]
-    pub chain: Vec<SseFastConfirmationBlock>,
 }
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
 pub struct SseExecutionPayload {

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1075,9 +1075,20 @@ pub struct BlockGossip {
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+pub struct SseFastConfirmationBlock {
+    pub block: Hash256,
+    pub slot: Slot,
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
 pub struct SseFastConfirmation {
     pub block: Hash256,
     pub slot: Slot,
+    /// Blocks newly confirmed by this advancement, ordered oldest-to-newest.
+    /// The last entry equals `{block, slot}`; the first entry's parent is the
+    /// previous confirmed root (or the finalized root on FCR reset).
+    #[serde(default)]
+    pub chain: Vec<SseFastConfirmationBlock>,
 }
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
 pub struct SseExecutionPayload {


### PR DESCRIPTION
Implements [beacon-APIs#598](https://github.com/ethereum/beacon-APIs/pull/598) — a `fast_confirmation` event on `/eth/v1/events?topics=fast_confirmation` that fires whenever FCR advances `confirmed_root`. Payload follows the spec verbatim: `{"block": "0x...", "slot": "N"}`.

When FCR advances over more than one slot in a single pass (e.g. a late block missed quorum in slot N, then slot N+1's attestations confirm both), we walk the ancestors from the previous confirmed_root to the new one and fire one event per block in chronological order, so consumers see every confirmed slot without having to maintain their own tree of unconfirmed blocks. Walk is bounded to 4096 ancestors as a safety cap for the pruned-old-root edge case.

Registered inside the existing FCR OK branch in `canonical_head.rs` (gated on `has_fast_confirmation_subscribers` so it costs nothing when nobody's listening), with the usual EventTopic/EventKind/broadcast-channel/http_api plumbing. Deployed on a mainnet observer node and confirmed firing every slot.