### PR TITLE
Add static file storage crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8655,6 +8655,7 @@ name = "static_file_storage"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "libc",
  "parking_lot",
  "rand 0.9.2",
  "rand_xorshift 0.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8651,6 +8651,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "static_file_storage"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "parking_lot",
+ "rand 0.9.2",
+ "rand_xorshift 0.4.0",
+ "tempfile",
+]
+
+[[package]]
 name = "store"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "common/oneshot_broadcast",
     "common/pretty_reqwest_error",
     "common/slot_clock",
+    "common/static_file_storage",
     "common/system_health",
     "common/target_check",
     "common/task_executor",

--- a/common/static_file_storage/Cargo.toml
+++ b/common/static_file_storage/Cargo.toml
@@ -6,6 +6,9 @@ edition = { workspace = true }
 [dependencies]
 parking_lot = { workspace = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 criterion = { workspace = true }
 rand = { workspace = true }

--- a/common/static_file_storage/Cargo.toml
+++ b/common/static_file_storage/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "static_file_storage"
+version = "0.1.0"
+edition = { workspace = true }
+
+[dependencies]
+parking_lot = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true }
+rand = { workspace = true }
+rand_xorshift = { workspace = true }
+tempfile = { workspace = true }
+
+[[bench]]
+name = "large_writes"
+harness = false

--- a/common/static_file_storage/benches/large_writes.rs
+++ b/common/static_file_storage/benches/large_writes.rs
@@ -96,7 +96,7 @@ fn bench_put_batch(c: &mut Criterion) {
                     (dir, sf, values.clone())
                 },
                 |(_dir, sf, items)| {
-                    sf.put_batch(borrowed_items(&items)).expect("put_batch");
+                    sf.put_batch(&borrowed_items(&items)).expect("put_batch");
                 },
                 BatchSize::PerIteration,
             );

--- a/common/static_file_storage/benches/large_writes.rs
+++ b/common/static_file_storage/benches/large_writes.rs
@@ -4,10 +4,9 @@
 //! state-diff records. Callers are expected to pre-compress payloads if they
 //! want compression; this benchmark measures only static storage write cost.
 //!
-//! Each iteration fixtures a fresh temp directory: this measures the first
-//! batch into an empty store (file creation included); open/heal cost is
-//! excluded by the setup closure. Point TMPDIR at a real disk — on tmpfs
-//! fsyncs are nearly free and the dominant cost disappears.
+//! Fresh temp dir per iteration: measures the first batch into an empty
+//! store (open/heal excluded). Point TMPDIR at a real disk — tmpfs makes
+//! fsyncs free.
 //!
 //! Run with: `cargo bench -p static_file_storage --bench large_writes`.
 

--- a/common/static_file_storage/benches/large_writes.rs
+++ b/common/static_file_storage/benches/large_writes.rs
@@ -4,8 +4,10 @@
 //! state-diff records. Callers are expected to pre-compress payloads if they
 //! want compression; this benchmark measures only static storage write cost.
 //!
-//! Each iteration fixtures a fresh temp directory so the bench measures
-//! steady-state put cost, not first-open or healing overhead.
+//! Each iteration fixtures a fresh temp directory: this measures the first
+//! batch into an empty store (file creation included); open/heal cost is
+//! excluded by the setup closure. Point TMPDIR at a real disk — on tmpfs
+//! fsyncs are nearly free and the dominant cost disappears.
 //!
 //! Run with: `cargo bench -p static_file_storage --bench large_writes`.
 

--- a/common/static_file_storage/benches/large_writes.rs
+++ b/common/static_file_storage/benches/large_writes.rs
@@ -1,0 +1,109 @@
+//! Benchmarks for the write path under ERA-load-shaped record sizes.
+//!
+//! The targeted profile is mainnet ERA import: ~10–30 MB state-snapshot and
+//! state-diff records. Callers are expected to pre-compress payloads if they
+//! want compression; this benchmark measures only static storage write cost.
+//!
+//! Each iteration fixtures a fresh temp directory so the bench measures
+//! steady-state put cost, not first-open or healing overhead.
+//!
+//! Run with: `cargo bench -p static_file_storage --bench large_writes`.
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use rand::{RngCore, SeedableRng};
+use rand_xorshift::XorShiftRng;
+use static_file_storage::{SLOTS_PER_FILE, StaticFile};
+use std::hint::black_box;
+use std::path::PathBuf;
+
+const RECORD_30MB: usize = 30 * 1024 * 1024;
+const RECORD_4MB: usize = 4 * 1024 * 1024;
+const RECORD_1KB: usize = 1024;
+
+const MAX_VALUE_BYTES: u64 = 1024 * 1024 * 1024;
+
+fn payload(seed: u64, len: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; len];
+    XorShiftRng::seed_from_u64(seed).fill_bytes(&mut buf);
+    buf
+}
+
+fn fresh_dir() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_path_buf();
+    (dir, path)
+}
+
+fn borrowed_items(values: &[(u64, Vec<u8>)]) -> Vec<(u64, &[u8])> {
+    values
+        .iter()
+        .map(|(slot, value)| (*slot, value.as_slice()))
+        .collect()
+}
+
+fn batch_values(start_slot: u64, count: u64, record_size: usize) -> Vec<(u64, Vec<u8>)> {
+    (0..count)
+        .map(|i| {
+            let slot = start_slot + i;
+            (slot, payload(slot, record_size))
+        })
+        .collect()
+}
+
+fn bench_put_single_30mb(c: &mut Criterion) {
+    let value = payload(1, RECORD_30MB);
+    let mut group = c.benchmark_group("put_single_30mb");
+    group.sample_size(20);
+    group.throughput(Throughput::Bytes(RECORD_30MB as u64));
+    group.bench_function("put", |b| {
+        b.iter_batched(
+            || {
+                let (dir, path) = fresh_dir();
+                let sf = StaticFile::open(path, MAX_VALUE_BYTES).expect("open");
+                (dir, sf)
+            },
+            |(_dir, sf)| {
+                sf.put(0, black_box(&value)).expect("put");
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+}
+
+fn bench_put_batch(c: &mut Criterion) {
+    for (name, start_slot, count, record_size, sample_size) in [
+        ("eight_30mb_one_file", 0, 8, RECORD_30MB, 20),
+        (
+            "32_records_4mb_cross_file",
+            SLOTS_PER_FILE - 16,
+            32,
+            RECORD_4MB,
+            20,
+        ),
+        ("two_full_files_1kb", 0, SLOTS_PER_FILE * 2, RECORD_1KB, 10),
+    ] {
+        let values = batch_values(start_slot, count, record_size);
+        let total_bytes = count * record_size as u64;
+        let mut group = c.benchmark_group(format!("put_batch_{name}"));
+        group.sample_size(sample_size);
+        group.throughput(Throughput::Bytes(total_bytes));
+        group.bench_function("put_batch", |b| {
+            b.iter_batched(
+                || {
+                    let (dir, path) = fresh_dir();
+                    let sf = StaticFile::open(path, MAX_VALUE_BYTES).expect("open");
+                    (dir, sf, values.clone())
+                },
+                |(_dir, sf, items)| {
+                    sf.put_batch(borrowed_items(&items)).expect("put_batch");
+                },
+                BatchSize::PerIteration,
+            );
+        });
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_put_single_30mb, bench_put_batch,);
+criterion_main!(benches);

--- a/common/static_file_storage/src/lib.rs
+++ b/common/static_file_storage/src/lib.rs
@@ -22,7 +22,8 @@
 //! Durable on return. Slots arrive ascending **or** are identical-value
 //! re-puts of an already-committed slot (so migration retries after a
 //! mid-loop crash are safe). Previously-skipped slots (offset 0) cannot
-//! be filled — that would break the append-only data file.
+//! be filled — that would break the append-only data file. A failed write
+//! poisons the handle: further writes error until reopen; reads stay live.
 //!
 //! # Recovery on open
 //!
@@ -102,10 +103,18 @@ pub struct StaticFile {
     root_dir: PathBuf,
     /// Max record size, an OOM guard on reads.
     max_value_bytes: u64,
-    /// Highest committed slot and committed data length from `column.conf`.
     // Writer holds this across put_batch's fsyncs, so readers block. Accepted:
     // simplicity over read concurrency.
-    committed: Mutex<CommittedState>,
+    state: Mutex<State>,
+}
+
+#[derive(Debug)]
+struct State {
+    /// Highest committed slot and committed data length from `column.conf`.
+    committed: CommittedState,
+    /// Set when a write error leaves on-disk state unverified; further writes
+    /// error until reopen. Reads stay safe: `committed` never runs ahead of disk.
+    poisoned: bool,
 }
 
 impl StaticFile {
@@ -137,7 +146,10 @@ impl StaticFile {
         let handle = Self {
             root_dir,
             max_value_bytes,
-            committed: Mutex::new(committed),
+            state: Mutex::new(State {
+                committed,
+                poisoned: false,
+            }),
         };
         handle.heal_to_marker(committed.highest_slot, committed.data_len)?;
         Ok(handle)
@@ -145,7 +157,7 @@ impl StaticFile {
 
     /// Slot of the most recently committed record, if any.
     fn highest_written_slot(&self) -> Option<u64> {
-        self.committed.lock().highest_slot
+        self.state.lock().committed.highest_slot
     }
 
     /// Read the record at `slot`, if present.
@@ -194,8 +206,13 @@ impl StaticFile {
             return Err(Error::Invalid("slot u64::MAX is reserved".into()));
         }
 
-        let mut committed = self.committed.lock();
-        let start = self.skip_committed_prefix(&items, committed.highest_slot)?;
+        let mut state = self.state.lock();
+        if state.poisoned {
+            return Err(Error::Invalid(
+                "writes rejected after an earlier write failure; reopen to heal".into(),
+            ));
+        }
+        let start = self.skip_committed_prefix(&items, state.committed.highest_slot)?;
         if start == items.len() {
             // Avoid rewriting config with no fresh data_len.
             return Ok(());
@@ -203,30 +220,26 @@ impl StaticFile {
 
         // Group remaining items by file_id, write each group with one
         // data fsync + one offset fsync. Single config commit at end of batch.
+        // Fail-stop: any error past this point leaves on-disk state unverified
+        // (stale offsets, or a conf rename that landed despite the Err), so
+        // poison writes and let open-time healing recover. Reads stay safe:
+        // `committed` never runs ahead of disk.
         let mut last_data_len: u64 = 0;
         for (target_file_id, group) in group_by_file_id(&items[start..]) {
-            match self.write_group(target_file_id, &group, *committed) {
+            match self.write_group(target_file_id, &group, state.committed) {
                 Ok(data_len) => last_data_len = data_len,
                 Err(e) => {
-                    // Reconcile after partial write.
-                    if let Ok(config_committed) = self.heal_from_config() {
-                        *committed = config_committed;
-                    }
+                    state.poisoned = true;
                     return Err(e);
                 }
             }
         }
 
         if let Err(e) = self.write_config(Some(*last_slot), last_data_len) {
-            // Edge: rename may have landed, so the batch can be durable despite this
-            // Err; safe because retry is idempotent. heal error is swallowed here;
-            // next open re-heals.
-            if let Ok(config_committed) = self.heal_from_config() {
-                *committed = config_committed;
-            }
+            state.poisoned = true;
             return Err(e);
         }
-        *committed = CommittedState {
+        state.committed = CommittedState {
             highest_slot: Some(*last_slot),
             data_len: last_data_len,
         };
@@ -385,13 +398,6 @@ impl StaticFile {
         } else {
             self.remove_uncommitted_files(None)
         }
-    }
-
-    /// Re-read `column.conf` and restore files to whatever marker is durable.
-    fn heal_from_config(&self) -> Result<CommittedState, Error> {
-        let committed = deserialize_on_disk_config(&fs::read(self.config_path())?)?;
-        self.heal_to_marker(committed.highest_slot, committed.data_len)?;
-        Ok(committed)
     }
 
     /// Truncate the committed file back to the config marker after a crash.
@@ -700,6 +706,26 @@ mod tests {
     fn max_slot_is_reserved() {
         let dir = tempfile::tempdir().unwrap();
         assert!(open(&dir).put(u64::MAX, b"x").is_err());
+    }
+
+    #[test]
+    fn write_failure_poisons_writes_until_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir);
+        store.put(0, b"a").unwrap();
+
+        let oversized = vec![0u8; (MAX_VALUE_BYTES + 1) as usize];
+        assert!(store.put_batch(vec![(1, b"b"), (2, &oversized)]).is_err());
+
+        // writes rejected, reads still served
+        assert!(store.put(3, b"c").is_err());
+        assert_eq!(store.get(0).unwrap(), Some(b"a".to_vec()));
+
+        // reopen heals and lifts the poison
+        drop(store);
+        let store = open(&dir);
+        store.put(3, b"c").unwrap();
+        assert_eq!(store.get(3).unwrap(), Some(b"c".to_vec()));
     }
 
     #[test]

--- a/common/static_file_storage/src/lib.rs
+++ b/common/static_file_storage/src/lib.rs
@@ -234,6 +234,15 @@ impl StaticFile {
         if *last_slot == EMPTY_SLOT {
             return Err(Error::Invalid("slot u64::MAX is reserved".into()));
         }
+        // Reject oversized records before any mutation: a caller mistake must
+        // not poison the store.
+        for (slot, value) in items {
+            if (value.len() as u64) > self.max_value_bytes || u32::try_from(value.len()).is_err() {
+                return Err(Error::Invalid(format!(
+                    "record at slot {slot} exceeds size limit"
+                )));
+            }
+        }
 
         let mut state = self.state.lock();
         if state.poisoned {
@@ -353,9 +362,7 @@ impl StaticFile {
             let mut writer = std::io::BufWriter::with_capacity(1 << 20, &mut data_file);
             let mut next_offset = cursor;
             for &(slot, value) in group {
-                if (value.len() as u64) > self.max_value_bytes {
-                    return Err(Error::Invalid("record exceeds size limit".into()));
-                }
+                // Sizes pre-validated by put_batch.
                 let payload_len = u32::try_from(value.len())
                     .map_err(|_| Error::Invalid("record too large".into()))?;
                 offsets.push((slot, next_offset));
@@ -762,8 +769,14 @@ mod tests {
         let store = open(&dir);
         store.put(0, b"a").unwrap();
 
-        let oversized = vec![0u8; (MAX_VALUE_BYTES + 1) as usize];
-        assert!(store.put_batch(&[(1, b"b"), (2, &oversized)]).is_err());
+        // Force a real write error: swap the data file for a directory.
+        let data_path = dir.path().join("data_00000");
+        let orig = fs::read(&data_path).unwrap();
+        fs::remove_file(&data_path).unwrap();
+        fs::create_dir(&data_path).unwrap();
+        assert!(store.put(1, b"b").is_err());
+        fs::remove_dir(&data_path).unwrap();
+        fs::write(&data_path, &orig).unwrap();
 
         // writes rejected, reads still served
         assert!(store.put(3, b"c").is_err());
@@ -774,6 +787,62 @@ mod tests {
         let store = open(&dir);
         store.put(3, b"c").unwrap();
         assert_eq!(store.get(3).unwrap(), Some(b"c".to_vec()));
+    }
+
+    #[test]
+    fn oversized_put_rejected_without_poisoning() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir);
+        let oversized = vec![0u8; (MAX_VALUE_BYTES + 1) as usize];
+        assert!(store.put(0, &oversized).is_err());
+        // caller mistake, not a write failure: store stays usable
+        store.put(0, b"a").unwrap();
+        assert_eq!(store.get(0).unwrap(), Some(b"a".to_vec()));
+    }
+
+    #[test]
+    fn corrupt_conf_rejected_on_open() {
+        let dir = tempfile::tempdir().unwrap();
+        open(&dir).put(0, b"a").unwrap();
+        let conf_path = dir.path().join("column.conf");
+        let good = fs::read(&conf_path).unwrap();
+
+        for bad in [
+            {
+                let mut b = good.clone();
+                b[0] ^= 0xff; // magic
+                b
+            },
+            {
+                let mut b = good.clone();
+                b[4] ^= 0xff; // version
+                b
+            },
+            good[..good.len() - 1].to_vec(), // length
+        ] {
+            fs::write(&conf_path, &bad).unwrap();
+            assert!(StaticFile::open(dir.path().to_path_buf(), MAX_VALUE_BYTES).is_err());
+        }
+
+        fs::write(&conf_path, &good).unwrap();
+        assert_eq!(open(&dir).get(0).unwrap(), Some(b"a".to_vec()));
+    }
+
+    #[test]
+    fn cannot_fill_skipped_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir);
+        store.put(10, b"a").unwrap();
+        assert!(store.put(5, b"b").is_err());
+    }
+
+    #[test]
+    fn empty_value_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir);
+        store.put(0, b"").unwrap();
+        assert_eq!(store.get(0).unwrap(), Some(vec![]));
+        assert!(store.contains(0).unwrap());
     }
 
     #[test]

--- a/common/static_file_storage/src/lib.rs
+++ b/common/static_file_storage/src/lib.rs
@@ -71,6 +71,13 @@ struct CommittedState {
 #[derive(Debug)]
 pub enum Error {
     Io(io::Error),
+    /// Writes rejected after an earlier write failure; reopen to heal.
+    Poisoned,
+    /// Another handle holds the column lock.
+    AlreadyOpen(PathBuf),
+    /// On-disk state failed validation — repair or rebuild.
+    Corrupt(String),
+    /// Caller contract violation; state unchanged.
     Invalid(String),
 }
 
@@ -78,6 +85,16 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Io(e) => write!(f, "static file io error: {e}"),
+            Self::Poisoned => {
+                write!(
+                    f,
+                    "writes rejected after an earlier write failure; reopen to heal"
+                )
+            }
+            Self::AlreadyOpen(path) => {
+                write!(f, "already open by another handle: {}", path.display())
+            }
+            Self::Corrupt(message) => write!(f, "static file corrupt: {message}"),
             Self::Invalid(message) => write!(f, "static file invalid data: {message}"),
         }
     }
@@ -87,7 +104,7 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Io(e) => Some(e),
-            Self::Invalid(_) => None,
+            _ => None,
         }
     }
 }
@@ -141,10 +158,7 @@ impl StaticFile {
         match lock.try_lock() {
             Ok(()) => {}
             Err(TryLockError::WouldBlock) => {
-                return Err(Error::Invalid(format!(
-                    "already open by another handle: {}",
-                    root_dir.display()
-                )));
+                return Err(Error::AlreadyOpen(root_dir));
             }
             Err(TryLockError::Error(e)) => return Err(e.into()),
         }
@@ -158,7 +172,7 @@ impl StaticFile {
             // A store writes column.conf before any data file, so data files
             // without a conf mean external damage — don't wipe them.
             if dir_has_static_files(&root_dir)? {
-                return Err(Error::Invalid(format!(
+                return Err(Error::Corrupt(format!(
                     "column.conf missing but data files exist in {}",
                     root_dir.display()
                 )));
@@ -246,9 +260,7 @@ impl StaticFile {
 
         let mut state = self.state.lock();
         if state.poisoned {
-            return Err(Error::Invalid(
-                "writes rejected after an earlier write failure; reopen to heal".into(),
-            ));
+            return Err(Error::Poisoned);
         }
         let start = self.skip_committed_prefix(items, state.committed.highest_slot)?;
         if start == items.len() {
@@ -347,7 +359,7 @@ impl StaticFile {
         };
         let data_len = data_file.metadata()?.len();
         if data_len < cursor {
-            return Err(Error::Invalid(
+            return Err(Error::Corrupt(
                 "data file shorter than committed length".into(),
             ));
         }
@@ -413,7 +425,7 @@ impl StaticFile {
         data_file.read_exact(&mut header)?;
         let len = u32::from_le_bytes(header);
         if u64::from(len) > self.max_value_bytes {
-            return Err(Error::Invalid("record exceeds size limit".into()));
+            return Err(Error::Corrupt("record exceeds size limit".into()));
         }
 
         let len = len as usize;
@@ -444,7 +456,7 @@ impl StaticFile {
         let data_file = OpenOptions::new().read(true).write(true).open(&data_path)?;
         let data_len = data_file.metadata()?.len();
         if data_len < current_data_len {
-            return Err(Error::Invalid(
+            return Err(Error::Corrupt(
                 "data file shorter than committed length".into(),
             ));
         }
@@ -458,7 +470,7 @@ impl StaticFile {
         let required_len = offset_position(slot) + OFFSET_SIZE;
         let off_len = off_file.metadata()?.len();
         if off_len < required_len {
-            return Err(Error::Invalid(
+            return Err(Error::Corrupt(
                 "offset file shorter than committed slot".into(),
             ));
         }
@@ -494,7 +506,7 @@ impl StaticFile {
             if max_file_id.is_none_or(|max| file_id > max) {
                 let file_type = entry.file_type()?;
                 if !file_type.is_file() {
-                    return Err(Error::Invalid(format!(
+                    return Err(Error::Corrupt(format!(
                         "static data path is not a file: {}",
                         entry.path().display()
                     )));
@@ -565,14 +577,14 @@ fn serialize_on_disk_config(committed: CommittedState) -> Vec<u8> {
 /// Parse the `column.conf` marker.
 fn deserialize_on_disk_config(bytes: &[u8]) -> Result<CommittedState, Error> {
     if bytes.len() != 24 {
-        return Err(Error::Invalid("invalid config length".into()));
+        return Err(Error::Corrupt("invalid config length".into()));
     }
     if &bytes[0..4] != CONFIG_MAGIC {
-        return Err(Error::Invalid("invalid config magic".into()));
+        return Err(Error::Corrupt("invalid config magic".into()));
     }
     let version = u32::from_le_bytes(bytes[4..8].try_into().expect("slice length checked"));
     if version != FORMAT_VERSION {
-        return Err(Error::Invalid(format!(
+        return Err(Error::Corrupt(format!(
             "unsupported config version {version}, expected {FORMAT_VERSION}"
         )));
     }
@@ -727,7 +739,10 @@ mod tests {
         store.put_batch(&[(0, b"a"), (1, b"b"), (2, b"c")]).unwrap();
 
         assert_eq!(store.get(2).unwrap(), Some(b"c".to_vec()));
-        assert!(store.put_batch(&[(1, b"wrong")]).is_err());
+        assert!(matches!(
+            store.put_batch(&[(1, b"wrong")]),
+            Err(Error::Invalid(_))
+        ));
     }
 
     #[test]
@@ -748,7 +763,10 @@ mod tests {
     #[test]
     fn max_slot_is_reserved() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(open(&dir).put(u64::MAX, b"x").is_err());
+        assert!(matches!(
+            open(&dir).put(u64::MAX, b"x"),
+            Err(Error::Invalid(_))
+        ));
     }
 
     #[test]
@@ -757,7 +775,10 @@ mod tests {
         let store = open(&dir);
         store.put(0, b"a").unwrap();
 
-        assert!(StaticFile::open(dir.path().to_path_buf(), MAX_VALUE_BYTES).is_err());
+        assert!(matches!(
+            StaticFile::open(dir.path().to_path_buf(), MAX_VALUE_BYTES),
+            Err(Error::AlreadyOpen(_))
+        ));
 
         drop(store);
         assert_eq!(open(&dir).get(0).unwrap(), Some(b"a".to_vec()));
@@ -774,12 +795,12 @@ mod tests {
         let orig = fs::read(&data_path).unwrap();
         fs::remove_file(&data_path).unwrap();
         fs::create_dir(&data_path).unwrap();
-        assert!(store.put(1, b"b").is_err());
+        assert!(matches!(store.put(1, b"b"), Err(Error::Io(_))));
         fs::remove_dir(&data_path).unwrap();
         fs::write(&data_path, &orig).unwrap();
 
         // writes rejected, reads still served
-        assert!(store.put(3, b"c").is_err());
+        assert!(matches!(store.put(3, b"c"), Err(Error::Poisoned)));
         assert_eq!(store.get(0).unwrap(), Some(b"a".to_vec()));
 
         // reopen heals and lifts the poison
@@ -794,7 +815,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = open(&dir);
         let oversized = vec![0u8; (MAX_VALUE_BYTES + 1) as usize];
-        assert!(store.put(0, &oversized).is_err());
+        assert!(matches!(store.put(0, &oversized), Err(Error::Invalid(_))));
         // caller mistake, not a write failure: store stays usable
         store.put(0, b"a").unwrap();
         assert_eq!(store.get(0).unwrap(), Some(b"a".to_vec()));
@@ -821,7 +842,10 @@ mod tests {
             good[..good.len() - 1].to_vec(), // length
         ] {
             fs::write(&conf_path, &bad).unwrap();
-            assert!(StaticFile::open(dir.path().to_path_buf(), MAX_VALUE_BYTES).is_err());
+            assert!(matches!(
+                StaticFile::open(dir.path().to_path_buf(), MAX_VALUE_BYTES),
+                Err(Error::Corrupt(_))
+            ));
         }
 
         fs::write(&conf_path, &good).unwrap();
@@ -833,7 +857,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = open(&dir);
         store.put(10, b"a").unwrap();
-        assert!(store.put(5, b"b").is_err());
+        assert!(matches!(store.put(5, b"b"), Err(Error::Invalid(_))));
     }
 
     #[test]
@@ -853,7 +877,10 @@ mod tests {
             .unwrap();
         fs::remove_file(dir.path().join("column.conf")).unwrap();
 
-        assert!(StaticFile::open(dir.path().to_path_buf(), MAX_VALUE_BYTES).is_err());
+        assert!(matches!(
+            StaticFile::open(dir.path().to_path_buf(), MAX_VALUE_BYTES),
+            Err(Error::Corrupt(_))
+        ));
         assert!(dir.path().join("data_00000").exists());
         assert!(dir.path().join("data_00001").exists());
     }

--- a/common/static_file_storage/src/lib.rs
+++ b/common/static_file_storage/src/lib.rs
@@ -212,7 +212,7 @@ impl StaticFile {
     /// after a mid-loop crash are safe). A previously-skipped slot (offset
     /// zero) cannot be filled — that would break the append-only data file.
     pub fn put(&self, slot: u64, bytes: &[u8]) -> Result<(), Error> {
-        self.put_batch(vec![(slot, bytes)])
+        self.put_batch(&[(slot, bytes)])
     }
 
     /// Append `items` with one fsync per file (data + offset), not per slot.
@@ -220,7 +220,7 @@ impl StaticFile {
     /// `put` — but with O(1) syncs per underlying file instead of O(n) per
     /// item. Items must be strictly ascending. Already-committed prefix items
     /// are treated as idempotent re-puts if their bytes match, then skipped.
-    pub fn put_batch(&self, items: Vec<(u64, &[u8])>) -> Result<(), Error> {
+    pub fn put_batch(&self, items: &[(u64, &[u8])]) -> Result<(), Error> {
         let Some((last_slot, _)) = items.last() else {
             return Ok(());
         };
@@ -241,7 +241,7 @@ impl StaticFile {
                 "writes rejected after an earlier write failure; reopen to heal".into(),
             ));
         }
-        let start = self.skip_committed_prefix(&items, state.committed.highest_slot)?;
+        let start = self.skip_committed_prefix(items, state.committed.highest_slot)?;
         if start == items.len() {
             // Avoid rewriting config with no fresh data_len.
             return Ok(());
@@ -703,7 +703,7 @@ mod tests {
     fn reopen_preserves_committed_records() {
         let dir = tempfile::tempdir().unwrap();
         open(&dir)
-            .put_batch(vec![(SLOTS_PER_FILE - 1, b"a"), (SLOTS_PER_FILE, b"b")])
+            .put_batch(&[(SLOTS_PER_FILE - 1, b"a"), (SLOTS_PER_FILE, b"b")])
             .unwrap();
 
         let store = open(&dir);
@@ -716,13 +716,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = open(&dir);
 
-        store.put_batch(vec![(0, b"a"), (1, b"b")]).unwrap();
-        store
-            .put_batch(vec![(0, b"a"), (1, b"b"), (2, b"c")])
-            .unwrap();
+        store.put_batch(&[(0, b"a"), (1, b"b")]).unwrap();
+        store.put_batch(&[(0, b"a"), (1, b"b"), (2, b"c")]).unwrap();
 
         assert_eq!(store.get(2).unwrap(), Some(b"c".to_vec()));
-        assert!(store.put_batch(vec![(1, b"wrong")]).is_err());
+        assert!(store.put_batch(&[(1, b"wrong")]).is_err());
     }
 
     #[test]
@@ -765,7 +763,7 @@ mod tests {
         store.put(0, b"a").unwrap();
 
         let oversized = vec![0u8; (MAX_VALUE_BYTES + 1) as usize];
-        assert!(store.put_batch(vec![(1, b"b"), (2, &oversized)]).is_err());
+        assert!(store.put_batch(&[(1, b"b"), (2, &oversized)]).is_err());
 
         // writes rejected, reads still served
         assert!(store.put(3, b"c").is_err());
@@ -782,7 +780,7 @@ mod tests {
     fn missing_conf_with_data_files_errors() {
         let dir = tempfile::tempdir().unwrap();
         open(&dir)
-            .put_batch(vec![(0, b"a"), (SLOTS_PER_FILE, b"b")])
+            .put_batch(&[(0, b"a"), (SLOTS_PER_FILE, b"b")])
             .unwrap();
         fs::remove_file(dir.path().join("column.conf")).unwrap();
 
@@ -809,7 +807,7 @@ mod tests {
     #[test]
     fn reopen_truncates_torn_append() {
         let dir = tempfile::tempdir().unwrap();
-        open(&dir).put_batch(vec![(0, b"a"), (1, b"b")]).unwrap();
+        open(&dir).put_batch(&[(0, b"a"), (1, b"b")]).unwrap();
         let data = dir.path().join("data_00000");
         let committed_len = fs::metadata(&data).unwrap().len();
         forge_uncommitted(&dir, 0, 2, committed_len, b"Z");

--- a/common/static_file_storage/src/lib.rs
+++ b/common/static_file_storage/src/lib.rs
@@ -1,0 +1,734 @@
+//! Slot-indexed, append-only static file storage.
+//!
+//! `StaticFile` owns one directory containing:
+//!
+//! ```text
+//! <root>/
+//!   data_{file_id:05}         # file_id = slot / SLOTS_PER_FILE
+//!   data_{file_id:05}.off     # SLOTS_PER_FILE × u64 LE offsets, 0 = no record
+//!   column.conf               # 34-byte commit marker, atomic-renamed
+//! ```
+//!
+//! # File format
+//!
+//! Data file: `b"LHSF"`, then records appended as `length[4 LE] | payload`.
+//!
+//! `column.conf`: `b"LHSF" | version u32 LE | highest_slot u64 LE (u64::MAX =
+//! empty) | current_data_len u64 LE`.
+//! Atomic update: write `.tmp`, fsync, rename, fsync dir.
+//!
+//! # Put contract
+//!
+//! Durable on return. Slots arrive ascending **or** are identical-value
+//! re-puts of an already-committed slot (so migration retries after a
+//! mid-loop crash are safe). Previously-skipped slots (offset 0) cannot
+//! be filled — that would break the append-only data file.
+//!
+//! # Recovery on open
+//!
+//! Data file truncated to `current_data_len`; `.off` entries beyond
+//! `highest_slot` cleared; files beyond the committed file removed. The
+//! `column.conf` rename is the commit point.
+
+use parking_lot::Mutex;
+use std::{
+    fmt,
+    fs::{self, File, OpenOptions},
+    io::{self, Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+};
+
+/// 8192-slot chunks; 8192 offsets fit in 64 KiB.
+pub const SLOTS_PER_FILE: u64 = 8192;
+type SlotGroup<'a> = (u64, Vec<(u64, &'a [u8])>);
+
+const OFFSET_SIZE: u64 = 8;
+const OFFSET_FILE_LEN: u64 = SLOTS_PER_FILE * OFFSET_SIZE;
+const CONFIG_FILE: &str = "column.conf";
+const CONFIG_TMP_FILE: &str = "column.conf.tmp";
+const DATA_FILE_PREFIX: &str = "data_";
+/// Config file identity. Format revisions bump `FORMAT_VERSION`, not this.
+const CONFIG_MAGIC: &[u8; 4] = b"LHSF";
+/// On-disk format version. Bump on any breaking layout change (implies a rebuild).
+const FORMAT_VERSION: u32 = 1;
+/// Empty-store sentinel for `highest_written_slot` in the per-file config.
+const EMPTY_SLOT: u64 = u64::MAX;
+/// Header marker, written once at the start of each data file.
+const DATA_FILE_HEADER: [u8; 4] = *b"LHSF";
+
+/// Last durable `column.conf` marker.
+#[derive(Debug, Clone, Copy)]
+struct CommittedState {
+    /// Highest committed slot, or `None` when empty.
+    highest_slot: Option<u64>,
+    /// Committed end of the file containing `highest_slot`.
+    data_len: u64,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    Invalid(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "static file io error: {e}"),
+            Self::Invalid(message) => write!(f, "static file invalid data: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Invalid(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Slot-keyed file set. Owns one directory of `data_*`, `data_*.off`, and
+/// `column.conf` files.
+#[derive(Debug)]
+pub struct StaticFile {
+    root_dir: PathBuf,
+    /// Max record size, an OOM guard on reads.
+    max_value_bytes: u64,
+    /// Highest committed slot and committed data length from `column.conf`.
+    // Writer holds this across put_batch's fsyncs, so readers block. Accepted:
+    // simplicity over read concurrency.
+    committed: Mutex<CommittedState>,
+}
+
+impl StaticFile {
+    /// Open or create a `StaticFile` rooted at `root_dir`. `max_value_bytes` is
+    /// a runtime-only read OOM cap. The column is identified by its directory.
+    pub fn open(root_dir: PathBuf, max_value_bytes: u64) -> Result<Self, Error> {
+        fs::create_dir_all(&root_dir)?;
+        let config_path = root_dir.join(CONFIG_FILE);
+        let tmp_path = root_dir.join(CONFIG_TMP_FILE);
+
+        let committed = if config_path.exists() {
+            deserialize_on_disk_config(&fs::read(&config_path)?)?
+        } else {
+            atomic_write_config(&config_path, &tmp_path, &root_dir, None, 0)?;
+            CommittedState {
+                highest_slot: None,
+                data_len: 0,
+            }
+        };
+
+        let handle = Self {
+            root_dir,
+            max_value_bytes,
+            committed: Mutex::new(committed),
+        };
+        handle.heal_to_marker(committed.highest_slot, committed.data_len)?;
+        Ok(handle)
+    }
+
+    /// Slot of the most recently committed record, if any.
+    fn highest_written_slot(&self) -> Option<u64> {
+        self.committed.lock().highest_slot
+    }
+
+    /// Read the record at `slot`, if present.
+    pub fn get(&self, slot: u64) -> Result<Option<Vec<u8>>, Error> {
+        if self.highest_written_slot().is_none_or(|h| slot > h) {
+            return Ok(None);
+        }
+        self.read_record(slot)
+    }
+
+    /// `true` if a record exists at `slot`. Cheaper than `get` — only the
+    /// `.off` sidecar is consulted; the data file is not read.
+    pub fn contains(&self, slot: u64) -> Result<bool, Error> {
+        if self.highest_written_slot().is_none_or(|h| slot > h) {
+            return Ok(false);
+        }
+        Ok(self.read_offset(file_id(slot), slot)? != 0)
+    }
+
+    /// Durably store `bytes` at `slot`. Slots must arrive strictly ascending,
+    /// or be an identical-value re-put of a previously committed slot
+    /// (re-puts at any committed slot are idempotent so migration retries
+    /// after a mid-loop crash are safe). A previously-skipped slot (offset
+    /// zero) cannot be filled — that would break the append-only data file.
+    pub fn put(&self, slot: u64, bytes: &[u8]) -> Result<(), Error> {
+        self.put_batch(vec![(slot, bytes)])
+    }
+
+    /// Append `items` with one fsync per file (data + offset), not per slot.
+    /// Whole batch is durable on return — the same caller-visible contract as
+    /// `put` — but with O(1) syncs per underlying file instead of O(n) per
+    /// item. Items must be strictly ascending. Already-committed prefix items
+    /// are treated as idempotent re-puts if their bytes match, then skipped.
+    pub fn put_batch(&self, items: Vec<(u64, &[u8])>) -> Result<(), Error> {
+        let Some((last_slot, _)) = items.last() else {
+            return Ok(());
+        };
+        for w in items.windows(2) {
+            if w[1].0 <= w[0].0 {
+                return Err(Error::Invalid(
+                    "put_batch slots must be strictly ascending".into(),
+                ));
+            }
+        }
+        if *last_slot == EMPTY_SLOT {
+            return Err(Error::Invalid("slot u64::MAX is reserved".into()));
+        }
+
+        let mut committed = self.committed.lock();
+        let start = self.skip_committed_prefix(&items, committed.highest_slot)?;
+        if start == items.len() {
+            // Avoid rewriting config with no fresh data_len.
+            return Ok(());
+        }
+
+        // Group remaining items by file_id, write each group with one
+        // data fsync + one offset fsync. Single config commit at end of batch.
+        let mut last_data_len: u64 = 0;
+        for (target_file_id, group) in group_by_file_id(&items[start..]) {
+            match self.write_group(target_file_id, &group, *committed) {
+                Ok(data_len) => last_data_len = data_len,
+                Err(e) => {
+                    // Reconcile after partial write.
+                    if let Ok(config_committed) = self.heal_from_config() {
+                        *committed = config_committed;
+                    }
+                    return Err(e);
+                }
+            }
+        }
+
+        if let Err(e) = self.write_config(Some(*last_slot), last_data_len) {
+            // Edge: rename may have landed, so the batch can be durable despite this
+            // Err; safe because retry is idempotent. heal error is swallowed here;
+            // next open re-heals.
+            if let Ok(config_committed) = self.heal_from_config() {
+                *committed = config_committed;
+            }
+            return Err(e);
+        }
+        *committed = CommittedState {
+            highest_slot: Some(*last_slot),
+            data_len: last_data_len,
+        };
+        Ok(())
+    }
+
+    /// Validate already-committed retry items and return the first new item.
+    /// This lets migration retries overlap with the committed prefix without
+    /// rewriting offsets or filling skipped slots.
+    fn skip_committed_prefix(
+        &self,
+        items: &[(u64, &[u8])],
+        highest_written_slot: Option<u64>,
+    ) -> Result<usize, Error> {
+        let Some(highest) = highest_written_slot else {
+            return Ok(0);
+        };
+
+        let mut start = 0;
+        while start < items.len() && items[start].0 <= highest {
+            let (slot, value) = &items[start];
+            let existing = self.read_record(*slot)?.ok_or_else(|| {
+                Error::Invalid(format!(
+                    "re-put at slot {slot} <= highest {highest} but no record exists; \
+                     cannot fill a previously-skipped slot"
+                ))
+            })?;
+            if existing.as_slice() != *value {
+                return Err(Error::Invalid(format!(
+                    "re-put at slot {slot} with mismatched value"
+                )));
+            }
+            start += 1;
+        }
+        Ok(start)
+    }
+
+    /// Write `group` (all in `target_file_id`) to disk: append records, fsync
+    /// the data file, write all offsets, fsync the offset file. Returns the
+    /// committed data file length. Does NOT update `highest_written_slot` or
+    /// `column.conf` — the caller commits via `write_config` after this.
+    fn write_group(
+        &self,
+        target_file_id: u64,
+        group: &[(u64, &[u8])],
+        committed: CommittedState,
+    ) -> Result<u64, Error> {
+        let data_path = self.data_path(target_file_id);
+        let off_path = self.offset_path(target_file_id);
+
+        let mut data_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false) // keep committed records; we seek + overwrite
+            .open(&data_path)?;
+        let cursor = if committed
+            .highest_slot
+            .is_some_and(|slot| file_id(slot) == target_file_id)
+        {
+            committed.data_len
+        } else {
+            // new file: plant header at offset 0, start just past it
+            data_file.seek(SeekFrom::Start(0))?;
+            data_file.write_all(&DATA_FILE_HEADER)?;
+            DATA_FILE_HEADER.len() as u64
+        };
+        let data_len = data_file.metadata()?.len();
+        if data_len < cursor {
+            return Err(Error::Invalid(
+                "data file shorter than committed length".into(),
+            ));
+        }
+        if data_len != cursor {
+            data_file.set_len(cursor)?;
+        }
+        data_file.seek(SeekFrom::Start(cursor))?;
+
+        let mut offsets = Vec::with_capacity(group.len());
+        {
+            // 1 MiB batches tiny record writes during imports.
+            let mut writer = std::io::BufWriter::with_capacity(1 << 20, &mut data_file);
+            let mut next_offset = cursor;
+            for &(slot, value) in group {
+                if (value.len() as u64) > self.max_value_bytes {
+                    return Err(Error::Invalid("record exceeds size limit".into()));
+                }
+                let payload_len = u32::try_from(value.len())
+                    .map_err(|_| Error::Invalid("record too large".into()))?;
+                offsets.push((slot, next_offset));
+                writer.write_all(&payload_len.to_le_bytes())?; // len[4]
+                next_offset += 4;
+                writer.write_all(value)?; // payload
+                next_offset += value.len() as u64;
+            }
+            writer.flush()?;
+        }
+        let data_len = data_file.seek(SeekFrom::End(0))?;
+        // Data must hit disk before offsets, both before config commit.
+        data_file.sync_all()?;
+
+        let mut off_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&off_path)?;
+        // Pre-size so skipped slots read as zero offsets.
+        if off_file.metadata()?.len() < OFFSET_FILE_LEN {
+            off_file.set_len(OFFSET_FILE_LEN)?;
+        }
+        for (slot, offset) in &offsets {
+            off_file.seek(SeekFrom::Start(offset_position(*slot)))?;
+            off_file.write_all(&offset.to_le_bytes())?;
+        }
+        off_file.sync_all()?;
+
+        Ok(data_len)
+    }
+
+    /// Read a record at `slot` without consulting the writer mutex. Used by
+    /// callers that already hold the lock (`put` for the idempotency check).
+    fn read_record(&self, slot: u64) -> Result<Option<Vec<u8>>, Error> {
+        let file_id = file_id(slot);
+        let offset = self.read_offset(file_id, slot)?;
+        if offset == 0 {
+            return Ok(None);
+        }
+
+        let data_path = self.data_path(file_id);
+        let mut data_file = File::open(&data_path)?;
+        data_file.seek(SeekFrom::Start(offset))?;
+
+        let mut header = [0; 4];
+        data_file.read_exact(&mut header)?;
+        let len = u32::from_le_bytes(header);
+        if u64::from(len) > self.max_value_bytes {
+            return Err(Error::Invalid("record exceeds size limit".into()));
+        }
+
+        let len = len as usize;
+        let mut payload = vec![0; len];
+        data_file.read_exact(&mut payload)?;
+        Ok(Some(payload))
+    }
+
+    /// Restore files to the committed marker and remove future crash leftovers.
+    fn heal_to_marker(
+        &self,
+        highest_written_slot: Option<u64>,
+        current_data_len: u64,
+    ) -> Result<(), Error> {
+        if let Some(slot) = highest_written_slot {
+            self.heal_current_file(slot, current_data_len)?;
+            self.remove_uncommitted_files(Some(file_id(slot)))
+        } else {
+            self.remove_uncommitted_files(None)
+        }
+    }
+
+    /// Re-read `column.conf` and restore files to whatever marker is durable.
+    fn heal_from_config(&self) -> Result<CommittedState, Error> {
+        let committed = deserialize_on_disk_config(&fs::read(self.config_path())?)?;
+        self.heal_to_marker(committed.highest_slot, committed.data_len)?;
+        Ok(committed)
+    }
+
+    /// Truncate the committed file back to the config marker after a crash.
+    /// Data beyond `current_data_len` and offsets beyond `slot` are uncommitted.
+    fn heal_current_file(&self, slot: u64, current_data_len: u64) -> Result<(), Error> {
+        let file_id = file_id(slot);
+        let data_path = self.data_path(file_id);
+        let data_file = OpenOptions::new().read(true).write(true).open(&data_path)?;
+        let data_len = data_file.metadata()?.len();
+        if data_len < current_data_len {
+            return Err(Error::Invalid(
+                "data file shorter than committed length".into(),
+            ));
+        }
+        if data_len != current_data_len {
+            data_file.set_len(current_data_len)?;
+            data_file.sync_all()?;
+        }
+
+        let off_path = self.offset_path(file_id);
+        let mut off_file = OpenOptions::new().read(true).write(true).open(&off_path)?;
+        let required_len = offset_position(slot) + OFFSET_SIZE;
+        let off_len = off_file.metadata()?.len();
+        if off_len < required_len {
+            return Err(Error::Invalid(
+                "offset file shorter than committed slot".into(),
+            ));
+        }
+        if off_len < OFFSET_FILE_LEN {
+            off_file.set_len(OFFSET_FILE_LEN)?;
+        }
+
+        let clear_start = required_len;
+        if clear_start < OFFSET_FILE_LEN {
+            // Remove offsets to entries beyond the committed slot.
+            off_file.seek(SeekFrom::Start(clear_start))?;
+            let zeroes = vec![0; (OFFSET_FILE_LEN - clear_start) as usize];
+            off_file.write_all(&zeroes)?;
+            off_file.sync_all()?;
+        }
+
+        Ok(())
+    }
+
+    /// Remove data/offset files newer than the committed file id.
+    /// `None` means the store is empty, so every data/offset file is removed.
+    fn remove_uncommitted_files(&self, max_file_id: Option<u64>) -> Result<(), Error> {
+        let mut removed = false;
+        for entry in fs::read_dir(&self.root_dir)? {
+            let entry = entry?;
+            let file_name = entry.file_name();
+            let Some(file_name) = file_name.to_str() else {
+                continue;
+            };
+            let Some(file_id) = static_file_id(file_name) else {
+                continue;
+            };
+            if max_file_id.is_none_or(|max| file_id > max) {
+                let file_type = entry.file_type()?;
+                if !file_type.is_file() {
+                    return Err(Error::Invalid(format!(
+                        "static data path is not a file: {}",
+                        entry.path().display()
+                    )));
+                }
+                fs::remove_file(entry.path())?;
+                removed = true;
+            }
+        }
+        if removed {
+            sync_dir(&self.root_dir)?;
+        }
+        Ok(())
+    }
+
+    /// Atomically publish the commit marker after data and offsets are durable.
+    fn write_config(
+        &self,
+        highest_written_slot: Option<u64>,
+        current_data_len: u64,
+    ) -> Result<(), Error> {
+        atomic_write_config(
+            &self.config_path(),
+            &self.root_dir.join(CONFIG_TMP_FILE),
+            &self.root_dir,
+            highest_written_slot,
+            current_data_len,
+        )
+    }
+
+    fn read_offset(&self, file_id: u64, slot: u64) -> Result<u64, Error> {
+        let off_path = self.offset_path(file_id);
+        let mut off_file = match File::open(&off_path) {
+            Ok(file) => file,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(0),
+            Err(e) => return Err(e.into()),
+        };
+        let mut bytes = [0; 8];
+        off_file.seek(SeekFrom::Start(offset_position(slot)))?;
+        off_file.read_exact(&mut bytes)?;
+        Ok(u64::from_le_bytes(bytes))
+    }
+
+    fn config_path(&self) -> PathBuf {
+        self.root_dir.join(CONFIG_FILE)
+    }
+
+    fn data_path(&self, file_id: u64) -> PathBuf {
+        self.root_dir
+            .join(format!("{DATA_FILE_PREFIX}{file_id:05}"))
+    }
+
+    fn offset_path(&self, file_id: u64) -> PathBuf {
+        self.root_dir
+            .join(format!("{DATA_FILE_PREFIX}{file_id:05}.off"))
+    }
+}
+
+/// Pack the 24-byte `column.conf` marker.
+fn serialize_on_disk_config(committed: CommittedState) -> Vec<u8> {
+    let mut bytes = vec![0u8; 24];
+    bytes[0..4].copy_from_slice(CONFIG_MAGIC);
+    bytes[4..8].copy_from_slice(&FORMAT_VERSION.to_le_bytes());
+    bytes[8..16].copy_from_slice(&committed.highest_slot.unwrap_or(EMPTY_SLOT).to_le_bytes());
+    bytes[16..24].copy_from_slice(&committed.data_len.to_le_bytes());
+    bytes
+}
+
+/// Parse the 24-byte `column.conf` marker.
+fn deserialize_on_disk_config(bytes: &[u8]) -> Result<CommittedState, Error> {
+    if bytes.len() != 24 {
+        return Err(Error::Invalid("invalid config length".into()));
+    }
+    if &bytes[0..4] != CONFIG_MAGIC {
+        return Err(Error::Invalid("invalid config magic".into()));
+    }
+    let version = u32::from_le_bytes(bytes[4..8].try_into().expect("slice length checked"));
+    if version != FORMAT_VERSION {
+        return Err(Error::Invalid(format!(
+            "unsupported config version {version}, expected {FORMAT_VERSION}"
+        )));
+    }
+    let highest = u64::from_le_bytes(bytes[8..16].try_into().expect("slice length checked"));
+    let data_len = u64::from_le_bytes(bytes[16..24].try_into().expect("slice length checked"));
+    Ok(CommittedState {
+        highest_slot: (highest != EMPTY_SLOT).then_some(highest),
+        data_len,
+    })
+}
+
+/// Write `column.conf.tmp`, fsync it, rename over `column.conf`, then fsync
+/// the directory so the rename is durable.
+fn atomic_write_config(
+    config_path: &Path,
+    tmp_path: &Path,
+    root_dir: &Path,
+    highest_written_slot: Option<u64>,
+    current_data_len: u64,
+) -> Result<(), Error> {
+    let bytes = serialize_on_disk_config(CommittedState {
+        highest_slot: highest_written_slot,
+        data_len: current_data_len,
+    });
+
+    {
+        let mut tmp = File::create(tmp_path)?;
+        tmp.write_all(&bytes)?;
+        tmp.sync_all()?;
+    }
+
+    fs::rename(tmp_path, config_path)?;
+    sync_dir(root_dir)
+}
+
+fn file_id(slot: u64) -> u64 {
+    slot / SLOTS_PER_FILE
+}
+
+fn offset_position(slot: u64) -> u64 {
+    (slot % SLOTS_PER_FILE) * OFFSET_SIZE
+}
+
+fn static_file_id(file_name: &str) -> Option<u64> {
+    let suffix = file_name.strip_prefix(DATA_FILE_PREFIX)?;
+    let id = suffix.strip_suffix(".off").unwrap_or(suffix);
+    if id.is_empty() || !id.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    id.parse().ok()
+}
+
+/// Convert an ascending slot list into consecutive groups for each data file.
+fn group_by_file_id<'a>(items: &[(u64, &'a [u8])]) -> Vec<SlotGroup<'a>> {
+    let mut groups = Vec::new();
+    let mut current_file_id = None;
+    let mut current_group = Vec::new();
+
+    for (slot, value) in items {
+        let target_file_id = file_id(*slot);
+        if current_file_id == Some(target_file_id) {
+            current_group.push((*slot, *value));
+        } else {
+            if let Some(file_id) = current_file_id {
+                groups.push((file_id, current_group));
+                current_group = Vec::new();
+            }
+            current_file_id = Some(target_file_id);
+            current_group.push((*slot, *value));
+        }
+    }
+
+    if let Some(file_id) = current_file_id {
+        groups.push((file_id, current_group));
+    }
+
+    groups
+}
+
+fn sync_dir(path: &Path) -> Result<(), Error> {
+    let dir = File::open(path)?;
+    dir.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAX_VALUE_BYTES: u64 = 1024;
+
+    fn open(dir: &tempfile::TempDir) -> StaticFile {
+        StaticFile::open(dir.path().to_path_buf(), MAX_VALUE_BYTES).unwrap()
+    }
+
+    #[test]
+    fn round_trip_sparse_slots() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir);
+
+        store.put(100, b"a").unwrap();
+        store.put(9000, b"b").unwrap();
+
+        assert_eq!(store.get(100).unwrap(), Some(b"a".to_vec()));
+        assert_eq!(store.get(101).unwrap(), None);
+        assert_eq!(store.get(9000).unwrap(), Some(b"b".to_vec()));
+        assert!(!store.contains(101).unwrap());
+    }
+
+    #[test]
+    fn reopen_preserves_committed_records() {
+        let dir = tempfile::tempdir().unwrap();
+        open(&dir)
+            .put_batch(vec![(SLOTS_PER_FILE - 1, b"a"), (SLOTS_PER_FILE, b"b")])
+            .unwrap();
+
+        let store = open(&dir);
+        assert_eq!(store.get(SLOTS_PER_FILE - 1).unwrap(), Some(b"a".to_vec()));
+        assert_eq!(store.get(SLOTS_PER_FILE).unwrap(), Some(b"b".to_vec()));
+    }
+
+    #[test]
+    fn batch_retries_committed_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir);
+
+        store.put_batch(vec![(0, b"a"), (1, b"b")]).unwrap();
+        store
+            .put_batch(vec![(0, b"a"), (1, b"b"), (2, b"c")])
+            .unwrap();
+
+        assert_eq!(store.get(2).unwrap(), Some(b"c".to_vec()));
+        assert!(store.put_batch(vec![(1, b"wrong")]).is_err());
+    }
+
+    #[test]
+    fn open_removes_uncommitted_future_file() {
+        let dir = tempfile::tempdir().unwrap();
+        open(&dir).put(0, b"a").unwrap();
+        fs::write(dir.path().join("data_00001"), b"stale").unwrap();
+        fs::write(dir.path().join("data_00001.off"), b"stale").unwrap();
+
+        let store = open(&dir);
+        assert!(!dir.path().join("data_00001").exists());
+        assert!(!dir.path().join("data_00001.off").exists());
+
+        store.put(SLOTS_PER_FILE, b"b").unwrap();
+        assert_eq!(store.get(SLOTS_PER_FILE).unwrap(), Some(b"b".to_vec()));
+    }
+
+    #[test]
+    fn max_slot_is_reserved() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(open(&dir).put(u64::MAX, b"x").is_err());
+    }
+
+    /// Forge a record + offset for `slot` without committing `column.conf`,
+    /// mimicking a crash after the data/offset fsyncs but before the marker.
+    fn forge_uncommitted(dir: &tempfile::TempDir, file_id: u64, slot: u64, at: u64, value: &[u8]) {
+        let data = dir.path().join(format!("data_{file_id:05}"));
+        let off = dir.path().join(format!("data_{file_id:05}.off"));
+        let mut d = OpenOptions::new().append(true).open(&data).unwrap();
+        d.write_all(&(value.len() as u32).to_le_bytes()).unwrap();
+        d.write_all(value).unwrap();
+        let mut o = OpenOptions::new().write(true).open(&off).unwrap();
+        o.seek(SeekFrom::Start(offset_position(slot))).unwrap();
+        o.write_all(&at.to_le_bytes()).unwrap();
+    }
+
+    // A torn append (data + offset written, marker not) is rolled back on open,
+    // leaving committed records intact and no phantom record.
+    #[test]
+    fn reopen_truncates_torn_append() {
+        let dir = tempfile::tempdir().unwrap();
+        open(&dir).put_batch(vec![(0, b"a"), (1, b"b")]).unwrap();
+        let data = dir.path().join("data_00000");
+        let committed_len = fs::metadata(&data).unwrap().len();
+        forge_uncommitted(&dir, 0, 2, committed_len, b"Z");
+
+        let store = open(&dir);
+        assert_eq!(store.get(0).unwrap(), Some(b"a".to_vec()));
+        assert_eq!(store.get(1).unwrap(), Some(b"b".to_vec()));
+        assert_eq!(store.get(2).unwrap(), None);
+        assert_eq!(fs::metadata(&data).unwrap().len(), committed_len);
+    }
+
+    // A torn multi-file batch (appended to the committed file and created a new
+    // one, marker not updated) rolls back wholesale on open.
+    #[test]
+    fn reopen_rolls_back_torn_multifile_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        open(&dir).put(0, b"a").unwrap();
+        let data0 = dir.path().join("data_00000");
+        let committed_len = fs::metadata(&data0).unwrap().len();
+        forge_uncommitted(&dir, 0, 1, committed_len, b"b");
+        fs::write(dir.path().join("data_00001"), b"garbage").unwrap();
+        fs::write(
+            dir.path().join("data_00001.off"),
+            vec![0u8; OFFSET_FILE_LEN as usize],
+        )
+        .unwrap();
+
+        let store = open(&dir);
+        assert_eq!(store.get(0).unwrap(), Some(b"a".to_vec()));
+        assert_eq!(store.get(1).unwrap(), None);
+        assert_eq!(fs::metadata(&data0).unwrap().len(), committed_len);
+        assert!(!dir.path().join("data_00001").exists());
+    }
+}

--- a/common/static_file_storage/src/lib.rs
+++ b/common/static_file_storage/src/lib.rs
@@ -631,9 +631,16 @@ fn group_by_file_id<'a>(items: &[(u64, &'a [u8])]) -> Vec<SlotGroup<'a>> {
     groups
 }
 
+#[cfg(not(windows))]
 fn sync_dir(path: &Path) -> Result<(), Error> {
     let dir = File::open(path)?;
     dir.sync_all()?;
+    Ok(())
+}
+
+/// Windows can't open directories to fsync them; NTFS journals metadata ops.
+#[cfg(windows)]
+fn sync_dir(_path: &Path) -> Result<(), Error> {
     Ok(())
 }
 

--- a/common/static_file_storage/src/lib.rs
+++ b/common/static_file_storage/src/lib.rs
@@ -6,7 +6,7 @@
 //! <root>/
 //!   data_{file_id:05}         # file_id = slot / SLOTS_PER_FILE
 //!   data_{file_id:05}.off     # SLOTS_PER_FILE × u64 LE offsets, 0 = no record
-//!   column.conf               # 24-byte commit marker, atomic-renamed
+//!   column.conf               # commit marker, atomic-renamed
 //!   lock                      # exclusive advisory lock held while open
 //! ```
 //!
@@ -40,7 +40,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// 8192-slot chunks; 8192 offsets fit in 64 KiB.
+/// Slots per data file.
 pub const SLOTS_PER_FILE: u64 = 8192;
 type SlotGroup<'a> = (u64, Vec<(u64, &'a [u8])>);
 
@@ -126,6 +126,10 @@ impl StaticFile {
     /// a runtime-only read OOM cap. The column is identified by its directory.
     pub fn open(root_dir: PathBuf, max_value_bytes: u64) -> Result<Self, Error> {
         fs::create_dir_all(&root_dir)?;
+        // Make the column dir's own dirent durable; fsyncs inside it don't.
+        if let Some(parent) = root_dir.parent().filter(|p| !p.as_os_str().is_empty()) {
+            sync_dir(parent)?;
+        }
 
         // Exclusive advisory lock before touching anything: a second handle
         // would heal destructively under a live writer. Released on drop.
@@ -540,7 +544,7 @@ impl StaticFile {
     }
 }
 
-/// Pack the 24-byte `column.conf` marker.
+/// Pack the `column.conf` marker.
 fn serialize_on_disk_config(committed: CommittedState) -> Vec<u8> {
     let mut bytes = vec![0u8; 24];
     bytes[0..4].copy_from_slice(CONFIG_MAGIC);
@@ -550,7 +554,7 @@ fn serialize_on_disk_config(committed: CommittedState) -> Vec<u8> {
     bytes
 }
 
-/// Parse the 24-byte `column.conf` marker.
+/// Parse the `column.conf` marker.
 fn deserialize_on_disk_config(bytes: &[u8]) -> Result<CommittedState, Error> {
     if bytes.len() != 24 {
         return Err(Error::Invalid("invalid config length".into()));

--- a/common/static_file_storage/src/lib.rs
+++ b/common/static_file_storage/src/lib.rs
@@ -119,6 +119,14 @@ impl StaticFile {
         let committed = if config_path.exists() {
             deserialize_on_disk_config(&fs::read(&config_path)?)?
         } else {
+            // A store writes column.conf before any data file, so data files
+            // without a conf mean external damage — don't wipe them.
+            if dir_has_static_files(&root_dir)? {
+                return Err(Error::Invalid(format!(
+                    "column.conf missing but data files exist in {}",
+                    root_dir.display()
+                )));
+            }
             atomic_write_config(&config_path, &tmp_path, &root_dir, None, 0)?;
             CommittedState {
                 highest_slot: None,
@@ -575,6 +583,21 @@ fn static_file_id(file_name: &str) -> Option<u64> {
     id.parse().ok()
 }
 
+/// `true` if `root_dir` contains any data or offset file.
+fn dir_has_static_files(root_dir: &Path) -> Result<bool, Error> {
+    for entry in fs::read_dir(root_dir)? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            continue;
+        };
+        if static_file_id(file_name).is_some() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Convert an ascending slot list into consecutive groups for each data file.
 fn group_by_file_id<'a>(items: &[(u64, &'a [u8])]) -> Vec<SlotGroup<'a>> {
     let mut groups = Vec::new();
@@ -677,6 +700,19 @@ mod tests {
     fn max_slot_is_reserved() {
         let dir = tempfile::tempdir().unwrap();
         assert!(open(&dir).put(u64::MAX, b"x").is_err());
+    }
+
+    #[test]
+    fn missing_conf_with_data_files_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        open(&dir)
+            .put_batch(vec![(0, b"a"), (SLOTS_PER_FILE, b"b")])
+            .unwrap();
+        fs::remove_file(dir.path().join("column.conf")).unwrap();
+
+        assert!(StaticFile::open(dir.path().to_path_buf(), MAX_VALUE_BYTES).is_err());
+        assert!(dir.path().join("data_00000").exists());
+        assert!(dir.path().join("data_00001").exists());
     }
 
     /// Forge a record + offset for `slot` without committing `column.conf`,

--- a/common/static_file_storage/src/lib.rs
+++ b/common/static_file_storage/src/lib.rs
@@ -377,7 +377,7 @@ impl StaticFile {
         }
         let data_len = data_file.seek(SeekFrom::End(0))?;
         // Data must hit disk before offsets, both before config commit.
-        data_file.sync_all()?;
+        sync_file(&data_file)?;
 
         let mut off_file = OpenOptions::new()
             .read(true)
@@ -393,7 +393,7 @@ impl StaticFile {
             off_file.seek(SeekFrom::Start(offset_position(*slot)))?;
             off_file.write_all(&offset.to_le_bytes())?;
         }
-        off_file.sync_all()?;
+        sync_file(&off_file)?;
 
         Ok(data_len)
     }
@@ -451,7 +451,7 @@ impl StaticFile {
         }
         if data_len != current_data_len {
             data_file.set_len(current_data_len)?;
-            data_file.sync_all()?;
+            sync_file(&data_file)?;
         }
 
         let off_path = self.offset_path(file_id);
@@ -473,7 +473,7 @@ impl StaticFile {
             off_file.seek(SeekFrom::Start(clear_start))?;
             let zeroes = vec![0; (OFFSET_FILE_LEN - clear_start) as usize];
             off_file.write_all(&zeroes)?;
-            off_file.sync_all()?;
+            sync_file(&off_file)?;
         }
 
         Ok(())
@@ -602,7 +602,7 @@ fn atomic_write_config(
     {
         let mut tmp = File::create(tmp_path)?;
         tmp.write_all(&bytes)?;
-        tmp.sync_all()?;
+        sync_file(&tmp)?;
     }
 
     fs::rename(tmp_path, config_path)?;
@@ -670,15 +670,36 @@ fn group_by_file_id<'a>(items: &[(u64, &'a [u8])]) -> Vec<SlotGroup<'a>> {
 
 #[cfg(not(windows))]
 fn sync_dir(path: &Path) -> Result<(), Error> {
-    let dir = File::open(path)?;
-    dir.sync_all()?;
-    Ok(())
+    sync_file(&File::open(path)?)
 }
 
 /// Windows can't open directories to fsync them; NTFS journals metadata ops.
 #[cfg(windows)]
 fn sync_dir(_path: &Path) -> Result<(), Error> {
     Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn sync_file(file: &File) -> Result<(), Error> {
+    file.sync_all()?;
+    Ok(())
+}
+
+/// macOS sync_all is F_FULLFSYNC, unsupported on some volumes (e.g. SMB);
+/// fall back to plain fsync like LevelDB does.
+#[cfg(target_os = "macos")]
+fn sync_file(file: &File) -> Result<(), Error> {
+    use std::os::fd::AsRawFd;
+    match file.sync_all() {
+        Err(e) if e.raw_os_error() == Some(libc::ENOTSUP) => {
+            if unsafe { libc::fsync(file.as_raw_fd()) } == 0 {
+                Ok(())
+            } else {
+                Err(io::Error::last_os_error().into())
+            }
+        }
+        other => Ok(other?),
+    }
 }
 
 #[cfg(test)]

--- a/common/static_file_storage/src/lib.rs
+++ b/common/static_file_storage/src/lib.rs
@@ -6,7 +6,8 @@
 //! <root>/
 //!   data_{file_id:05}         # file_id = slot / SLOTS_PER_FILE
 //!   data_{file_id:05}.off     # SLOTS_PER_FILE × u64 LE offsets, 0 = no record
-//!   column.conf               # 34-byte commit marker, atomic-renamed
+//!   column.conf               # 24-byte commit marker, atomic-renamed
+//!   lock                      # exclusive advisory lock held while open
 //! ```
 //!
 //! # File format
@@ -34,7 +35,7 @@
 use parking_lot::Mutex;
 use std::{
     fmt,
-    fs::{self, File, OpenOptions},
+    fs::{self, File, OpenOptions, TryLockError},
     io::{self, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
 };
@@ -48,6 +49,7 @@ const OFFSET_FILE_LEN: u64 = SLOTS_PER_FILE * OFFSET_SIZE;
 const CONFIG_FILE: &str = "column.conf";
 const CONFIG_TMP_FILE: &str = "column.conf.tmp";
 const DATA_FILE_PREFIX: &str = "data_";
+const LOCK_FILE: &str = "lock";
 /// Config file identity. Format revisions bump `FORMAT_VERSION`, not this.
 const CONFIG_MAGIC: &[u8; 4] = b"LHSF";
 /// On-disk format version. Bump on any breaking layout change (implies a rebuild).
@@ -106,6 +108,8 @@ pub struct StaticFile {
     // Writer holds this across put_batch's fsyncs, so readers block. Accepted:
     // simplicity over read concurrency.
     state: Mutex<State>,
+    /// Exclusive lock on the column dir, released by the OS on drop.
+    _lock: File,
 }
 
 #[derive(Debug)]
@@ -122,6 +126,25 @@ impl StaticFile {
     /// a runtime-only read OOM cap. The column is identified by its directory.
     pub fn open(root_dir: PathBuf, max_value_bytes: u64) -> Result<Self, Error> {
         fs::create_dir_all(&root_dir)?;
+
+        // Exclusive advisory lock before touching anything: a second handle
+        // would heal destructively under a live writer. Released on drop.
+        let lock = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(root_dir.join(LOCK_FILE))?;
+        match lock.try_lock() {
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => {
+                return Err(Error::Invalid(format!(
+                    "already open by another handle: {}",
+                    root_dir.display()
+                )));
+            }
+            Err(TryLockError::Error(e)) => return Err(e.into()),
+        }
+
         let config_path = root_dir.join(CONFIG_FILE);
         let tmp_path = root_dir.join(CONFIG_TMP_FILE);
 
@@ -150,6 +173,7 @@ impl StaticFile {
                 committed,
                 poisoned: false,
             }),
+            _lock: lock,
         };
         handle.heal_to_marker(committed.highest_slot, committed.data_len)?;
         Ok(handle)
@@ -713,6 +737,18 @@ mod tests {
     fn max_slot_is_reserved() {
         let dir = tempfile::tempdir().unwrap();
         assert!(open(&dir).put(u64::MAX, b"x").is_err());
+    }
+
+    #[test]
+    fn second_open_rejected_while_locked() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir);
+        store.put(0, b"a").unwrap();
+
+        assert!(StaticFile::open(dir.path().to_path_buf(), MAX_VALUE_BYTES).is_err());
+
+        drop(store);
+        assert_eq!(open(&dir).get(0).unwrap(), Some(b"a".to_vec()));
     }
 
     #[test]

--- a/common/static_file_storage/src/lib.rs
+++ b/common/static_file_storage/src/lib.rs
@@ -183,8 +183,9 @@ impl StaticFile {
         Ok(handle)
     }
 
-    /// Slot of the most recently committed record, if any.
-    fn highest_written_slot(&self) -> Option<u64> {
+    /// Slot of the most recently committed record, if any — the resume point
+    /// for interrupted migrations. Slots below it may still be gaps.
+    pub fn highest_written_slot(&self) -> Option<u64> {
         self.state.lock().committed.highest_slot
     }
 
@@ -686,9 +687,11 @@ mod tests {
     fn round_trip_sparse_slots() {
         let dir = tempfile::tempdir().unwrap();
         let store = open(&dir);
+        assert_eq!(store.highest_written_slot(), None);
 
         store.put(100, b"a").unwrap();
         store.put(9000, b"b").unwrap();
+        assert_eq!(store.highest_written_slot(), Some(9000));
 
         assert_eq!(store.get(100).unwrap(), Some(b"a".to_vec()));
         assert_eq!(store.get(101).unwrap(), None);

--- a/common/static_file_storage/src/lib.rs
+++ b/common/static_file_storage/src/lib.rs
@@ -115,8 +115,7 @@ impl From<io::Error> for Error {
     }
 }
 
-/// Slot-keyed file set. Owns one directory of `data_*`, `data_*.off`, and
-/// `column.conf` files.
+/// Slot-keyed file set owning one column directory.
 #[derive(Debug)]
 pub struct StaticFile {
     root_dir: PathBuf,
@@ -148,8 +147,8 @@ impl StaticFile {
             sync_dir(parent)?;
         }
 
-        // Exclusive advisory lock before touching anything: a second handle
-        // would heal destructively under a live writer. Released on drop.
+        // Lock before touching anything: a second handle would heal
+        // destructively under a live writer.
         let lock = OpenOptions::new()
             .create(true)
             .write(true)
@@ -220,20 +219,14 @@ impl StaticFile {
         Ok(self.read_offset(file_id(slot), slot)? != 0)
     }
 
-    /// Durably store `bytes` at `slot`. Slots must arrive strictly ascending,
-    /// or be an identical-value re-put of a previously committed slot
-    /// (re-puts at any committed slot are idempotent so migration retries
-    /// after a mid-loop crash are safe). A previously-skipped slot (offset
-    /// zero) cannot be filled — that would break the append-only data file.
+    /// Durably store `bytes` at `slot`; single-item [`Self::put_batch`].
     pub fn put(&self, slot: u64, bytes: &[u8]) -> Result<(), Error> {
         self.put_batch(&[(slot, bytes)])
     }
 
-    /// Append `items` with one fsync per file (data + offset), not per slot.
-    /// Whole batch is durable on return — the same caller-visible contract as
-    /// `put` — but with O(1) syncs per underlying file instead of O(n) per
-    /// item. Items must be strictly ascending. Already-committed prefix items
-    /// are treated as idempotent re-puts if their bytes match, then skipped.
+    /// Append `items`, strictly ascending, durable on return; one fsync per
+    /// file rather than per slot. An already-committed prefix is skipped if
+    /// byte-identical, so retrying a crashed batch is safe.
     pub fn put_batch(&self, items: &[(u64, &[u8])]) -> Result<(), Error> {
         let Some((last_slot, _)) = items.last() else {
             return Ok(());
@@ -268,12 +261,9 @@ impl StaticFile {
             return Ok(());
         }
 
-        // Group remaining items by file_id, write each group with one
-        // data fsync + one offset fsync. Single config commit at end of batch.
-        // Fail-stop: any error past this point leaves on-disk state unverified
-        // (stale offsets, or a conf rename that landed despite the Err), so
-        // poison writes and let open-time healing recover. Reads stay safe:
-        // `committed` never runs ahead of disk.
+        // One data fsync + one offset fsync per file group, one config commit
+        // per batch. Any error past this point leaves disk state unverified,
+        // so poison writes; open-time healing recovers.
         let mut last_data_len: u64 = 0;
         for (target_file_id, group) in group_by_file_id(&items[start..]) {
             match self.write_group(target_file_id, &group, state.committed) {
@@ -408,8 +398,7 @@ impl StaticFile {
         Ok(data_len)
     }
 
-    /// Read a record at `slot` without consulting the writer mutex. Used by
-    /// callers that already hold the lock (`put` for the idempotency check).
+    /// Read the record at `slot`; lock-free — committed bytes are immutable.
     fn read_record(&self, slot: u64) -> Result<Option<Vec<u8>>, Error> {
         let file_id = file_id(slot);
         let offset = self.read_offset(file_id, slot)?;


### PR DESCRIPTION
## Summary
- add and simplify slot-indexed static file storage
- remove built-in compression so callers own payload encoding
- move crash cleanup to open-time recovery
- add critical behavior tests and batch write benchmarks

## Testing
- cargo fmt --package static_file_storage
- cargo check -p static_file_storage
- cargo clippy -p static_file_storage --benches --tests -- -D warnings
- cargo test -p static_file_storage