### PR TITLE
Align FCR implementation with consensus spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3451,6 +3451,7 @@ dependencies = [
  "fixed_bytes",
  "metrics",
  "proto_array",
+ "safe_arith",
  "state_processing",
  "strum",
  "tracing",

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -909,7 +909,8 @@ where
             head_payload_status,
             self.chain_config.fast_confirmation,
             &self.spec,
-        );
+        )
+        .map_err(|e| format!("Unable to initialize canonical head: {e:?}"))?;
         let shuffling_cache_size = self.chain_config.shuffling_cache_size;
         let complete_blob_backfill = self.chain_config.complete_blob_backfill;
         let enable_partial_columns = self.chain_config.enable_partial_columns;

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -910,7 +910,7 @@ where
             self.chain_config.fast_confirmation,
             &self.spec,
         )
-        .map_err(|e| format!("Unable to initialize canonical head: {e:?}"))?;
+        .map_err(|e| format!("Unable to initialize canonical head: {e}"))?;
         let shuffling_cache_size = self.chain_config.shuffling_cache_size;
         let complete_blob_backfill = self.chain_config.complete_blob_backfill;
         let enable_partial_columns = self.chain_config.enable_partial_columns;

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1037,10 +1037,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// The current head's state pulled up as in spec `get_pulled_up_head_state`, with committee
     /// caches built, as the Fast Confirmation Rule requires.
     ///
-    /// Prefer a cached state at or before the current epoch start, which lets us pull a previous
-    /// epoch head exactly to the spec target. If the head itself is from the current epoch, no such
-    /// state exists with `head_root` as latest block, so fall back to the normal per-slot advanced
-    /// cache. Returns `Ok(None)` if no state for `head_root` is cached.
+    /// Takes the best cached state for `head_root` (populated by `state_advance_timer`) and, if it
+    /// is still in an earlier epoch, advances it to the current epoch boundary. Within an epoch the
+    /// committee assignments and effective balances FCR reads are invariant, so a current-epoch
+    /// state needs no further advance. Returns `Ok(None)` if no state for `head_root` is cached.
     fn fcr_pulled_up_head_state(
         &self,
         head_root: Hash256,
@@ -1050,21 +1050,16 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let epoch_start = current_epoch.start_slot(T::EthSpec::slots_per_epoch());
         let Some((state_root, mut state)) = self
             .store
-            .get_advanced_hot_state_from_cache(head_root, epoch_start)
-            .or_else(|| {
-                self.store
-                    .get_advanced_hot_state_from_cache(head_root, slot)
-            })
+            .get_advanced_hot_state_from_cache(head_root, slot)
         else {
             return Ok(None);
         };
 
-        let target_slot = if state.current_epoch() < current_epoch {
-            epoch_start
-        } else {
-            state.slot()
-        };
-        complete_state_advance(&mut state, Some(state_root), target_slot, &self.spec)?;
+        // A previous-epoch head is pulled up to the current epoch boundary; a current-epoch
+        // head is already pulled up, so leave it as-is.
+        if state.current_epoch() < current_epoch {
+            complete_state_advance(&mut state, Some(state_root), epoch_start, &self.spec)?;
+        }
         state.build_all_caches(&self.spec)?;
         Ok(Some(state))
     }

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -839,7 +839,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                             ));
                         }
                     }
-                    let balance_epoch = fcr.current_balance_source.checkpoint.epoch;
+                    let balance_epoch = fcr
+                        .current_epoch_observed_justified
+                        .balances
+                        .checkpoint
+                        .epoch;
                     let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
                     let age = current_epoch
                         .as_u64()

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -781,17 +781,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     equivocating_indices,
                     fcr_head_state,
                 ) {
-                    // During sync and just after checkpoint sync the head state can't yet
-                    // provide current-epoch committee assignments; FCR skips those ticks. These
-                    // are expected transients (never seen in steady state), so log them at debug
-                    // and don't count them as FCR errors.
-                    if matches!(e, fast_confirmation::Error::CommitteeCache(_)) {
-                        debug!(error = ?e, "FCR: head state not ready, skipping tick");
-                    } else {
-                        error!(error = ?e, "Fast Confirmation Rule error, continuing without FCR");
-                        let label: &'static str = (&e).into();
-                        metrics::inc_counter_vec(&fcr_metrics::FCR_ERRORS, &[label]);
-                    }
+                    error!(error = ?e, "Fast Confirmation Rule error, continuing without FCR");
+                    let label: &'static str = (&e).into();
+                    metrics::inc_counter_vec(&fcr_metrics::FCR_ERRORS, &[label]);
                 } else {
                     let confirmed_root_changed = fcr.confirmed_root != old_confirmed;
                     fcr_confirmed_root_changed = confirmed_root_changed;

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -285,7 +285,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         head_payload_status: proto_array::PayloadStatus,
         fast_confirmation: FastConfirmationMode,
         spec: &ChainSpec,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         let fork_choice_view = fork_choice.cached_fork_choice_view();
         let forkchoice_update_params = fork_choice.get_forkchoice_update_parameters();
         let fcr = if fast_confirmation.is_enabled() {
@@ -296,7 +296,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
                     spec.confirmation_byzantine_threshold,
                     spec.proposer_score_boost,
                 )
-                .expect("FCR initialization from head state"),
+                .map_err(|e| Error::FastConfirmationError(format!("{e:?}")))?,
             ))
         } else {
             None
@@ -312,12 +312,12 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
             finalized_hash: forkchoice_update_params.finalized_hash,
         };
 
-        Self {
+        Ok(Self {
             fork_choice: CanonicalHeadRwLock::new(fork_choice),
             cached_head: CanonicalHeadRwLock::new(cached_head),
             recompute_head_lock: Mutex::new(()),
             fast_confirmation: fcr,
-        }
+        })
     }
 
     /// Load a persisted version of `BeaconForkChoice` from the `store` and restore `self` to that
@@ -391,7 +391,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
                 spec.confirmation_byzantine_threshold,
                 spec.proposer_score_boost,
             )
-            .expect("FCR initialization from restored head state");
+            .map_err(|e| Error::FastConfirmationError(format!("{e:?}")))?;
         }
 
         Ok(())
@@ -841,12 +841,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                             ));
                         }
                     }
-                    let balance_epoch = fcr.current_epoch_observed_justified.checkpoint().epoch;
-                    let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
-                    let age = current_epoch
-                        .as_u64()
-                        .saturating_sub(balance_epoch.as_u64());
-                    metrics::set_gauge(&fcr_metrics::FCR_BALANCE_SOURCE_AGE_EPOCHS, age as i64);
                 }
             }
         }
@@ -1049,7 +1043,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         slot: Slot,
     ) -> Result<Option<BeaconState<T::EthSpec>>, Error> {
         let current_epoch = slot.epoch(T::EthSpec::slots_per_epoch());
-        let epoch_start = current_epoch.start_slot(T::EthSpec::slots_per_epoch());
         let Some((state_root, mut state)) = self
             .store
             .get_advanced_hot_state_from_cache(head_root, slot)
@@ -1060,6 +1053,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // A previous-epoch head is pulled up to the current epoch boundary; a current-epoch
         // head is already pulled up, so leave it as-is.
         if state.current_epoch() < current_epoch {
+            let epoch_start = current_epoch.start_slot(T::EthSpec::slots_per_epoch());
             complete_state_advance(&mut state, Some(state_root), epoch_start, &self.spec)?;
         }
         state.build_all_caches(&self.spec)?;

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -289,12 +289,15 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         let fork_choice_view = fork_choice.cached_fork_choice_view();
         let forkchoice_update_params = fork_choice.get_forkchoice_update_parameters();
         let fcr = if fast_confirmation.is_enabled() {
-            Some(Mutex::new(FastConfirmationRule::new(
-                fork_choice_view.finalized_checkpoint,
-                &snapshot.beacon_state,
-                spec.confirmation_byzantine_threshold,
-                spec.proposer_score_boost,
-            )))
+            Some(Mutex::new(
+                FastConfirmationRule::new(
+                    fork_choice_view.finalized_checkpoint,
+                    &snapshot.beacon_state,
+                    spec.confirmation_byzantine_threshold,
+                    spec.proposer_score_boost,
+                )
+                .expect("FCR initialization from head state"),
+            ))
         } else {
             None
         };
@@ -387,7 +390,8 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
                 &self.cached_head.read().snapshot.beacon_state,
                 spec.confirmation_byzantine_threshold,
                 spec.proposer_score_boost,
-            );
+            )
+            .expect("FCR initialization from restored head state");
         }
 
         Ok(())
@@ -781,11 +785,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     // provide current-epoch committee assignments; FCR skips those ticks. These
                     // are expected transients (never seen in steady state), so log them at debug
                     // and don't count them as FCR errors.
-                    if matches!(
-                        e,
-                        fast_confirmation::Error::StaleStateForAssignments { .. }
-                            | fast_confirmation::Error::CommitteeCache(_)
-                    ) {
+                    if matches!(e, fast_confirmation::Error::CommitteeCache(_)) {
                         debug!(error = ?e, "FCR: head state not ready, skipping tick");
                     } else {
                         error!(error = ?e, "Fast Confirmation Rule error, continuing without FCR");

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -841,11 +841,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                             ));
                         }
                     }
-                    let balance_epoch = fcr
-                        .current_epoch_observed_justified
-                        .balances()
-                        .checkpoint
-                        .epoch;
+                    let balance_epoch = fcr.current_epoch_observed_justified.checkpoint().epoch;
                     let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
                     let age = current_epoch
                         .as_u64()

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -285,7 +285,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         head_payload_status: proto_array::PayloadStatus,
         fast_confirmation: FastConfirmationMode,
         spec: &ChainSpec,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, String> {
         let fork_choice_view = fork_choice.cached_fork_choice_view();
         let forkchoice_update_params = fork_choice.get_forkchoice_update_parameters();
         let fcr = if fast_confirmation.is_enabled() {
@@ -296,7 +296,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
                     spec.confirmation_byzantine_threshold,
                     spec.proposer_score_boost,
                 )
-                .map_err(|e| Error::FastConfirmationError(format!("{e:?}")))?,
+                .map_err(|e| format!("Unable to initialize fast confirmation rule: {e:?}"))?,
             ))
         } else {
             None
@@ -391,7 +391,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
                 spec.confirmation_byzantine_threshold,
                 spec.proposer_score_boost,
             )
-            .map_err(|e| Error::FastConfirmationError(format!("{e:?}")))?;
+            .map_err(|e| Error::DBInconsistent(format!("fast confirmation rule reset: {e:?}")))?;
         }
 
         Ok(())
@@ -1034,7 +1034,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         head_root: Hash256,
         slot: Slot,
     ) -> Result<Option<BeaconState<T::EthSpec>>, Error> {
-        let current_epoch = slot.epoch(T::EthSpec::slots_per_epoch());
         let Some((state_root, mut state)) = self
             .store
             .get_advanced_hot_state_from_cache(head_root, slot)
@@ -1044,6 +1043,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // A previous-epoch head is pulled up to the current epoch boundary; a current-epoch
         // head is already pulled up, so leave it as-is.
+        let current_epoch = slot.epoch(T::EthSpec::slots_per_epoch());
         if state.current_epoch() < current_epoch {
             let epoch_start = current_epoch.start_slot(T::EthSpec::slots_per_epoch());
             complete_state_advance(&mut state, Some(state_root), epoch_start, &self.spec)?;

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -841,7 +841,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     }
                     let balance_epoch = fcr
                         .current_epoch_observed_justified
-                        .balances
+                        .balances()
                         .checkpoint
                         .epoch;
                     let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1034,27 +1034,37 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         Ok(Some(el_update_handle))
     }
 
-    /// The current head's state pulled up to `slot` (spec `get_pulled_up_head_state`), with
-    /// committee caches built, as the Fast Confirmation Rule requires.
+    /// The current head's state pulled up as in spec `get_pulled_up_head_state`, with committee
+    /// caches built, as the Fast Confirmation Rule requires.
     ///
-    /// The state is taken from the cache (populated by `state_advance_timer`) and advanced to
-    /// `slot` if it lags behind. Returns `Ok(None)` if no state for `head_root` is cached.
+    /// Prefer a cached state at or before the current epoch start, which lets us pull a previous
+    /// epoch head exactly to the spec target. If the head itself is from the current epoch, no such
+    /// state exists with `head_root` as latest block, so fall back to the normal per-slot advanced
+    /// cache. Returns `Ok(None)` if no state for `head_root` is cached.
     fn fcr_pulled_up_head_state(
         &self,
         head_root: Hash256,
         slot: Slot,
     ) -> Result<Option<BeaconState<T::EthSpec>>, Error> {
+        let current_epoch = slot.epoch(T::EthSpec::slots_per_epoch());
+        let epoch_start = current_epoch.start_slot(T::EthSpec::slots_per_epoch());
         let Some((state_root, mut state)) = self
             .store
-            .get_advanced_hot_state_from_cache(head_root, slot)
+            .get_advanced_hot_state_from_cache(head_root, epoch_start)
+            .or_else(|| {
+                self.store
+                    .get_advanced_hot_state_from_cache(head_root, slot)
+            })
         else {
             return Ok(None);
         };
 
-        // The cache is best-effort and may return a state at any slot <= `slot`; advance it so FCR
-        // sees the head pulled up to the current slot.
-        // TODO(fcr): Consider changing to same epoch state
-        complete_state_advance(&mut state, Some(state_root), slot, &self.spec)?;
+        let target_slot = if state.current_epoch() < current_epoch {
+            epoch_start
+        } else {
+            state.slot()
+        };
+        complete_state_advance(&mut state, Some(state_root), target_slot, &self.spec)?;
         state.build_all_caches(&self.spec)?;
         Ok(Some(state))
     }

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -288,6 +288,17 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
     ) -> Self {
         let fork_choice_view = fork_choice.cached_fork_choice_view();
         let forkchoice_update_params = fork_choice.get_forkchoice_update_parameters();
+        let fcr = if fast_confirmation.is_enabled() {
+            Some(Mutex::new(FastConfirmationRule::new(
+                fork_choice_view.finalized_checkpoint,
+                &snapshot.beacon_state,
+                spec.confirmation_byzantine_threshold,
+                spec.proposer_score_boost,
+            )))
+        } else {
+            None
+        };
+
         let cached_head = CachedHead {
             snapshot,
             justified_checkpoint: fork_choice_view.justified_checkpoint,
@@ -296,16 +307,6 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
             head_hash: forkchoice_update_params.head_hash,
             justified_hash: forkchoice_update_params.justified_hash,
             finalized_hash: forkchoice_update_params.finalized_hash,
-        };
-
-        let fcr = if fast_confirmation.is_enabled() {
-            Some(Mutex::new(FastConfirmationRule::new(
-                fork_choice_view.finalized_checkpoint,
-                spec.confirmation_byzantine_threshold,
-                spec.proposer_score_boost,
-            )))
-        } else {
-            None
         };
 
         Self {
@@ -383,6 +384,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         if let Some(ref fcr_mutex) = self.fast_confirmation {
             *fcr_mutex.lock() = FastConfirmationRule::new(
                 fork_choice_view.finalized_checkpoint,
+                &self.cached_head.read().snapshot.beacon_state,
                 spec.confirmation_byzantine_threshold,
                 spec.proposer_score_boost,
             );

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -57,6 +57,7 @@ pub enum BeaconChainError {
     NoBlockForSlot(Slot),
     BeaconStateError(BeaconStateError),
     EpochCacheError(EpochCacheError),
+    FastConfirmationError(String),
     DBInconsistent(String),
     DBError(store::Error),
     ForkChoiceError(ForkChoiceError),

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -57,7 +57,6 @@ pub enum BeaconChainError {
     NoBlockForSlot(Slot),
     BeaconStateError(BeaconStateError),
     EpochCacheError(EpochCacheError),
-    FastConfirmationError(String),
     DBInconsistent(String),
     DBError(store::Error),
     ForkChoiceError(ForkChoiceError),

--- a/beacon_node/beacon_chain/src/payload_bid_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/payload_bid_verification/tests.rs
@@ -151,7 +151,8 @@ impl TestContext {
             PayloadStatus::Pending,
             FastConfirmationMode::Disabled,
             &spec,
-        );
+        )
+        .unwrap();
 
         let slot_clock = TestingSlotClock::new(
             Slot::new(0),

--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
@@ -84,7 +84,8 @@ impl TestContext {
             PayloadStatus::Pending,
             FastConfirmationMode::Disabled,
             &spec,
-        );
+        )
+        .unwrap();
 
         let slot_clock = TestingSlotClock::new(
             Slot::new(0),

--- a/consensus/fast_confirmation/Cargo.toml
+++ b/consensus/fast_confirmation/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 [dependencies]
 metrics = { workspace = true }
 proto_array = { workspace = true }
+safe_arith = { workspace = true }
 strum = { workspace = true }
 tracing = { workspace = true }
 types = { workspace = true }

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -144,11 +144,21 @@ fn build_chain(num_validators: usize) -> BenchData {
         slashed: vec![false; num_validators],
     };
 
-    // Build FCR state. `new` needs a state to seed balances; the bench overwrites them below, so an
-    // empty genesis state suffices.
+    // Build FCR state. `new` builds head assignments/balances from the state; the bench overwrites
+    // balances below, so a committee-cache-ready empty state suffices.
     let unrealized_justified_checkpoint = justified_checkpoint;
-    let empty_state = BeaconState::<E>::new(0, Default::default(), &spec);
-    let mut fcr = FastConfirmationRule::new(finalized_checkpoint, &empty_state, 25, 40);
+    let mut seed_state = BeaconState::<E>::new(0, Default::default(), &spec);
+    for relative_epoch in [
+        RelativeEpoch::Previous,
+        RelativeEpoch::Current,
+        RelativeEpoch::Next,
+    ] {
+        seed_state
+            .build_committee_cache(relative_epoch, &spec)
+            .expect("committee cache");
+    }
+    let mut fcr = FastConfirmationRule::new(finalized_checkpoint, &seed_state, 25, 40)
+        .expect("fcr initialization");
     fcr.previous_slot_head = head_root;
     fcr.current_slot_head = head_root;
     fcr.test_set_head_balance_source(balance_source.clone());
@@ -156,19 +166,6 @@ fn build_chain(num_validators: usize) -> BenchData {
         CheckpointAndBalance::new(justified_checkpoint, balance_source.clone());
     fcr.previous_epoch_observed_justified =
         CheckpointAndBalance::new(justified_checkpoint, balance_source.clone());
-
-    // Synthetic committee slot assignments: spread validators across the epoch.
-    // Canonical 3-column layout: column 0 (previous epoch) is left UNSET because
-    // the bench scenario runs entirely within epoch 0; columns 1 and 2 (current
-    // and next) hold the validator's slot.
-    let spe = E::slots_per_epoch() as usize;
-    let mut assignments = vec![fast_confirmation::UNSET_SLOT; num_validators * 3];
-    for val_idx in 0..num_validators {
-        let slot = Slot::new((val_idx % spe) as u64);
-        assignments[val_idx * 3 + 1] = slot;
-        assignments[val_idx * 3 + 2] = slot;
-    }
-    fcr.test_set_head_slot_assignments(assignments);
 
     BenchData {
         proto_array,

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -138,7 +138,7 @@ fn build_chain(num_validators: usize) -> BenchData {
     // Build balance source.
     let total_active_balance = BALANCE.saturating_mul(num_validators as u64);
     let balance_source = BalanceSourceData {
-        checkpoint: justified_checkpoint,
+        dependent_root: justified_checkpoint.root,
         total_active_balance,
         effective_balances: vec![BALANCE; num_validators],
         slashed: vec![false; num_validators],

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -190,7 +190,7 @@ fn build_chain(num_validators: usize) -> BenchData {
 fn bench_get_current_target_score(c: &mut Criterion) {
     let mut group = c.benchmark_group("get_current_target_score");
 
-    for &n in &[64, 16_000, 100_000, 500_000] {
+    for &n in &[64, 16_000, 100_000, 500_000, 1_000_000] {
         let data = build_chain(n);
 
         if n >= 100_000 {
@@ -216,7 +216,7 @@ fn bench_get_current_target_score(c: &mut Criterion) {
 fn bench_precompute_chain_scores(c: &mut Criterion) {
     let mut group = c.benchmark_group("precompute_chain_scores");
 
-    for &n in &[64, 16_000, 100_000, 500_000] {
+    for &n in &[64, 16_000, 100_000, 500_000, 1_000_000] {
         let data = build_chain(n);
         let genesis_root = data.block_roots[0];
         // `block_roots[1..]` is exactly `get_ancestor_roots(head, genesis)` for this linear chain.
@@ -249,7 +249,7 @@ fn bench_precompute_chain_scores(c: &mut Criterion) {
 fn bench_get_latest_confirmed(c: &mut Criterion) {
     let mut group = c.benchmark_group("get_latest_confirmed");
 
-    for &n in &[64, 16_000, 100_000, 500_000] {
+    for &n in &[64, 16_000, 100_000, 500_000, 1_000_000] {
         let data = build_chain(n);
 
         if n >= 100_000 {

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeSet;
 use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use fast_confirmation::{BalanceSourceData, FastConfirmationRule};
+use fast_confirmation::{BalanceSourceData, CheckpointAndBalance, FastConfirmationRule};
 use fixed_bytes::FixedBytesExtended;
 use proto_array::core::{ProtoArray, VoteTracker};
 use proto_array::{Block, ExecutionStatus, JustifiedBalances, ProtoArrayForkChoice};
@@ -150,10 +150,14 @@ fn build_chain(num_validators: usize) -> BenchData {
     fcr.previous_slot_head = head_root;
     fcr.current_slot_head = head_root;
     fcr.test_set_head_balance_source(balance_source.clone());
-    fcr.current_balance_source = balance_source.clone();
-    fcr.previous_balance_source = balance_source.clone();
-    fcr.current_epoch_observed_justified_checkpoint = justified_checkpoint;
-    fcr.previous_epoch_observed_justified_checkpoint = justified_checkpoint;
+    fcr.current_epoch_observed_justified = CheckpointAndBalance {
+        checkpoint: justified_checkpoint,
+        balances: balance_source.clone(),
+    };
+    fcr.previous_epoch_observed_justified = CheckpointAndBalance {
+        checkpoint: justified_checkpoint,
+        balances: balance_source.clone(),
+    };
 
     // Synthetic committee slot assignments: spread validators across the epoch.
     // Canonical 3-column layout: column 0 (previous epoch) is left UNSET because

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -149,6 +149,7 @@ fn build_chain(num_validators: usize) -> BenchData {
     let mut fcr = FastConfirmationRule::new(finalized_checkpoint, 25, 40);
     fcr.previous_slot_head = head_root;
     fcr.current_slot_head = head_root;
+    fcr.test_set_head_balance_source(balance_source.clone());
     fcr.current_balance_source = balance_source.clone();
     fcr.previous_balance_source = balance_source.clone();
     fcr.current_epoch_observed_justified_checkpoint = justified_checkpoint;

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -144,9 +144,11 @@ fn build_chain(num_validators: usize) -> BenchData {
         slashed: vec![false; num_validators],
     };
 
-    // Build FCR state.
+    // Build FCR state. `new` needs a state to seed balances; the bench overwrites them below, so an
+    // empty genesis state suffices.
     let unrealized_justified_checkpoint = justified_checkpoint;
-    let mut fcr = FastConfirmationRule::new(finalized_checkpoint, 25, 40);
+    let empty_state = BeaconState::<E>::new(0, Default::default(), &spec);
+    let mut fcr = FastConfirmationRule::new(finalized_checkpoint, &empty_state, 25, 40);
     fcr.previous_slot_head = head_root;
     fcr.current_slot_head = head_root;
     fcr.test_set_head_balance_source(balance_source.clone());

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -150,14 +150,10 @@ fn build_chain(num_validators: usize) -> BenchData {
     fcr.previous_slot_head = head_root;
     fcr.current_slot_head = head_root;
     fcr.test_set_head_balance_source(balance_source.clone());
-    fcr.current_epoch_observed_justified = CheckpointAndBalance {
-        checkpoint: justified_checkpoint,
-        balances: balance_source.clone(),
-    };
-    fcr.previous_epoch_observed_justified = CheckpointAndBalance {
-        checkpoint: justified_checkpoint,
-        balances: balance_source.clone(),
-    };
+    fcr.current_epoch_observed_justified =
+        CheckpointAndBalance::new(justified_checkpoint, balance_source.clone());
+    fcr.previous_epoch_observed_justified =
+        CheckpointAndBalance::new(justified_checkpoint, balance_source.clone());
 
     // Synthetic committee slot assignments: spread validators across the epoch.
     // Canonical 3-column layout: column 0 (previous epoch) is left UNSET because

--- a/consensus/fast_confirmation/src/balance_source.rs
+++ b/consensus/fast_confirmation/src/balance_source.rs
@@ -52,6 +52,25 @@ impl BalanceSourceData {
         }
     }
 
+    /// Build a balance source for a single `epoch`, anchored to `checkpoint`.
+    pub(crate) fn for_epoch<E: EthSpec>(
+        state: &BeaconState<E>,
+        epoch: Epoch,
+        checkpoint: Checkpoint,
+    ) -> Result<Self, Error> {
+        let (slashed, per_epoch) = Self::build_for_epochs(state, &[epoch])?;
+        let eb = per_epoch
+            .into_iter()
+            .next()
+            .ok_or(Error::IndexOutOfBounds(0))?;
+        Ok(Self::from_parts(
+            checkpoint,
+            eb.effective_balances,
+            eb.total_active_balance,
+            slashed,
+        ))
+    }
+
     /// Build the shared (epoch-independent) `slashed` bitvec and, for each requested epoch, the
     /// active-validator `effective_balances` vector and `total_active_balance`, in a **single**
     /// pass over the validator set.

--- a/consensus/fast_confirmation/src/balance_source.rs
+++ b/consensus/fast_confirmation/src/balance_source.rs
@@ -1,5 +1,7 @@
 //! Per-checkpoint snapshot of validator balances used by the Fast Confirmation Rule.
 
+use crate::Error;
+use safe_arith::SafeArith;
 use tracing::{debug, debug_span};
 use types::{BeaconState, Checkpoint, Epoch, EthSpec};
 
@@ -63,7 +65,7 @@ impl BalanceSourceData {
     pub(crate) fn build_for_epochs<E: EthSpec>(
         state: &BeaconState<E>,
         epochs: &[Epoch],
-    ) -> (Vec<bool>, Vec<EpochBalances>) {
+    ) -> Result<(Vec<bool>, Vec<EpochBalances>), Error> {
         let _span = debug_span!("fcr_build_balance_source", epochs = epochs.len()).entered();
 
         let validator_count = state.validators().len();
@@ -82,14 +84,16 @@ impl BalanceSourceData {
             for (i, &epoch) in epochs.iter().enumerate() {
                 if validator.is_active_at(epoch) {
                     per_epoch[i].effective_balances.push(effective_balance);
-                    per_epoch[i].total_active_balance += effective_balance;
+                    per_epoch[i].total_active_balance = per_epoch[i]
+                        .total_active_balance
+                        .safe_add(effective_balance)?;
                 } else {
                     per_epoch[i].effective_balances.push(0);
                 }
             }
         }
 
-        (slashed, per_epoch)
+        Ok((slashed, per_epoch))
     }
 
     pub(crate) fn balance(&self, val_idx: usize) -> u64 {

--- a/consensus/fast_confirmation/src/balance_source.rs
+++ b/consensus/fast_confirmation/src/balance_source.rs
@@ -1,14 +1,14 @@
-//! Per-checkpoint snapshot of validator balances used by the Fast Confirmation Rule.
+//! Validator-balance snapshot used by the Fast Confirmation Rule.
 
-use types::{BeaconState, Checkpoint, Epoch, EthSpec};
+use types::{BeaconState, Epoch, EthSpec, Hash256};
 
-/// Snapshot of a checkpoint state's balances and committee assignments.
+/// Snapshot of a validator set's effective balances for one epoch.
 ///
-/// FCR needs two of these simultaneously: one for new confirmations (current epoch
-/// observed justified) and one for reconfirmation at epoch boundaries (previous).
+/// `dependent_root` (the block at the last slot of the previous epoch) is the chain-identity that
+/// fixes this snapshot — two chains sharing it have the same view — and is used as the cache key.
 #[derive(Clone, Debug)]
 pub struct BalanceSourceData {
-    pub checkpoint: Checkpoint,
+    pub dependent_root: Hash256,
     pub total_active_balance: u64,
     /// Effective balance per validator index. 0 for inactive.
     pub effective_balances: Vec<u64>,
@@ -18,15 +18,15 @@ pub struct BalanceSourceData {
 }
 
 impl BalanceSourceData {
-    /// Build a balance source for a single `epoch`, anchored to `checkpoint`, in one pass over the
-    /// validator set. Effective balance is counted for active validators regardless of slashed
+    /// Build a balance source for a single `epoch`, tagged with `dependent_root`, in one pass over
+    /// the validator set. Effective balance is counted for active validators regardless of slashed
     /// status (matching the spec's `get_total_active_balance`); `slashed` is recorded separately
     /// for the slashed-filtering used by `get_block_support_between_slots`. The total uses a
     /// saturating add — it is a sum of effective balances and cannot realistically overflow `u64`.
     pub(crate) fn for_epoch<E: EthSpec>(
         state: &BeaconState<E>,
         epoch: Epoch,
-        checkpoint: Checkpoint,
+        dependent_root: Hash256,
     ) -> Self {
         let validators = state.validators();
         let mut effective_balances = Vec::with_capacity(validators.len());
@@ -45,7 +45,7 @@ impl BalanceSourceData {
         }
 
         Self {
-            checkpoint,
+            dependent_root,
             total_active_balance,
             effective_balances,
             slashed,

--- a/consensus/fast_confirmation/src/balance_source.rs
+++ b/consensus/fast_confirmation/src/balance_source.rs
@@ -1,6 +1,5 @@
 //! Per-checkpoint snapshot of validator balances used by the Fast Confirmation Rule.
 
-use tracing::{debug, debug_span};
 use types::{BeaconState, Checkpoint, Epoch, EthSpec};
 
 /// Snapshot of a checkpoint state's balances and committee assignments.
@@ -19,27 +18,6 @@ pub struct BalanceSourceData {
 }
 
 impl BalanceSourceData {
-    /// Assemble a `BalanceSourceData` from already-computed parts.
-    pub(crate) fn from_parts(
-        checkpoint: Checkpoint,
-        effective_balances: Vec<u64>,
-        total_active_balance: u64,
-        slashed: Vec<bool>,
-    ) -> Self {
-        debug!(
-            validators = effective_balances.len(),
-            active_balance = total_active_balance,
-            epoch = %checkpoint.epoch,
-            "FCR balance source built"
-        );
-        Self {
-            checkpoint,
-            total_active_balance,
-            effective_balances,
-            slashed,
-        }
-    }
-
     /// Build a balance source for a single `epoch`, anchored to `checkpoint`, in one pass over the
     /// validator set. Effective balance is counted for active validators regardless of slashed
     /// status (matching the spec's `get_total_active_balance`); `slashed` is recorded separately
@@ -50,8 +28,6 @@ impl BalanceSourceData {
         epoch: Epoch,
         checkpoint: Checkpoint,
     ) -> Self {
-        let _span = debug_span!("fcr_build_balance_source", epoch = %epoch).entered();
-
         let validators = state.validators();
         let mut effective_balances = Vec::with_capacity(validators.len());
         let mut slashed = Vec::with_capacity(validators.len());
@@ -68,12 +44,12 @@ impl BalanceSourceData {
             }
         }
 
-        Self::from_parts(
+        Self {
             checkpoint,
-            effective_balances,
             total_active_balance,
+            effective_balances,
             slashed,
-        )
+        }
     }
 
     pub(crate) fn balance(&self, val_idx: usize) -> u64 {

--- a/consensus/fast_confirmation/src/balance_source.rs
+++ b/consensus/fast_confirmation/src/balance_source.rs
@@ -82,9 +82,7 @@ impl BalanceSourceData {
             for (i, &epoch) in epochs.iter().enumerate() {
                 if validator.is_active_at(epoch) {
                     per_epoch[i].effective_balances.push(effective_balance);
-                    per_epoch[i].total_active_balance = per_epoch[i]
-                        .total_active_balance
-                        .saturating_add(effective_balance);
+                    per_epoch[i].total_active_balance += effective_balance;
                 } else {
                     per_epoch[i].effective_balances.push(0);
                 }
@@ -96,6 +94,22 @@ impl BalanceSourceData {
 
     pub(crate) fn balance(&self, val_idx: usize) -> u64 {
         self.effective_balances.get(val_idx).copied().unwrap_or(0)
+    }
+
+    pub(crate) fn active_indices(&self) -> impl Iterator<Item = usize> + '_ {
+        self.effective_balances
+            .iter()
+            .enumerate()
+            .filter_map(|(i, balance)| (*balance > 0).then_some(i))
+    }
+
+    pub(crate) fn unslashed_and_active_indices(&self) -> impl Iterator<Item = usize> + '_ {
+        self.effective_balances
+            .iter()
+            .enumerate()
+            .filter_map(|(i, balance)| {
+                (*balance > 0 && !self.slashed.get(i).copied().unwrap_or(false)).then_some(i)
+            })
     }
 
     /// Return balance only if the validator is not slashed.

--- a/consensus/fast_confirmation/src/balance_source.rs
+++ b/consensus/fast_confirmation/src/balance_source.rs
@@ -1,5 +1,6 @@
 //! Validator-balance snapshot used by the Fast Confirmation Rule.
 
+use crate::Error;
 use types::{BeaconState, Epoch, EthSpec, Hash256};
 
 /// Snapshot of a validator set's effective balances for one epoch.
@@ -18,16 +19,16 @@ pub struct BalanceSourceData {
 }
 
 impl BalanceSourceData {
-    /// Build a balance source for a single `epoch`, tagged with `dependent_root`, in one pass over
-    /// the validator set. Effective balance is counted for active validators regardless of slashed
-    /// status (matching the spec's `get_total_active_balance`); `slashed` is recorded separately
-    /// for the slashed-filtering used by `get_block_support_between_slots`. The total uses a
-    /// saturating add — it is a sum of effective balances and cannot realistically overflow `u64`.
+    /// Build a balance source for a single `epoch` in one pass over the validator set, tagged with
+    /// the epoch's dependent root. Effective balance is counted for active validators regardless of
+    /// slashed status (matching the spec's `get_total_active_balance`); `slashed` is recorded
+    /// separately for the slashed-filtering used by `get_block_support_between_slots`. The total
+    /// uses a saturating add — it is a sum of effective balances and cannot realistically overflow.
     pub(crate) fn for_epoch<E: EthSpec>(
         state: &BeaconState<E>,
         epoch: Epoch,
-        dependent_root: Hash256,
-    ) -> Self {
+    ) -> Result<Self, Error> {
+        let dependent_root = crate::dependent_root::<E>(state, epoch)?;
         let validators = state.validators();
         let mut effective_balances = Vec::with_capacity(validators.len());
         let mut slashed = Vec::with_capacity(validators.len());
@@ -44,12 +45,12 @@ impl BalanceSourceData {
             }
         }
 
-        Self {
+        Ok(Self {
             dependent_root,
             total_active_balance,
             effective_balances,
             slashed,
-        }
+        })
     }
 
     pub(crate) fn balance(&self, val_idx: usize) -> u64 {

--- a/consensus/fast_confirmation/src/balance_source.rs
+++ b/consensus/fast_confirmation/src/balance_source.rs
@@ -1,7 +1,5 @@
 //! Per-checkpoint snapshot of validator balances used by the Fast Confirmation Rule.
 
-use crate::Error;
-use safe_arith::SafeArith;
 use tracing::{debug, debug_span};
 use types::{BeaconState, Checkpoint, Epoch, EthSpec};
 
@@ -9,7 +7,7 @@ use types::{BeaconState, Checkpoint, Epoch, EthSpec};
 ///
 /// FCR needs two of these simultaneously: one for new confirmations (current epoch
 /// observed justified) and one for reconfirmation at epoch boundaries (previous).
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct BalanceSourceData {
     pub checkpoint: Checkpoint,
     pub total_active_balance: u64,
@@ -20,18 +18,8 @@ pub struct BalanceSourceData {
     pub slashed: Vec<bool>,
 }
 
-/// Active-validator balances for a single epoch, produced by
-/// [`BalanceSourceData::build_for_epochs`].
-#[derive(Default)]
-pub(crate) struct EpochBalances {
-    /// Per-validator effective balance; `0` for validators not active at the epoch.
-    pub(crate) effective_balances: Vec<u64>,
-    /// Sum of `effective_balances` over validators active at the epoch.
-    pub(crate) total_active_balance: u64,
-}
-
 impl BalanceSourceData {
-    /// Assemble a `BalanceSourceData` from already-computed parts (see `build_for_epochs`).
+    /// Assemble a `BalanceSourceData` from already-computed parts.
     pub(crate) fn from_parts(
         checkpoint: Checkpoint,
         effective_balances: Vec<u64>,
@@ -52,67 +40,40 @@ impl BalanceSourceData {
         }
     }
 
-    /// Build a balance source for a single `epoch`, anchored to `checkpoint`.
+    /// Build a balance source for a single `epoch`, anchored to `checkpoint`, in one pass over the
+    /// validator set. Effective balance is counted for active validators regardless of slashed
+    /// status (matching the spec's `get_total_active_balance`); `slashed` is recorded separately
+    /// for the slashed-filtering used by `get_block_support_between_slots`. The total uses a
+    /// saturating add — it is a sum of effective balances and cannot realistically overflow `u64`.
     pub(crate) fn for_epoch<E: EthSpec>(
         state: &BeaconState<E>,
         epoch: Epoch,
         checkpoint: Checkpoint,
-    ) -> Result<Self, Error> {
-        let (slashed, per_epoch) = Self::build_for_epochs(state, &[epoch])?;
-        let eb = per_epoch
-            .into_iter()
-            .next()
-            .ok_or(Error::IndexOutOfBounds(0))?;
-        Ok(Self::from_parts(
-            checkpoint,
-            eb.effective_balances,
-            eb.total_active_balance,
-            slashed,
-        ))
-    }
+    ) -> Self {
+        let _span = debug_span!("fcr_build_balance_source", epoch = %epoch).entered();
 
-    /// Build the shared (epoch-independent) `slashed` bitvec and, for each requested epoch, the
-    /// active-validator `effective_balances` vector and `total_active_balance`, in a **single**
-    /// pass over the validator set.
-    ///
-    /// At an epoch boundary FCR rebuilds three balance sources (head, current, previous); they
-    /// share the same state and differ only by epoch, so batching them here turns three full
-    /// validator-set iterations into one. The per-validator computation is identical to building
-    /// each source separately: effective balance is counted for active validators regardless of
-    /// slashed status (matching the spec's `get_total_active_balance`), and `slashed` is recorded
-    /// for the separate slashed-filtering used by `get_block_support_between_slots`.
-    pub(crate) fn build_for_epochs<E: EthSpec>(
-        state: &BeaconState<E>,
-        epochs: &[Epoch],
-    ) -> Result<(Vec<bool>, Vec<EpochBalances>), Error> {
-        let _span = debug_span!("fcr_build_balance_source", epochs = epochs.len()).entered();
+        let validators = state.validators();
+        let mut effective_balances = Vec::with_capacity(validators.len());
+        let mut slashed = Vec::with_capacity(validators.len());
+        let mut total_active_balance = 0u64;
 
-        let validator_count = state.validators().len();
-        let mut slashed = Vec::with_capacity(validator_count);
-        let mut per_epoch: Vec<EpochBalances> = epochs
-            .iter()
-            .map(|_| EpochBalances {
-                effective_balances: Vec::with_capacity(validator_count),
-                total_active_balance: 0,
-            })
-            .collect();
-
-        for validator in state.validators().iter() {
+        for validator in validators.iter() {
             slashed.push(validator.slashed);
-            let effective_balance = validator.effective_balance;
-            for (i, &epoch) in epochs.iter().enumerate() {
-                if validator.is_active_at(epoch) {
-                    per_epoch[i].effective_balances.push(effective_balance);
-                    per_epoch[i].total_active_balance = per_epoch[i]
-                        .total_active_balance
-                        .safe_add(effective_balance)?;
-                } else {
-                    per_epoch[i].effective_balances.push(0);
-                }
+            if validator.is_active_at(epoch) {
+                effective_balances.push(validator.effective_balance);
+                total_active_balance =
+                    total_active_balance.saturating_add(validator.effective_balance);
+            } else {
+                effective_balances.push(0);
             }
         }
 
-        Ok((slashed, per_epoch))
+        Self::from_parts(
+            checkpoint,
+            effective_balances,
+            total_active_balance,
+            slashed,
+        )
     }
 
     pub(crate) fn balance(&self, val_idx: usize) -> u64 {

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -77,13 +77,6 @@ pub enum Error {
     BlockEpochNone(Hash256),
     CommitteeCache(String),
     UnsetSlotAssignment(usize),
-    /// The state's epoch window does not cover `current_slot`'s epoch.
-    /// This means the state is too stale to provide committee assignments for the
-    /// slots FCR needs to query.
-    StaleStateForAssignments {
-        current_slot_epoch: Epoch,
-        state_epoch: Epoch,
-    },
     /// A computed index was out of bounds. Indicates a broken internal invariant, not bad input.
     IndexOutOfBounds(usize),
     ArithError(ArithError),
@@ -157,17 +150,18 @@ impl FastConfirmationRule {
     /// Maximum valid value for `byzantine_threshold` (25%).
     const MAX_BYZANTINE_THRESHOLD: u64 = 25;
 
-    /// Initialize FCR from the finalized checkpoint and head `state`, building all three balance
-    /// sources up front. Head is anchored to `finalized_checkpoint` as a placeholder and re-anchored
-    /// to its dependent root on the first tick. `byzantine_threshold` is clamped to [0, 25].
+    /// Initialize FCR from the finalized checkpoint and head `state`, building the balance sources
+    /// and committee assignments up front. The head-derived caches are anchored to
+    /// `finalized_checkpoint.root` as a placeholder and re-anchored to the head's dependent root on
+    /// the first tick. `byzantine_threshold` is clamped to [0, 25].
     pub fn new<E: EthSpec>(
         finalized_checkpoint: Checkpoint,
         state: &BeaconState<E>,
         byzantine_threshold: u64,
         proposer_score_boost: u64,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         let byzantine_threshold = byzantine_threshold.min(Self::MAX_BYZANTINE_THRESHOLD);
-        Self {
+        Ok(Self {
             confirmed_root: finalized_checkpoint.root,
             previous_epoch_observed_justified: CheckpointAndBalance::new(
                 finalized_checkpoint,
@@ -190,7 +184,7 @@ impl FastConfirmationRule {
             current_slot_head: finalized_checkpoint.root,
             byzantine_threshold,
             proposer_score_boost,
-            head_assignments: SlotAssignments::new(),
+            head_assignments: SlotAssignments::new(state, finalized_checkpoint.root)?,
             head_balance_source: BalanceSourceData::for_epoch(
                 state,
                 state.current_epoch(),
@@ -198,7 +192,7 @@ impl FastConfirmationRule {
             ),
             last_update_slot: None,
             spec_test_mode: false,
-        }
+        })
     }
 
     /// Enable spec test mode: `on_fast_confirmation` still tracks variables but
@@ -206,15 +200,6 @@ impl FastConfirmationRule {
     /// when the test needs the confirmation result.
     pub fn set_spec_test_mode(&mut self, enabled: bool) {
         self.spec_test_mode = enabled;
-    }
-
-    /// Directly set committee slot assignments. Intended for synthetic-data benchmarks
-    /// that lack a real `BeaconState`; not used in production.
-    ///
-    /// `assignments` must be in the canonical 3-column layout
-    /// (`validator_count * 3`). Use `UNSET_SLOT` for columns with no assignment.
-    pub fn test_set_head_slot_assignments(&mut self, assignments: Vec<Slot>) {
-        self.head_assignments.test_set_from(assignments);
     }
 
     /// Directly set head balances for synthetic-data benchmarks; not used in production.
@@ -295,17 +280,19 @@ impl FastConfirmationRule {
             self.previous_slot_head = self.current_slot_head;
             self.current_slot_head = head_root;
 
-            // The head-derived caches (committee assignments + head balance source) are keyed on the
-            // dependent root; rebuild both from scratch when a reorg past the previous-epoch boundary
-            // (or a new epoch) changes it.
+            // The head-derived caches (committee assignments + head balance source) are each keyed on
+            // the head's dependent root; rebuild each from scratch, independently, when its own
+            // dependent root is stale (a reorg past the previous-epoch boundary, or a new epoch).
             let current_epoch = current_slot.epoch(E::slots_per_epoch());
             let head_dependent_root = dependent_root::<E>(state, current_epoch)?;
+
+            if self.head_assignments.dependent_root() != head_dependent_root {
+                let _span = debug_span!("fcr_rebuild_assignments").entered();
+                self.head_assignments = SlotAssignments::new::<E>(state, head_dependent_root)?;
+            }
+
             if self.head_balance_source.dependent_root != head_dependent_root {
-                // Two distinct O(V) builds — span each so the cost is individually attributable.
-                self.head_assignments = {
-                    let _span = debug_span!("fcr_rebuild_assignments").entered();
-                    SlotAssignments::for_state::<E>(state, current_slot)?
-                };
+                let _span = debug_span!("fcr_rebuild_head_balance").entered();
                 let head_epoch = if state.current_epoch() < current_epoch {
                     state
                         .next_epoch()
@@ -313,10 +300,8 @@ impl FastConfirmationRule {
                 } else {
                     state.current_epoch()
                 };
-                self.head_balance_source = {
-                    let _span = debug_span!("fcr_rebuild_head_balance").entered();
-                    BalanceSourceData::for_epoch(state, head_epoch, head_dependent_root)
-                };
+                self.head_balance_source =
+                    BalanceSourceData::for_epoch(state, head_epoch, head_dependent_root);
             }
         }
 

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -293,15 +293,8 @@ impl FastConfirmationRule {
 
             if self.head_balance_source.dependent_root != head_dependent_root {
                 let _span = debug_span!("fcr_rebuild_head_balance").entered();
-                let head_epoch = if state.current_epoch() < current_epoch {
-                    state
-                        .next_epoch()
-                        .map_err(|e| Error::CommitteeCache(format!("{e:?}")))?
-                } else {
-                    state.current_epoch()
-                };
                 self.head_balance_source =
-                    BalanceSourceData::for_epoch(state, head_epoch, head_dependent_root);
+                    BalanceSourceData::for_epoch(state, current_epoch, head_dependent_root);
             }
         }
 

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -151,9 +151,8 @@ impl FastConfirmationRule {
     const MAX_BYZANTINE_THRESHOLD: u64 = 25;
 
     /// Initialize FCR from the finalized checkpoint and head `state`, building the balance sources
-    /// and committee assignments up front. The head-derived caches are anchored to
-    /// `finalized_checkpoint.root` as a placeholder and re-anchored to the head's dependent root on
-    /// the first tick. `byzantine_threshold` is clamped to [0, 25].
+    /// and committee assignments up front (each tagged with its own dependent root derived from the
+    /// state). `byzantine_threshold` is clamped to [0, 25].
     pub fn new<E: EthSpec>(
         finalized_checkpoint: Checkpoint,
         state: &BeaconState<E>,
@@ -165,31 +164,19 @@ impl FastConfirmationRule {
             confirmed_root: finalized_checkpoint.root,
             previous_epoch_observed_justified: CheckpointAndBalance::new(
                 finalized_checkpoint,
-                BalanceSourceData::for_epoch(
-                    state,
-                    state.previous_epoch(),
-                    finalized_checkpoint.root,
-                ),
+                BalanceSourceData::for_epoch(state, state.previous_epoch())?,
             ),
             current_epoch_observed_justified: CheckpointAndBalance::new(
                 finalized_checkpoint,
-                BalanceSourceData::for_epoch(
-                    state,
-                    state.current_epoch(),
-                    finalized_checkpoint.root,
-                ),
+                BalanceSourceData::for_epoch(state, state.current_epoch())?,
             ),
             previous_epoch_greatest_unrealized_checkpoint: finalized_checkpoint,
             previous_slot_head: finalized_checkpoint.root,
             current_slot_head: finalized_checkpoint.root,
             byzantine_threshold,
             proposer_score_boost,
-            head_assignments: SlotAssignments::new(state, finalized_checkpoint.root)?,
-            head_balance_source: BalanceSourceData::for_epoch(
-                state,
-                state.current_epoch(),
-                finalized_checkpoint.root,
-            ),
+            head_assignments: SlotAssignments::new(state)?,
+            head_balance_source: BalanceSourceData::for_epoch(state, state.current_epoch())?,
             last_update_slot: None,
             spec_test_mode: false,
         })
@@ -274,6 +261,7 @@ impl FastConfirmationRule {
         state: &BeaconState<E>,
     ) -> Result<(), Error> {
         let _span = debug_span!("fcr_update_variables", slot = %current_slot).entered();
+        let current_epoch = current_slot.epoch(E::slots_per_epoch());
 
         // Track head changes (including within a slot, e.g. a late block or reorg).
         if self.current_slot_head != head_root {
@@ -283,18 +271,16 @@ impl FastConfirmationRule {
             // The head-derived caches (committee assignments + head balance source) are each keyed on
             // the head's dependent root; rebuild each from scratch, independently, when its own
             // dependent root is stale (a reorg past the previous-epoch boundary, or a new epoch).
-            let current_epoch = current_slot.epoch(E::slots_per_epoch());
             let head_dependent_root = dependent_root::<E>(state, current_epoch)?;
 
             if self.head_assignments.dependent_root() != head_dependent_root {
                 let _span = debug_span!("fcr_rebuild_assignments").entered();
-                self.head_assignments = SlotAssignments::new::<E>(state, head_dependent_root)?;
+                self.head_assignments = SlotAssignments::new::<E>(state)?;
             }
 
             if self.head_balance_source.dependent_root != head_dependent_root {
                 let _span = debug_span!("fcr_rebuild_head_balance").entered();
-                self.head_balance_source =
-                    BalanceSourceData::for_epoch(state, current_epoch, head_dependent_root);
+                self.head_balance_source = BalanceSourceData::for_epoch(state, current_epoch)?;
             }
         }
 
@@ -312,13 +298,12 @@ impl FastConfirmationRule {
             // checkpoint in one step so the pair stays coherent.
             if is_start_slot_at_epoch::<E>(current_slot) {
                 let new_current_cp = self.previous_epoch_greatest_unrealized_checkpoint;
-                let dep_root = dependent_root::<E>(state, state.current_epoch())?;
                 self.previous_epoch_observed_justified =
                     self.current_epoch_observed_justified.clone();
                 self.current_epoch_observed_justified =
                     CheckpointAndBalance::new(new_current_cp, {
                         let _span = debug_span!("fcr_rebuild_current_balance").entered();
-                        BalanceSourceData::for_epoch(state, state.current_epoch(), dep_root)
+                        BalanceSourceData::for_epoch(state, current_epoch)?
                     });
             }
 
@@ -1356,7 +1341,10 @@ fn compute_start_slot_at_epoch<E: EthSpec>(epoch: Epoch) -> Slot {
 
 /// Shuffling/validator-set decision root for `epoch`: the block at the last slot of the previous
 /// epoch. Genesis has no previous epoch, so it is identified by the zero root.
-fn dependent_root<E: EthSpec>(state: &BeaconState<E>, epoch: Epoch) -> Result<Hash256, Error> {
+pub(crate) fn dependent_root<E: EthSpec>(
+    state: &BeaconState<E>,
+    epoch: Epoch,
+) -> Result<Hash256, Error> {
     if epoch == 0 {
         return Ok(Hash256::ZERO);
     }

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -290,22 +290,19 @@ impl FastConfirmationRule {
     ) -> Result<(), Error> {
         let _span = debug_span!("fcr_update_variables", slot = %current_slot).entered();
 
-        // Track head changes (including within a slot, e.g. a late block or reorg) and rebuild the
-        // head-derived caches — committee assignments and the head balance source — for the new head.
+        // Track head changes (including within a slot, e.g. a late block or reorg).
         if self.current_slot_head != head_root {
             self.previous_slot_head = self.current_slot_head;
             self.current_slot_head = head_root;
-            {
-                let _span = debug_span!("fcr_rebuild_assignments").entered();
-                self.head_assignments.rebuild::<E>(state, current_slot)?;
-            }
 
-            // Head balance source is keyed on the dependent root; rebuild it when a reorg past the
-            // previous-epoch boundary changes it.
+            // The head-derived caches (committee assignments + head balance source) are keyed on the
+            // dependent root; rebuild both from scratch when a reorg past the previous-epoch boundary
+            // (or a new epoch) changes it.
             let current_epoch = current_slot.epoch(E::slots_per_epoch());
             let head_dependent_root = dependent_root::<E>(state, current_epoch)?;
             if self.head_balance_source.dependent_root != head_dependent_root {
-                let _span = debug_span!("fcr_rebuild_balances").entered();
+                let _span = debug_span!("fcr_rebuild_head_caches").entered();
+                self.head_assignments = SlotAssignments::for_state::<E>(state, current_slot)?;
                 let head_epoch = if state.current_epoch() < current_epoch {
                     state
                         .next_epoch()

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -243,6 +243,11 @@ impl FastConfirmationRule {
         self.head_assignments.test_set_from(assignments);
     }
 
+    /// Directly set head balances for synthetic-data benchmarks; not used in production.
+    pub fn test_set_head_balance_source(&mut self, balance_source: BalanceSourceData) {
+        self.head_balance_source = balance_source;
+    }
+
     /// Rebuild the head / current / previous balance sources from `state`.
     ///
     /// Each source keeps its own cache key and is rebuilt only when stale (the previous

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -50,6 +50,7 @@ use slot_assignments::SlotAssignments;
 pub use slot_assignments::UNSET_SLOT;
 
 use proto_array::core::{ProtoArray, VoteTracker};
+use safe_arith::{ArithError, SafeArith};
 use std::collections::{BTreeSet, HashMap};
 use tracing::{debug, debug_span};
 use types::{BeaconState, Checkpoint, Epoch, EthSpec, Hash256, Slot};
@@ -79,6 +80,13 @@ pub enum Error {
         current_slot_epoch: Epoch,
         state_epoch: Epoch,
     },
+    ArithError(ArithError),
+}
+
+impl From<ArithError> for Error {
+    fn from(e: ArithError) -> Self {
+        Error::ArithError(e)
+    }
 }
 
 /// Per-mille adjustment factor for committee weight estimates that don't cover a full epoch.
@@ -90,8 +98,9 @@ fn dedup_epoch_index(epochs: &mut Vec<Epoch>, e: Epoch) -> usize {
     match epochs.iter().position(|x| *x == e) {
         Some(i) => i,
         None => {
+            let index = epochs.len();
             epochs.push(e);
-            epochs.len() - 1
+            index
         }
     }
 }
@@ -113,8 +122,8 @@ impl AttestationScoreCache {
         balance_source: &BalanceSourceData,
         votes: &[VoteTracker],
         equivocating_indices: &BTreeSet<u64>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, Error> {
+        Ok(Self {
             scores: optimizations::precompute_chain_attestation_scores(
                 proto_array,
                 chain,
@@ -122,8 +131,8 @@ impl AttestationScoreCache {
                 balance_source,
                 votes,
                 equivocating_indices,
-            ),
-        }
+            )?,
+        })
     }
 
     fn get_attestation_score(&self, block_root: Hash256) -> Result<u64, Error> {
@@ -270,7 +279,7 @@ impl FastConfirmationRule {
         let head_dependent_slot = if current_epoch == Epoch::new(0) {
             compute_start_slot_at_epoch::<E>(current_epoch)
         } else {
-            compute_start_slot_at_epoch::<E>(current_epoch) - 1
+            compute_start_slot_at_epoch::<E>(current_epoch).safe_sub(1)?
         };
         let head_checkpoint = Checkpoint {
             epoch: current_epoch,
@@ -308,7 +317,7 @@ impl FastConfirmationRule {
         let previous_i =
             previous_stale.then(|| dedup_epoch_index(&mut epochs, state.previous_epoch()));
 
-        let (slashed, per_epoch) = BalanceSourceData::build_for_epochs(state, &epochs);
+        let (slashed, per_epoch) = BalanceSourceData::build_for_epochs(state, &epochs)?;
 
         if let Some(i) = head_i {
             let eb = &per_epoch[i];
@@ -364,7 +373,7 @@ impl FastConfirmationRule {
             head_root,
             unrealized_justified_checkpoint,
             current_slot,
-        );
+        )?;
 
         // Rebuild committee assignments from the head state.
         {
@@ -417,7 +426,7 @@ impl FastConfirmationRule {
         head_root: Hash256,
         unrealized_justified_checkpoint: &Checkpoint,
         current_slot: Slot,
-    ) {
+    ) -> Result<(), Error> {
         let _span = debug_span!("fcr_update_variables", slot = %current_slot).entered();
 
         // Spec: update_fast_confirmation_variables is called once per slot,
@@ -428,7 +437,7 @@ impl FastConfirmationRule {
             self.current_slot_head = head_root;
 
             // At last slot of epoch: snapshot greatest unrealized justified.
-            if is_start_slot_at_epoch::<E>(current_slot + 1) {
+            if is_start_slot_at_epoch::<E>(current_slot.safe_add(1)?) {
                 self.previous_epoch_greatest_unrealized_checkpoint =
                     *unrealized_justified_checkpoint;
             }
@@ -443,6 +452,8 @@ impl FastConfirmationRule {
 
             self.last_update_slot = Some(current_slot);
         }
+
+        Ok(())
     }
 
     /// Spec: get_latest_confirmed
@@ -463,7 +474,7 @@ impl FastConfirmationRule {
 
         // Revert to finalized block if either of the following is true:
         let should_revert_to_finalized_reason =
-            if get_block_epoch::<E>(confirmed_root, proto_array)? + 1 < current_epoch {
+            if get_block_epoch::<E>(confirmed_root, proto_array)?.safe_add(1)? < current_epoch {
                 // 1) the latest confirmed block's epoch is older than the previous epoch,
                 Some("epoch_too_old")
             } else if !is_ancestor(head_root, confirmed_root, proto_array)? {
@@ -503,8 +514,10 @@ impl FastConfirmationRule {
             proto_array,
         )?;
         // 2) epoch of fcr_store.current_epoch_observed_justified_checkpoint.root equals to the previous epoch,
-        let is_observed_justified_block_epoch_ok =
-            observed_justified_block_slot.epoch(E::slots_per_epoch()) + 1 == current_epoch;
+        let is_observed_justified_block_epoch_ok = observed_justified_block_slot
+            .epoch(E::slots_per_epoch())
+            .safe_add(1)?
+            == current_epoch;
         // 3) fcr_store.current_epoch_observed_justified_checkpoint equals to unrealized justification of the head,
         let is_head_unrealized_justified_ok = self.current_epoch_observed_justified_checkpoint
             == unrealized_justification_of(head_root, proto_array)?;
@@ -527,7 +540,7 @@ impl FastConfirmationRule {
         }
 
         // Attempt to further advance the latest confirmed block
-        if get_block_epoch::<E>(confirmed_root, proto_array)? + 1 >= current_epoch {
+        if get_block_epoch::<E>(confirmed_root, proto_array)?.safe_add(1)? >= current_epoch {
             confirmed_root = self.find_latest_confirmed_descendant::<E>(
                 confirmed_root,
                 head_root,
@@ -565,8 +578,9 @@ impl FastConfirmationRule {
         let mut honest_ffg_support = None;
         let mut no_conflicting_checkpoint = None;
 
-        if get_block_epoch::<E>(confirmed_root, proto_array)? + 1 == current_epoch
-            && get_voting_source_epoch::<E>(self.previous_slot_head, current_slot, proto_array)? + 2
+        if get_block_epoch::<E>(confirmed_root, proto_array)?.safe_add(1)? == current_epoch
+            && get_voting_source_epoch::<E>(self.previous_slot_head, current_slot, proto_array)?
+                .safe_add(2)?
                 >= current_epoch
             && (is_start_slot_at_epoch::<E>(current_slot)
                 || (self.will_no_conflicting_checkpoint_be_justified_cached::<E>(
@@ -580,9 +594,11 @@ impl FastConfirmationRule {
                     &mut no_conflicting_checkpoint,
                 )? && (unrealized_justification_of(self.previous_slot_head, proto_array)?
                     .epoch
-                    + 1
+                    .safe_add(1)?
                     >= current_epoch
-                    || unrealized_justification_of(head_root, proto_array)?.epoch + 1
+                    || unrealized_justification_of(head_root, proto_array)?
+                        .epoch
+                        .safe_add(1)?
                         >= current_epoch)))
         {
             let _s = debug_span!("fcr_loop1").entered();
@@ -623,7 +639,10 @@ impl FastConfirmationRule {
         }
 
         if is_start_slot_at_epoch::<E>(current_slot)
-            || unrealized_justification_of(head_root, proto_array)?.epoch + 1 >= current_epoch
+            || unrealized_justification_of(head_root, proto_array)?
+                .epoch
+                .safe_add(1)?
+                >= current_epoch
         {
             let _s = debug_span!("fcr_loop2").entered();
             let canonical_roots = get_ancestor_roots(head_root, confirmed_root, proto_array)?;
@@ -674,7 +693,8 @@ impl FastConfirmationRule {
                     tentative_confirmed_root,
                     current_slot,
                     proto_array,
-                )? + 2
+                )?
+                .safe_add(2)?
                     >= current_epoch
                     && (is_start_slot_at_epoch::<E>(current_slot)
                         || self.will_no_conflicting_checkpoint_be_justified_cached::<E>(
@@ -728,27 +748,31 @@ impl FastConfirmationRule {
         }
 
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
-        let start_root_exclusive =
-            if self.current_epoch_observed_justified_checkpoint.epoch + 1 >= current_epoch {
-                self.current_epoch_observed_justified_checkpoint.root
+        let start_root_exclusive = if self
+            .current_epoch_observed_justified_checkpoint
+            .epoch
+            .safe_add(1)?
+            >= current_epoch
+        {
+            self.current_epoch_observed_justified_checkpoint.root
+        } else {
+            // Limit reconfirmation to the first block of the previous epoch.
+            // If successful, reconfirmation of ancestors is implied.
+            let ancestor_at_previous_epoch_start = get_ancestor(
+                confirmed_root,
+                compute_start_slot_at_epoch::<E>(current_epoch.safe_sub(1)?),
+                proto_array,
+            )?;
+            if get_block_epoch::<E>(ancestor_at_previous_epoch_start, proto_array)?.safe_add(1)?
+                == current_epoch
+            {
+                // The parent of the first block of the previous epoch.
+                parent_root(ancestor_at_previous_epoch_start, proto_array)?
             } else {
-                // Limit reconfirmation to the first block of the previous epoch.
-                // If successful, reconfirmation of ancestors is implied.
-                let ancestor_at_previous_epoch_start = get_ancestor(
-                    confirmed_root,
-                    compute_start_slot_at_epoch::<E>(current_epoch - 1),
-                    proto_array,
-                )?;
-                if get_block_epoch::<E>(ancestor_at_previous_epoch_start, proto_array)? + 1
-                    == current_epoch
-                {
-                    // The parent of the first block of the previous epoch.
-                    parent_root(ancestor_at_previous_epoch_start, proto_array)?
-                } else {
-                    // The last block of the epoch before the previous one.
-                    ancestor_at_previous_epoch_start
-                }
-            };
+                // The last block of the epoch before the previous one.
+                ancestor_at_previous_epoch_start
+            }
+        };
 
         let chain_roots = get_ancestor_roots(confirmed_root, start_root_exclusive, proto_array)?;
         let terminal_slot = get_block_slot(start_root_exclusive, proto_array)?;
@@ -759,7 +783,7 @@ impl FastConfirmationRule {
             self.get_previous_balance_source(),
             votes,
             equivocating_indices,
-        );
+        )?;
 
         for root in &chain_roots {
             let one_confirmation = self.one_confirmation::<E>(
@@ -812,7 +836,7 @@ impl FastConfirmationRule {
                 && vote.current_root() == block_root
                 && !equivocating_indices.contains(&(val_idx as u64))
             {
-                score += balance;
+                score = score.safe_add(balance)?;
             }
         }
         Ok(score)
@@ -821,9 +845,16 @@ impl FastConfirmationRule {
     /// Spec: `compute_proposer_score(balance_source)`.
     /// Uses `(committee_weight * proposer_score_boost) // 100` (multiply-first) to match
     /// the spec and avoid precision loss from divide-first ordering.
-    fn compute_proposer_score<E: EthSpec>(&self, balance_source: &BalanceSourceData) -> u64 {
-        let committee_weight = balance_source.total_active_balance / E::slots_per_epoch();
-        committee_weight * self.proposer_score_boost / 100
+    fn compute_proposer_score<E: EthSpec>(
+        &self,
+        balance_source: &BalanceSourceData,
+    ) -> Result<u64, Error> {
+        let committee_weight = balance_source
+            .total_active_balance
+            .safe_div(E::slots_per_epoch())?;
+        Ok(committee_weight
+            .safe_mul(self.proposer_score_boost)?
+            .safe_div(100)?)
     }
 
     /// Spec: `compute_empty_slot_support_discount`.
@@ -839,28 +870,28 @@ impl FastConfirmationRule {
         let parent_root = parent_root(block_root, proto_array)?;
         let parent_slot = get_block_slot(parent_root, proto_array)?;
 
-        if parent_slot + 1 == block_slot {
+        if parent_slot.safe_add(1)? == block_slot {
             return Ok(0);
         }
 
         let parent_support_in_empty_slots = self.get_block_support_between_slots(
             balance_source,
             parent_root,
-            parent_slot + 1,
-            block_slot - 1,
+            parent_slot.safe_add(1)?,
+            block_slot.safe_sub(1)?,
             votes,
             equivocating_indices,
         )?;
 
         let adversarial_weight = self.compute_adversarial_weight::<E>(
             balance_source,
-            parent_slot + 1,
-            block_slot - 1,
+            parent_slot.safe_add(1)?,
+            block_slot.safe_sub(1)?,
             equivocating_indices,
         )?;
 
         if parent_support_in_empty_slots > adversarial_weight {
-            Ok(parent_support_in_empty_slots - adversarial_weight)
+            Ok(parent_support_in_empty_slots.safe_sub(adversarial_weight)?)
         } else {
             Ok(0)
         }
@@ -898,12 +929,12 @@ impl FastConfirmationRule {
         let parent_slot = get_block_slot(parent_root, proto_array)?;
 
         let total_active_balance = balance_source.total_active_balance;
-        let proposer_score = self.compute_proposer_score::<E>(balance_source);
+        let proposer_score = self.compute_proposer_score::<E>(balance_source)?;
         let maximum_support = estimate_committee_weight_between_slots::<E>(
             total_active_balance,
-            parent_slot + 1,
-            current_slot - 1,
-        );
+            parent_slot.safe_add(1)?,
+            current_slot.safe_sub(1)?,
+        )?;
         let support_discount = self.get_support_discount::<E>(
             balance_source,
             block_root,
@@ -919,8 +950,13 @@ impl FastConfirmationRule {
             equivocating_indices,
         )?;
 
-        if support_discount < maximum_support + proposer_score + 2 * adversarial_weight {
-            Ok((maximum_support + proposer_score + 2 * adversarial_weight - support_discount) / 2)
+        let threshold_numerator = maximum_support
+            .safe_add(proposer_score)?
+            .safe_add(adversarial_weight.safe_mul(2)?)?;
+        if support_discount < threshold_numerator {
+            Ok(threshold_numerator
+                .safe_sub(support_discount)?
+                .safe_div(2)?)
         } else {
             Ok(0)
         }
@@ -943,14 +979,14 @@ impl FastConfirmationRule {
             self.compute_adversarial_weight::<E>(
                 balance_source,
                 compute_start_slot_at_epoch::<E>(block_epoch),
-                current_slot - 1,
+                current_slot.safe_sub(1)?,
                 equivocating_indices,
             )
         } else {
             self.compute_adversarial_weight::<E>(
                 balance_source,
                 block_slot,
-                current_slot - 1,
+                current_slot.safe_sub(1)?,
                 equivocating_indices,
             )
         }
@@ -970,8 +1006,10 @@ impl FastConfirmationRule {
             total_active_balance,
             start_slot,
             end_slot,
-        );
-        let max_adversarial_weight = maximum_weight / 100 * self.byzantine_threshold;
+        )?;
+        let max_adversarial_weight = maximum_weight
+            .safe_div(100)?
+            .safe_mul(self.byzantine_threshold)?;
 
         let equivocation_score = self.get_equivocation_score(
             balance_source,
@@ -981,7 +1019,7 @@ impl FastConfirmationRule {
         )?;
 
         if max_adversarial_weight > equivocation_score {
-            Ok(max_adversarial_weight - equivocation_score)
+            Ok(max_adversarial_weight.safe_sub(equivocation_score)?)
         } else {
             Ok(0)
         }
@@ -1004,7 +1042,7 @@ impl FastConfirmationRule {
                     .head_assignments
                     .is_in_range(idx, start_slot, end_slot)?
             {
-                score += balance_source.balance(idx);
+                score = score.safe_add(balance_source.balance(idx))?;
             }
         }
         Ok(score)
@@ -1105,7 +1143,7 @@ impl FastConfirmationRule {
                     get_checkpoint_for_block::<E>(vote_root, vote_epoch, proto_array)
                 })? == target
             } {
-                score += self.head_balance_source.balance(val_idx);
+                score = score.safe_add(self.head_balance_source.balance(val_idx))?;
             }
         }
         Ok(score)
@@ -1135,24 +1173,27 @@ impl FastConfirmationRule {
         let ffg_weight_till_now = estimate_committee_weight_between_slots::<E>(
             total_active_balance,
             compute_start_slot_at_epoch::<E>(current_epoch),
-            current_slot - 1,
-        );
+            current_slot.safe_sub(1)?,
+        )?;
 
-        let remaining_ffg_weight = total_active_balance - ffg_weight_till_now;
-        let remaining_honest_ffg_weight =
-            remaining_ffg_weight / 100 * (100 - self.byzantine_threshold);
+        let remaining_ffg_weight = total_active_balance.safe_sub(ffg_weight_till_now)?;
+        let remaining_honest_ffg_weight = remaining_ffg_weight
+            .safe_div(100)?
+            .safe_mul(100u64.safe_sub(self.byzantine_threshold)?)?;
 
         // Compute potential adversarial weight (accounts for slashed validators).
         let adversarial_weight = self.compute_adversarial_weight::<E>(
             balance_source,
             compute_start_slot_at_epoch::<E>(current_epoch),
-            current_slot - 1,
+            current_slot.safe_sub(1)?,
             equivocating_indices,
         )?;
-        let min_honest_ffg_support = ffg_support_for_checkpoint
-            - std::cmp::min(adversarial_weight, ffg_support_for_checkpoint);
+        let min_honest_ffg_support = ffg_support_for_checkpoint.safe_sub(std::cmp::min(
+            adversarial_weight,
+            ffg_support_for_checkpoint,
+        ))?;
 
-        Ok(min_honest_ffg_support + remaining_honest_ffg_weight)
+        Ok(min_honest_ffg_support.safe_add(remaining_honest_ffg_weight)?)
     }
 
     /// Spec: `is_one_confirmed`.
@@ -1206,7 +1247,7 @@ impl FastConfirmationRule {
                 self.get_current_balance_source(),
                 votes,
                 equivocating_indices,
-            ));
+            )?);
         }
         Ok(cache
             .as_ref()
@@ -1539,11 +1580,14 @@ fn compute_start_slot_at_epoch<E: EthSpec>(epoch: Epoch) -> Slot {
 }
 
 /// Spec: `is_full_validator_set_covered`.
-fn is_full_validator_set_covered<E: EthSpec>(start_slot: Slot, end_slot: Slot) -> bool {
+fn is_full_validator_set_covered<E: EthSpec>(
+    start_slot: Slot,
+    end_slot: Slot,
+) -> Result<bool, Error> {
     let spe = E::slots_per_epoch();
-    let start_full_epoch = (start_slot + (spe - 1)).epoch(spe);
-    let end_full_epoch = (end_slot + 1).epoch(spe);
-    start_full_epoch < end_full_epoch
+    let start_full_epoch = start_slot.safe_add(spe.safe_sub(1)?)?.epoch(spe);
+    let end_full_epoch = end_slot.safe_add(1)?.epoch(spe);
+    Ok(start_full_epoch < end_full_epoch)
 }
 
 /// Spec: `adjust_committee_weight_estimate_to_ensure_safety`.
@@ -1551,9 +1595,9 @@ fn is_full_validator_set_covered<E: EthSpec>(start_slot: Slot, end_slot: Slot) -
 /// Spec uses ceiling division: `(estimate + 999) // 1000`. The function exists to
 /// conservatively over-estimate committee weight; flooring would under-estimate and
 /// weaken the safety threshold.
-fn adjust_committee_weight_estimate_to_ensure_safety(estimate: u64) -> u64 {
+fn adjust_committee_weight_estimate_to_ensure_safety(estimate: u64) -> Result<u64, Error> {
     let ceil = estimate.div_ceil(1000);
-    ceil * (1000 + COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR)
+    Ok(ceil.safe_mul(1000u64.safe_add(COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR)?)?)
 }
 
 /// Spec: `estimate_committee_weight_between_slots`.
@@ -1561,40 +1605,49 @@ fn estimate_committee_weight_between_slots<E: EthSpec>(
     total_active_balance: u64,
     start_slot: Slot,
     end_slot: Slot,
-) -> u64 {
+) -> Result<u64, Error> {
     let spe = E::slots_per_epoch();
 
     if start_slot > end_slot {
-        return 0;
+        return Ok(0);
     }
 
-    if is_full_validator_set_covered::<E>(start_slot, end_slot) {
-        return total_active_balance;
+    if is_full_validator_set_covered::<E>(start_slot, end_slot)? {
+        return Ok(total_active_balance);
     }
 
-    let start_epoch = start_slot.as_u64() / spe;
-    let end_epoch = end_slot.as_u64() / spe;
+    let start_epoch = start_slot.as_u64().safe_div(spe)?;
+    let end_epoch = end_slot.as_u64().safe_div(spe)?;
 
     if start_epoch == end_epoch {
-        let num_slots = end_slot.as_u64() - start_slot.as_u64() + 1;
-        return (total_active_balance / spe) * num_slots;
+        let num_slots = end_slot
+            .as_u64()
+            .safe_sub(start_slot.as_u64())?
+            .safe_add(1)?;
+        return Ok(total_active_balance.safe_div(spe)?.safe_mul(num_slots)?);
     }
 
     // Cross-epoch boundary but not covering a full epoch.
-    let slots_since_start_epoch = start_slot.as_u64() % spe;
-    let num_slots_in_start_epoch = spe - slots_since_start_epoch;
+    let slots_since_start_epoch = start_slot.as_u64().safe_rem(spe)?;
+    let num_slots_in_start_epoch = spe.safe_sub(slots_since_start_epoch)?;
 
-    let slots_since_end_epoch = end_slot.as_u64() % spe;
-    let num_slots_in_end_epoch = slots_since_end_epoch + 1;
-    let remaining_slots_in_end_epoch = spe - num_slots_in_end_epoch;
+    let slots_since_end_epoch = end_slot.as_u64().safe_rem(spe)?;
+    let num_slots_in_end_epoch = slots_since_end_epoch.safe_add(1)?;
+    let remaining_slots_in_end_epoch = spe.safe_sub(num_slots_in_end_epoch)?;
 
-    let start_epoch_weight = (total_active_balance / spe) * num_slots_in_start_epoch;
-    let end_epoch_weight = (total_active_balance / spe) * num_slots_in_end_epoch;
+    let start_epoch_weight = total_active_balance
+        .safe_div(spe)?
+        .safe_mul(num_slots_in_start_epoch)?;
+    let end_epoch_weight = total_active_balance
+        .safe_div(spe)?
+        .safe_mul(num_slots_in_end_epoch)?;
 
-    let start_epoch_weight_pro_rated = (start_epoch_weight / spe) * remaining_slots_in_end_epoch;
+    let start_epoch_weight_pro_rated = start_epoch_weight
+        .safe_div(spe)?
+        .safe_mul(remaining_slots_in_end_epoch)?;
 
     adjust_committee_weight_estimate_to_ensure_safety(
-        start_epoch_weight_pro_rated + end_epoch_weight,
+        start_epoch_weight_pro_rated.safe_add(end_epoch_weight)?,
     )
 }
 
@@ -1616,36 +1669,26 @@ mod tests {
     #[test]
     fn test_is_full_validator_set_covered() {
         // 32 slots = full epoch
-        assert!(is_full_validator_set_covered::<E>(
-            Slot::new(0),
-            Slot::new(31)
-        ));
+        assert!(is_full_validator_set_covered::<E>(Slot::new(0), Slot::new(31)).unwrap());
         // 33 slots crossing boundary
-        assert!(is_full_validator_set_covered::<E>(
-            Slot::new(0),
-            Slot::new(32)
-        ));
+        assert!(is_full_validator_set_covered::<E>(Slot::new(0), Slot::new(32)).unwrap());
         // Single slot — not full
-        assert!(!is_full_validator_set_covered::<E>(
-            Slot::new(0),
-            Slot::new(0)
-        ));
+        assert!(!is_full_validator_set_covered::<E>(Slot::new(0), Slot::new(0)).unwrap());
         // 31 slots — not full
-        assert!(!is_full_validator_set_covered::<E>(
-            Slot::new(1),
-            Slot::new(31)
-        ));
+        assert!(!is_full_validator_set_covered::<E>(Slot::new(1), Slot::new(31)).unwrap());
     }
 
     #[test]
     fn test_estimate_committee_weight_same_epoch() {
         let total = 32_000_000_000u64; // 32B gwei
         // 1 slot out of 32 => total/32 = 1B
-        let w = estimate_committee_weight_between_slots::<E>(total, Slot::new(0), Slot::new(0));
+        let w = estimate_committee_weight_between_slots::<E>(total, Slot::new(0), Slot::new(0))
+            .unwrap();
         assert_eq!(w, 1_000_000_000);
 
         // Full epoch => total
-        let w = estimate_committee_weight_between_slots::<E>(total, Slot::new(0), Slot::new(31));
+        let w = estimate_committee_weight_between_slots::<E>(total, Slot::new(0), Slot::new(31))
+            .unwrap();
         assert_eq!(w, total);
     }
 
@@ -1655,7 +1698,8 @@ mod tests {
             32_000_000_000,
             Slot::new(10),
             Slot::new(5),
-        );
+        )
+        .unwrap();
         assert_eq!(w, 0);
     }
 
@@ -1663,17 +1707,23 @@ mod tests {
     fn test_adjustment_factor() {
         // Ceiling division: ceil(1000/1000) * 1005 = 1 * 1005 = 1005
         assert_eq!(
-            adjust_committee_weight_estimate_to_ensure_safety(1000),
+            adjust_committee_weight_estimate_to_ensure_safety(1000).unwrap(),
             1005
         );
         // Ceiling division: ceil(999/1000) * 1005 = 1 * 1005 = 1005 (NOT 0)
-        assert_eq!(adjust_committee_weight_estimate_to_ensure_safety(999), 1005);
+        assert_eq!(
+            adjust_committee_weight_estimate_to_ensure_safety(999).unwrap(),
+            1005
+        );
         // Ceiling division: ceil(1500/1000) * 1005 = 2 * 1005 = 2010
         assert_eq!(
-            adjust_committee_weight_estimate_to_ensure_safety(1500),
+            adjust_committee_weight_estimate_to_ensure_safety(1500).unwrap(),
             2010
         );
         // Edge case: 0 -> ceil(0/1000) = 0
-        assert_eq!(adjust_committee_weight_estimate_to_ensure_safety(0), 0);
+        assert_eq!(
+            adjust_committee_weight_estimate_to_ensure_safety(0).unwrap(),
+            0
+        );
     }
 }

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -634,17 +634,17 @@ impl FastConfirmationRule {
                 let block_epoch = get_block_epoch::<E>(*block_root, proto_array)?;
                 let tentative_epoch = get_block_epoch::<E>(tentative_confirmed_root, proto_array)?;
 
-                if block_epoch > tentative_epoch {
-                    if !self.will_current_target_be_justified::<E>(
+                if block_epoch > tentative_epoch
+                    && !self.will_current_target_be_justified::<E>(
                         head_root,
                         current_slot,
                         proto_array,
                         votes,
                         equivocating_indices,
                         &mut honest_ffg_support,
-                    )? {
-                        break;
-                    }
+                    )?
+                {
+                    break;
                 }
 
                 let attestation_scores = self.current_balance_attestation_scores(
@@ -1530,7 +1530,7 @@ struct NotOneConfirmed {
 
 /// Spec: `is_start_slot_at_epoch`.
 fn is_start_slot_at_epoch<E: EthSpec>(slot: Slot) -> bool {
-    slot.as_u64() % E::slots_per_epoch() == 0
+    slot.as_u64().is_multiple_of(E::slots_per_epoch())
 }
 
 /// Spec: `compute_start_slot_at_epoch`.
@@ -1552,7 +1552,7 @@ fn is_full_validator_set_covered<E: EthSpec>(start_slot: Slot, end_slot: Slot) -
 /// conservatively over-estimate committee weight; flooring would under-estimate and
 /// weaken the safety threshold.
 fn adjust_committee_weight_estimate_to_ensure_safety(estimate: u64) -> u64 {
-    let ceil = (estimate + 999) / 1000;
+    let ceil = estimate.div_ceil(1000);
     ceil * (1000 + COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR)
 }
 

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -134,13 +134,8 @@ pub struct FastConfirmationRule {
     head_assignments: SlotAssignments,
 
     // === FFG data from the head state ===
-    /// Built from the spec's `get_pulled_up_head_state`: the current head's state advanced
-    /// to the current slot, so epoch-boundary activations/exits/slashings are reflected.
-    ///
-    /// `checkpoint.root` is repurposed here to carry the **dependent root** of
-    /// the cached epoch (the block at the previous epoch's last slot), used as
-    /// the chain-identity component of the cache key — *not* a justified-block
-    /// root like the anchored snapshots' `checkpoint.root`.
+    /// Built from the spec's `get_pulled_up_head_state`. Keyed (via `BalanceSourceData.dependent_root`)
+    /// on the head's dependent root, so a reorg past the previous-epoch boundary rebuilds it.
     head_balance_source: BalanceSourceData,
 
     // === Internal bookkeeping ===
@@ -176,11 +171,19 @@ impl FastConfirmationRule {
             confirmed_root: finalized_checkpoint.root,
             previous_epoch_observed_justified: CheckpointAndBalance::new(
                 finalized_checkpoint,
-                BalanceSourceData::for_epoch(state, state.previous_epoch(), finalized_checkpoint),
+                BalanceSourceData::for_epoch(
+                    state,
+                    state.previous_epoch(),
+                    finalized_checkpoint.root,
+                ),
             ),
             current_epoch_observed_justified: CheckpointAndBalance::new(
                 finalized_checkpoint,
-                BalanceSourceData::for_epoch(state, state.current_epoch(), finalized_checkpoint),
+                BalanceSourceData::for_epoch(
+                    state,
+                    state.current_epoch(),
+                    finalized_checkpoint.root,
+                ),
             ),
             previous_epoch_greatest_unrealized_checkpoint: finalized_checkpoint,
             previous_slot_head: finalized_checkpoint.root,
@@ -191,7 +194,7 @@ impl FastConfirmationRule {
             head_balance_source: BalanceSourceData::for_epoch(
                 state,
                 state.current_epoch(),
-                finalized_checkpoint,
+                finalized_checkpoint.root,
             ),
             last_update_slot: None,
             spec_test_mode: false,
@@ -297,18 +300,11 @@ impl FastConfirmationRule {
                 self.head_assignments.rebuild::<E>(state, current_slot)?;
             }
 
-            // Head balance source is keyed on the dependent root (last block of the previous
-            // epoch); rebuild it when a reorg past that boundary changes it.
+            // Head balance source is keyed on the dependent root; rebuild it when a reorg past the
+            // previous-epoch boundary changes it.
             let current_epoch = current_slot.epoch(E::slots_per_epoch());
-            let head_dependent_slot =
-                compute_start_slot_at_epoch::<E>(current_epoch).saturating_sub(1u64);
-            let head_checkpoint = Checkpoint {
-                epoch: current_epoch,
-                root: *state
-                    .get_block_root(head_dependent_slot)
-                    .map_err(|e| Error::CommitteeCache(format!("dep_root lookup: {e:?}")))?,
-            };
-            if self.head_balance_source.checkpoint != head_checkpoint {
+            let head_dependent_root = dependent_root::<E>(state, current_epoch)?;
+            if self.head_balance_source.dependent_root != head_dependent_root {
                 let _span = debug_span!("fcr_rebuild_balances").entered();
                 let head_epoch = if state.current_epoch() < current_epoch {
                     state
@@ -318,7 +314,7 @@ impl FastConfirmationRule {
                     state.current_epoch()
                 };
                 self.head_balance_source =
-                    BalanceSourceData::for_epoch(state, head_epoch, head_checkpoint);
+                    BalanceSourceData::for_epoch(state, head_epoch, head_dependent_root);
             }
         }
 
@@ -336,11 +332,12 @@ impl FastConfirmationRule {
             // checkpoint in one step so the pair stays coherent.
             if is_start_slot_at_epoch::<E>(current_slot) {
                 let new_current_cp = self.previous_epoch_greatest_unrealized_checkpoint;
+                let dep_root = dependent_root::<E>(state, state.current_epoch())?;
                 self.previous_epoch_observed_justified =
                     self.current_epoch_observed_justified.clone();
                 self.current_epoch_observed_justified = CheckpointAndBalance::new(
                     new_current_cp,
-                    BalanceSourceData::for_epoch(state, state.current_epoch(), new_current_cp),
+                    BalanceSourceData::for_epoch(state, state.current_epoch(), dep_root),
                 );
             }
 
@@ -1374,6 +1371,18 @@ fn is_start_slot_at_epoch<E: EthSpec>(slot: Slot) -> bool {
 /// Spec: `compute_start_slot_at_epoch`.
 fn compute_start_slot_at_epoch<E: EthSpec>(epoch: Epoch) -> Slot {
     epoch.start_slot(E::slots_per_epoch())
+}
+
+/// Shuffling/validator-set decision root for `epoch`: the block at the last slot of the previous
+/// epoch. Genesis has no previous epoch, so it is identified by the zero root.
+fn dependent_root<E: EthSpec>(state: &BeaconState<E>, epoch: Epoch) -> Result<Hash256, Error> {
+    if epoch == 0 {
+        return Ok(Hash256::ZERO);
+    }
+    let slot = compute_start_slot_at_epoch::<E>(epoch).safe_sub(1)?;
+    Ok(*state
+        .get_block_root(slot)
+        .map_err(|e| Error::CommitteeCache(format!("dep_root lookup: {e:?}")))?)
 }
 
 /// Spec: `is_full_validator_set_covered`.

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -75,8 +75,8 @@ pub enum Error {
     },
     MissingPrecomputedScore(Hash256),
     BlockEpochNone(Hash256),
-    CommitteeCache(String),
-    UnsetSlotAssignment(usize),
+    CommitteeCacheUninitialized(String),
+    BlockRootsOutOfBounds(String),
     /// A computed index was out of bounds. Indicates a broken internal invariant, not bad input.
     IndexOutOfBounds(usize),
     ArithError(ArithError),
@@ -1286,7 +1286,9 @@ fn get_attestation_score(
     block_root: Hash256,
     attestation_scores: &AttestationScoreCache,
 ) -> Result<u64, Error> {
-    attestation_scores.get_attestation_score(block_root)
+    attestation_scores
+        .get_attestation_score(block_root)
+        .ok_or(Error::MissingPrecomputedScore(block_root))
 }
 
 struct OneConfirmation {
@@ -1351,7 +1353,7 @@ pub(crate) fn dependent_root<E: EthSpec>(
     let slot = compute_start_slot_at_epoch::<E>(epoch).safe_sub(1)?;
     Ok(*state
         .get_block_root(slot)
-        .map_err(|e| Error::CommitteeCache(format!("dep_root lookup: {e:?}")))?)
+        .map_err(|e| Error::BlockRootsOutOfBounds(format!("dep_root lookup: {e:?}")))?)
 }
 
 /// Spec: `is_full_validator_set_covered`.

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -539,7 +539,22 @@ impl FastConfirmationRule {
 
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
         let mut confirmed_root = latest_confirmed_root;
-        let mut current_attestation_scores = None;
+
+        // Precompute attestation scores for the whole chain (confirmed → head) in one O(V × depth)
+        // pass; both loops below read per-block scores from it instead of recomputing per block.
+        let attestation_scores = {
+            let _s = debug_span!("fcr_precompute").entered();
+            let chain = get_ancestor_roots(head_root, latest_confirmed_root, proto_array)?;
+            let terminal_slot = get_block_slot(latest_confirmed_root, proto_array)?;
+            AttestationScoreCache::for_chain(
+                proto_array,
+                &chain,
+                terminal_slot,
+                self.get_current_balance_source(),
+                votes,
+                equivocating_indices,
+            )?
+        };
 
         if get_block_epoch::<E>(confirmed_root, proto_array)?.safe_add(1)? == current_epoch
             && get_voting_source_epoch::<E>(self.previous_slot_head, current_slot, proto_array)?
@@ -576,18 +591,10 @@ impl FastConfirmationRule {
                     break;
                 }
 
-                let attestation_scores = self.current_balance_attestation_scores(
-                    &mut current_attestation_scores,
-                    head_root,
-                    latest_confirmed_root,
-                    proto_array,
-                    votes,
-                    equivocating_indices,
-                )?;
                 if !self.is_one_confirmed::<E>(
                     self.get_current_balance_source(),
                     *block_root,
-                    attestation_scores,
+                    &attestation_scores,
                     current_slot,
                     proto_array,
                     votes,
@@ -626,18 +633,10 @@ impl FastConfirmationRule {
                     break;
                 }
 
-                let attestation_scores = self.current_balance_attestation_scores(
-                    &mut current_attestation_scores,
-                    head_root,
-                    latest_confirmed_root,
-                    proto_array,
-                    votes,
-                    equivocating_indices,
-                )?;
                 if !self.is_one_confirmed::<E>(
                     self.get_current_balance_source(),
                     *block_root,
-                    attestation_scores,
+                    &attestation_scores,
                     current_slot,
                     proto_array,
                     votes,
@@ -1176,34 +1175,6 @@ impl FastConfirmationRule {
     // -----------------------------------------------------------------------
     // Implementation caches / diagnostics
     // -----------------------------------------------------------------------
-
-    /// Lazy current-balance attestation score cache.
-    fn current_balance_attestation_scores<'a>(
-        &self,
-        cache: &'a mut Option<AttestationScoreCache>,
-        head_root: Hash256,
-        latest_confirmed_root: Hash256,
-        proto_array: &ProtoArray,
-        votes: &[VoteTracker],
-        equivocating_indices: &BTreeSet<u64>,
-    ) -> Result<&'a AttestationScoreCache, Error> {
-        if cache.is_none() {
-            let _s = debug_span!("fcr_precompute_current_scores").entered();
-            let chain = get_ancestor_roots(head_root, latest_confirmed_root, proto_array)?;
-            let terminal_slot = get_block_slot(latest_confirmed_root, proto_array)?;
-            *cache = Some(AttestationScoreCache::for_chain(
-                proto_array,
-                &chain,
-                terminal_slot,
-                self.get_current_balance_source(),
-                votes,
-                equivocating_indices,
-            )?);
-        }
-        Ok(cache
-            .as_ref()
-            .expect("current balance attestation score cache initialized"))
-    }
 
     /// Cached `is_one_confirmed` evaluation for metrics.
     #[allow(clippy::too_many_arguments)]

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -242,11 +242,10 @@ impl FastConfirmationRule {
         // epoch). Two chains share the same validator-set view at `current_epoch` iff they
         // share this root, so it is the right chain-identity cache key. A re-org that pivots
         // before the previous-epoch boundary changes it, forcing a rebuild.
-        let head_dependent_slot = if current_epoch == Epoch::new(0) {
-            compute_start_slot_at_epoch::<E>(current_epoch)
-        } else {
-            compute_start_slot_at_epoch::<E>(current_epoch).safe_sub(1)?
-        };
+        // Last slot of the previous epoch; clamps to genesis (slot 0) at epoch 0, which has no
+        // previous epoch.
+        let head_dependent_slot =
+            compute_start_slot_at_epoch::<E>(current_epoch).saturating_sub(1u64);
         let head_checkpoint = Checkpoint {
             epoch: current_epoch,
             root: *state

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -22,8 +22,8 @@
 //!
 //! 2. **Cached spec helpers**: `is_one_confirmed` still reads as
 //!    `support > compute_safety_threshold`, but `get_attestation_score` is backed by a
-//!    precomputed chain score cache. Likewise the FFG predicates keep their spec shape while
-//!    sharing one cached `compute_honest_ffg_support` result per run.
+//!    precomputed chain score cache. Likewise `compute_honest_ffg_support` is evaluated once
+//!    per descendant search and passed by value into the FFG predicates.
 //!
 //! 3. **Multi-entry vote-root / checkpoint memos** (`optimizations::RootMemo`): inside
 //!    `precompute_chain_attestation_scores` and `get_current_target_score`, each distinct
@@ -575,31 +575,41 @@ impl FastConfirmationRule {
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
         let mut confirmed_root = latest_confirmed_root;
         let mut current_attestation_scores = None;
-        let mut honest_ffg_support = None;
-        let mut no_conflicting_checkpoint = None;
+
+        // FFG support is invariant across this run (fixed head, slot, vote set), so compute it
+        // once and thread it into the will_* checks below.
+        let honest_ffg = {
+            let _s = debug_span!("fcr_honest_ffg").entered();
+            self.compute_honest_ffg_support::<E>(
+                head_root,
+                current_slot,
+                proto_array,
+                votes,
+                equivocating_indices,
+            )?
+        };
+        let no_conflict = self.will_no_conflicting_checkpoint_be_justified::<E>(
+            head_root,
+            unrealized_justified_checkpoint,
+            current_slot,
+            proto_array,
+            honest_ffg,
+        )?;
 
         if get_block_epoch::<E>(confirmed_root, proto_array)?.safe_add(1)? == current_epoch
             && get_voting_source_epoch::<E>(self.previous_slot_head, current_slot, proto_array)?
                 .safe_add(2)?
                 >= current_epoch
             && (is_start_slot_at_epoch::<E>(current_slot)
-                || (self.will_no_conflicting_checkpoint_be_justified_cached::<E>(
-                    head_root,
-                    unrealized_justified_checkpoint,
-                    current_slot,
-                    proto_array,
-                    votes,
-                    equivocating_indices,
-                    &mut honest_ffg_support,
-                    &mut no_conflicting_checkpoint,
-                )? && (unrealized_justification_of(self.previous_slot_head, proto_array)?
-                    .epoch
-                    .safe_add(1)?
-                    >= current_epoch
-                    || unrealized_justification_of(head_root, proto_array)?
+                || (no_conflict
+                    && (unrealized_justification_of(self.previous_slot_head, proto_array)?
                         .epoch
                         .safe_add(1)?
-                        >= current_epoch)))
+                        >= current_epoch
+                        || unrealized_justification_of(head_root, proto_array)?
+                            .epoch
+                            .safe_add(1)?
+                            >= current_epoch)))
         {
             let _s = debug_span!("fcr_loop1").entered();
             let canonical_roots = get_ancestor_roots(head_root, confirmed_root, proto_array)?;
@@ -654,14 +664,7 @@ impl FastConfirmationRule {
                 let tentative_epoch = get_block_epoch::<E>(tentative_confirmed_root, proto_array)?;
 
                 if block_epoch > tentative_epoch
-                    && !self.will_current_target_be_justified::<E>(
-                        head_root,
-                        current_slot,
-                        proto_array,
-                        votes,
-                        equivocating_indices,
-                        &mut honest_ffg_support,
-                    )?
+                    && !self.will_current_target_be_justified(honest_ffg)?
                 {
                     break;
                 }
@@ -696,17 +699,7 @@ impl FastConfirmationRule {
                 )?
                 .safe_add(2)?
                     >= current_epoch
-                    && (is_start_slot_at_epoch::<E>(current_slot)
-                        || self.will_no_conflicting_checkpoint_be_justified_cached::<E>(
-                            head_root,
-                            unrealized_justified_checkpoint,
-                            current_slot,
-                            proto_array,
-                            votes,
-                            equivocating_indices,
-                            &mut honest_ffg_support,
-                            &mut no_conflicting_checkpoint,
-                        )?))
+                    && (is_start_slot_at_epoch::<E>(current_slot) || no_conflict))
             {
                 confirmed_root = tentative_confirmed_root;
             }
@@ -1053,16 +1046,16 @@ impl FastConfirmationRule {
     // -----------------------------------------------------------------------
 
     /// Spec: `will_no_conflicting_checkpoint_be_justified`.
-    #[allow(clippy::too_many_arguments)]
+    ///
+    /// `honest_ffg` is the precomputed `compute_honest_ffg_support` result (identical for
+    /// every FFG check in a descendant search, so computed once and passed in).
     fn will_no_conflicting_checkpoint_be_justified<E: EthSpec>(
         &self,
         head_root: Hash256,
         unrealized_justified_checkpoint: &Checkpoint,
         current_slot: Slot,
         proto_array: &ProtoArray,
-        votes: &[VoteTracker],
-        equivocating_indices: &BTreeSet<u64>,
-        honest_ffg_support: &mut Option<u64>,
+        honest_ffg: u64,
     ) -> Result<bool, Error> {
         if get_current_target::<E>(head_root, current_slot, proto_array)?
             == *unrealized_justified_checkpoint
@@ -1071,40 +1064,16 @@ impl FastConfirmationRule {
         }
 
         let total_active_balance = self.head_balance_source.total_active_balance;
-        let honest_ffg_support = self.compute_honest_ffg_support_cached::<E>(
-            head_root,
-            current_slot,
-            proto_array,
-            votes,
-            equivocating_indices,
-            honest_ffg_support,
-        )?;
-
-        Ok(3u128 * honest_ffg_support as u128 > total_active_balance as u128)
+        Ok(3u128 * honest_ffg as u128 > total_active_balance as u128)
     }
 
     /// Spec: `will_current_target_be_justified`.
-    #[allow(clippy::too_many_arguments)]
-    fn will_current_target_be_justified<E: EthSpec>(
-        &self,
-        head_root: Hash256,
-        current_slot: Slot,
-        proto_array: &ProtoArray,
-        votes: &[VoteTracker],
-        equivocating_indices: &BTreeSet<u64>,
-        honest_ffg_support: &mut Option<u64>,
-    ) -> Result<bool, Error> {
+    ///
+    /// `honest_ffg` is the precomputed `compute_honest_ffg_support` result (see
+    /// `will_no_conflicting_checkpoint_be_justified`).
+    fn will_current_target_be_justified(&self, honest_ffg: u64) -> Result<bool, Error> {
         let total_active_balance = self.head_balance_source.total_active_balance;
-        let honest_ffg_support = self.compute_honest_ffg_support_cached::<E>(
-            head_root,
-            current_slot,
-            proto_array,
-            votes,
-            equivocating_indices,
-            honest_ffg_support,
-        )?;
-
-        Ok(3u128 * honest_ffg_support as u128 >= 2u128 * total_active_balance as u128)
+        Ok(3u128 * honest_ffg as u128 >= 2u128 * total_active_balance as u128)
     }
 
     /// Spec: `get_current_target_score` — estimates FFG support for current epoch target.
@@ -1252,61 +1221,6 @@ impl FastConfirmationRule {
         Ok(cache
             .as_ref()
             .expect("current balance attestation score cache initialized"))
-    }
-
-    /// Lazy FFG support cache for one descendant search.
-    #[allow(clippy::too_many_arguments)]
-    fn compute_honest_ffg_support_cached<E: EthSpec>(
-        &self,
-        head_root: Hash256,
-        current_slot: Slot,
-        proto_array: &ProtoArray,
-        votes: &[VoteTracker],
-        equivocating_indices: &BTreeSet<u64>,
-        honest_ffg_support: &mut Option<u64>,
-    ) -> Result<u64, Error> {
-        if let Some(honest_ffg) = *honest_ffg_support {
-            return Ok(honest_ffg);
-        }
-        let _s = debug_span!("fcr_honest_ffg").entered();
-        let honest_ffg = self.compute_honest_ffg_support::<E>(
-            head_root,
-            current_slot,
-            proto_array,
-            votes,
-            equivocating_indices,
-        )?;
-        *honest_ffg_support = Some(honest_ffg);
-        Ok(honest_ffg)
-    }
-
-    /// Lazy no-conflicting-checkpoint cache for one descendant search.
-    #[allow(clippy::too_many_arguments)]
-    fn will_no_conflicting_checkpoint_be_justified_cached<E: EthSpec>(
-        &self,
-        head_root: Hash256,
-        unrealized_justified_checkpoint: &Checkpoint,
-        current_slot: Slot,
-        proto_array: &ProtoArray,
-        votes: &[VoteTracker],
-        equivocating_indices: &BTreeSet<u64>,
-        honest_ffg_support: &mut Option<u64>,
-        no_conflicting_checkpoint: &mut Option<bool>,
-    ) -> Result<bool, Error> {
-        if let Some(will_not_conflict) = *no_conflicting_checkpoint {
-            return Ok(will_not_conflict);
-        }
-        let will_not_conflict = self.will_no_conflicting_checkpoint_be_justified::<E>(
-            head_root,
-            unrealized_justified_checkpoint,
-            current_slot,
-            proto_array,
-            votes,
-            equivocating_indices,
-            honest_ffg_support,
-        )?;
-        *no_conflicting_checkpoint = Some(will_not_conflict);
-        Ok(will_not_conflict)
     }
 
     /// Cached `is_one_confirmed` evaluation for metrics.

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -22,8 +22,9 @@
 //!
 //! 2. **Cached spec helpers**: `is_one_confirmed` still reads as
 //!    `support > compute_safety_threshold`, but `get_attestation_score` is backed by a
-//!    precomputed chain score cache. Likewise `compute_honest_ffg_support` is evaluated once
-//!    per descendant search and passed by value into the FFG predicates.
+//!    precomputed chain score cache. The FFG predicates compute `compute_honest_ffg_support`
+//!    internally; their call sites are short-circuited, so the O(V) FFG sweep only runs near
+//!    epoch boundaries (and at most a couple of times) rather than every slot.
 //!
 //! 3. **Multi-entry vote-root / checkpoint memos** (`optimizations::RootMemo`): inside
 //!    `precompute_chain_attestation_scores` and `get_current_target_score`, each distinct
@@ -576,40 +577,26 @@ impl FastConfirmationRule {
         let mut confirmed_root = latest_confirmed_root;
         let mut current_attestation_scores = None;
 
-        // FFG support is invariant across this run (fixed head, slot, vote set), so compute it
-        // once and thread it into the will_* checks below.
-        let honest_ffg = {
-            let _s = debug_span!("fcr_honest_ffg").entered();
-            self.compute_honest_ffg_support::<E>(
-                head_root,
-                current_slot,
-                proto_array,
-                votes,
-                equivocating_indices,
-            )?
-        };
-        let no_conflict = self.will_no_conflicting_checkpoint_be_justified::<E>(
-            head_root,
-            unrealized_justified_checkpoint,
-            current_slot,
-            proto_array,
-            honest_ffg,
-        )?;
-
         if get_block_epoch::<E>(confirmed_root, proto_array)?.safe_add(1)? == current_epoch
             && get_voting_source_epoch::<E>(self.previous_slot_head, current_slot, proto_array)?
                 .safe_add(2)?
                 >= current_epoch
             && (is_start_slot_at_epoch::<E>(current_slot)
-                || (no_conflict
-                    && (unrealized_justification_of(self.previous_slot_head, proto_array)?
+                || (self.will_no_conflicting_checkpoint_be_justified::<E>(
+                    head_root,
+                    unrealized_justified_checkpoint,
+                    current_slot,
+                    proto_array,
+                    votes,
+                    equivocating_indices,
+                )? && (unrealized_justification_of(self.previous_slot_head, proto_array)?
+                    .epoch
+                    .safe_add(1)?
+                    >= current_epoch
+                    || unrealized_justification_of(head_root, proto_array)?
                         .epoch
                         .safe_add(1)?
-                        >= current_epoch
-                        || unrealized_justification_of(head_root, proto_array)?
-                            .epoch
-                            .safe_add(1)?
-                            >= current_epoch)))
+                        >= current_epoch)))
         {
             let _s = debug_span!("fcr_loop1").entered();
             let canonical_roots = get_ancestor_roots(head_root, confirmed_root, proto_array)?;
@@ -664,7 +651,13 @@ impl FastConfirmationRule {
                 let tentative_epoch = get_block_epoch::<E>(tentative_confirmed_root, proto_array)?;
 
                 if block_epoch > tentative_epoch
-                    && !self.will_current_target_be_justified(honest_ffg)?
+                    && !self.will_current_target_be_justified::<E>(
+                        head_root,
+                        current_slot,
+                        proto_array,
+                        votes,
+                        equivocating_indices,
+                    )?
                 {
                     break;
                 }
@@ -699,7 +692,15 @@ impl FastConfirmationRule {
                 )?
                 .safe_add(2)?
                     >= current_epoch
-                    && (is_start_slot_at_epoch::<E>(current_slot) || no_conflict))
+                    && (is_start_slot_at_epoch::<E>(current_slot)
+                        || self.will_no_conflicting_checkpoint_be_justified::<E>(
+                            head_root,
+                            unrealized_justified_checkpoint,
+                            current_slot,
+                            proto_array,
+                            votes,
+                            equivocating_indices,
+                        )?))
             {
                 confirmed_root = tentative_confirmed_root;
             }
@@ -1046,16 +1047,14 @@ impl FastConfirmationRule {
     // -----------------------------------------------------------------------
 
     /// Spec: `will_no_conflicting_checkpoint_be_justified`.
-    ///
-    /// `honest_ffg` is the precomputed `compute_honest_ffg_support` result (identical for
-    /// every FFG check in a descendant search, so computed once and passed in).
     fn will_no_conflicting_checkpoint_be_justified<E: EthSpec>(
         &self,
         head_root: Hash256,
         unrealized_justified_checkpoint: &Checkpoint,
         current_slot: Slot,
         proto_array: &ProtoArray,
-        honest_ffg: u64,
+        votes: &[VoteTracker],
+        equivocating_indices: &BTreeSet<u64>,
     ) -> Result<bool, Error> {
         if get_current_target::<E>(head_root, current_slot, proto_array)?
             == *unrealized_justified_checkpoint
@@ -1064,15 +1063,33 @@ impl FastConfirmationRule {
         }
 
         let total_active_balance = self.head_balance_source.total_active_balance;
+        let honest_ffg = self.compute_honest_ffg_support::<E>(
+            head_root,
+            current_slot,
+            proto_array,
+            votes,
+            equivocating_indices,
+        )?;
         Ok(3u128 * honest_ffg as u128 > total_active_balance as u128)
     }
 
     /// Spec: `will_current_target_be_justified`.
-    ///
-    /// `honest_ffg` is the precomputed `compute_honest_ffg_support` result (see
-    /// `will_no_conflicting_checkpoint_be_justified`).
-    fn will_current_target_be_justified(&self, honest_ffg: u64) -> Result<bool, Error> {
+    fn will_current_target_be_justified<E: EthSpec>(
+        &self,
+        head_root: Hash256,
+        current_slot: Slot,
+        proto_array: &ProtoArray,
+        votes: &[VoteTracker],
+        equivocating_indices: &BTreeSet<u64>,
+    ) -> Result<bool, Error> {
         let total_active_balance = self.head_balance_source.total_active_balance;
+        let honest_ffg = self.compute_honest_ffg_support::<E>(
+            head_root,
+            current_slot,
+            proto_array,
+            votes,
+            equivocating_indices,
+        )?;
         Ok(3u128 * honest_ffg as u128 >= 2u128 * total_active_balance as u128)
     }
 
@@ -1127,6 +1144,7 @@ impl FastConfirmationRule {
         votes: &[VoteTracker],
         equivocating_indices: &BTreeSet<u64>,
     ) -> Result<u64, Error> {
+        let _s = debug_span!("fcr_honest_ffg").entered();
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
         let balance_source = &self.head_balance_source;
         let total_active_balance = balance_source.total_active_balance;

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -1,6 +1,6 @@
 //! Fast Confirmation Rule (FCR) for Ethereum consensus.
 //!
-//! Implements the algorithm from consensus-specs PR #4747. FCR is a pure read-only
+//! Implements the Fast Confirmation Rule from the latest merged consensus-specs. FCR is a pure read-only
 //! observer of fork-choice state that computes a `confirmed_root` — a block guaranteed
 //! to remain canonical under standard assumptions (synchrony + <25% Byzantine).
 //!
@@ -20,12 +20,10 @@
 //!    a suffix-sum score array. Reduces cost from O(B × V × depth) to O(V × depth + B).
 //!    Used by `find_latest_confirmed_descendant` and `is_confirmed_chain_safe`.
 //!
-//! 2. **`is_one_confirmed_with_score`**: variant of `is_one_confirmed` that takes a
-//!    precomputed attestation score instead of calling `get_attestation_score`. The rest
-//!    of the logic (proposer score, support discount, adversarial weight) is identical.
-//!    Likewise the FFG support (`compute_honest_ffg_support`) is computed once per run and
-//!    threaded into `will_no_conflicting_checkpoint_be_justified` /
-//!    `will_current_target_be_justified` rather than recomputed per call.
+//! 2. **Cached spec helpers**: `is_one_confirmed` still reads as
+//!    `support > compute_safety_threshold`, but `get_attestation_score` is backed by a
+//!    precomputed chain score cache. Likewise the FFG predicates keep their spec shape while
+//!    sharing one cached `compute_honest_ffg_support` result per run.
 //!
 //! 3. **Multi-entry vote-root / checkpoint memos** (`optimizations::RootMemo`): inside
 //!    `precompute_chain_attestation_scores` and `get_current_target_score`, each distinct
@@ -39,8 +37,8 @@
 //!    head/current/previous balance sources are rebuilt from one validator-set iteration
 //!    over the (usually two) distinct epochs rather than one iteration each.
 //!
-//! The original spec functions (`is_one_confirmed`, `get_attestation_score`) are not
-//! present — only the optimized equivalents are used.
+//! The visible algorithm deliberately keeps the spec function names and control-flow shape;
+//! the caches are implementation details behind those helpers.
 
 mod balance_source;
 pub mod metrics;
@@ -52,7 +50,7 @@ use slot_assignments::SlotAssignments;
 pub use slot_assignments::UNSET_SLOT;
 
 use proto_array::core::{ProtoArray, VoteTracker};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use tracing::{debug, debug_span};
 use types::{BeaconState, Checkpoint, Epoch, EthSpec, Hash256, Slot};
 
@@ -60,6 +58,7 @@ use types::{BeaconState, Checkpoint, Epoch, EthSpec, Hash256, Slot};
 #[strum(serialize_all = "snake_case")]
 pub enum Error {
     NodeNotFound(Hash256),
+    ParentRootNotFound(Hash256),
     AncestorNotFound {
         block: Hash256,
         slot: Slot,
@@ -94,6 +93,44 @@ fn dedup_epoch_index(epochs: &mut Vec<Epoch>, e: Epoch) -> usize {
             epochs.push(e);
             epochs.len() - 1
         }
+    }
+}
+
+/// Cached implementation of the spec's `get_attestation_score`.
+///
+/// The Python spec computes `get_attestation_score(store, node, balance_source)` independently
+/// for each candidate block. Lighthouse computes the same scores for a canonical chain segment in
+/// one pass and then serves individual `get_attestation_score` calls from this cache.
+struct AttestationScoreCache {
+    scores: HashMap<Hash256, u64>,
+}
+
+impl AttestationScoreCache {
+    fn for_chain(
+        proto_array: &ProtoArray,
+        chain: &[Hash256],
+        terminal_slot: Slot,
+        balance_source: &BalanceSourceData,
+        votes: &[VoteTracker],
+        equivocating_indices: &BTreeSet<u64>,
+    ) -> Self {
+        Self {
+            scores: optimizations::precompute_chain_attestation_scores(
+                proto_array,
+                chain,
+                terminal_slot,
+                balance_source,
+                votes,
+                equivocating_indices,
+            ),
+        }
+    }
+
+    fn get_attestation_score(&self, block_root: Hash256) -> Result<u64, Error> {
+        self.scores
+            .get(&block_root)
+            .copied()
+            .ok_or(Error::MissingPrecomputedScore(block_root))
     }
 }
 
@@ -225,14 +262,15 @@ impl FastConfirmationRule {
         // epoch). Two chains share the same validator-set view at `current_epoch` iff they
         // share this root, so it is the right chain-identity cache key. A re-org that pivots
         // before the previous-epoch boundary changes it, forcing a rebuild.
+        let head_dependent_slot = if current_epoch == Epoch::new(0) {
+            compute_start_slot_at_epoch::<E>(current_epoch)
+        } else {
+            compute_start_slot_at_epoch::<E>(current_epoch) - 1
+        };
         let head_checkpoint = Checkpoint {
             epoch: current_epoch,
             root: *state
-                .get_block_root(
-                    current_epoch
-                        .start_slot(E::slots_per_epoch())
-                        .saturating_sub(1u64),
-                )
+                .get_block_root(head_dependent_slot)
                 .map_err(|e| Error::CommitteeCache(format!("dep_root lookup: {e:?}")))?,
         };
         let head_epoch = if state.current_epoch() < current_epoch {
@@ -358,6 +396,16 @@ impl FastConfirmationRule {
         self.last_update_slot
     }
 
+    /// Spec: `get_previous_balance_source`.
+    fn get_previous_balance_source(&self) -> &BalanceSourceData {
+        &self.previous_balance_source
+    }
+
+    /// Spec: `get_current_balance_source`.
+    fn get_current_balance_source(&self) -> &BalanceSourceData {
+        &self.current_balance_source
+    }
+
     /// Spec: `update_fast_confirmation_variables`.
     fn update_fast_confirmation_variables<E: EthSpec>(
         &mut self,
@@ -375,7 +423,7 @@ impl FastConfirmationRule {
             self.current_slot_head = head_root;
 
             // At last slot of epoch: snapshot greatest unrealized justified.
-            if is_start_slot_at_epoch::<E>(current_slot.saturating_add(1u64)) {
+            if is_start_slot_at_epoch::<E>(current_slot + 1) {
                 self.previous_epoch_greatest_unrealized_checkpoint =
                     *unrealized_justified_checkpoint;
             }
@@ -409,31 +457,28 @@ impl FastConfirmationRule {
         let mut confirmed_root = self.confirmed_root;
 
         // Revert to finalized block if either of the following is true:
-        let should_revert_to_finalized_reason = if self
-            .block_epoch::<E>(confirmed_root, proto_array)?
-            .saturating_add(1u64)
-            < current_epoch
-        {
-            // 1) the latest confirmed block's epoch is older than the previous epoch,
-            Some("epoch_too_old")
-        } else if !self.is_ancestor(head_root, confirmed_root, proto_array)? {
-            // 2) the latest confirmed block does not belong to the canonical chain,
-            Some("not_ancestor")
-        } else if is_epoch_start
-            && let Some(chain_unsafe_reason) = self.is_confirmed_chain_safe::<E>(
-                // 3) the confirmed chain starting from the current epoch observed justified
-                //    checkpoint cannot be re-confirmed at the start of the current epoch.
-                confirmed_root,
-                current_slot,
-                proto_array,
-                votes,
-                equivocating_indices,
-            )?
-        {
-            Some(chain_unsafe_reason)
-        } else {
-            None
-        };
+        let should_revert_to_finalized_reason =
+            if get_block_epoch::<E>(confirmed_root, proto_array)? + 1 < current_epoch {
+                // 1) the latest confirmed block's epoch is older than the previous epoch,
+                Some("epoch_too_old")
+            } else if !is_ancestor(head_root, confirmed_root, proto_array)? {
+                // 2) the latest confirmed block does not belong to the canonical chain,
+                Some("not_ancestor")
+            } else if is_epoch_start
+                && let Some(chain_unsafe_reason) = self.is_confirmed_chain_safe::<E>(
+                    // 3) the confirmed chain starting from the current epoch observed justified
+                    //    checkpoint cannot be re-confirmed at the start of the current epoch.
+                    confirmed_root,
+                    current_slot,
+                    proto_array,
+                    votes,
+                    equivocating_indices,
+                )?
+            {
+                Some(chain_unsafe_reason)
+            } else {
+                None
+            };
         if let Some(reason) = should_revert_to_finalized_reason {
             debug!(
                 prev_confirmed = %confirmed_root,
@@ -448,19 +493,19 @@ impl FastConfirmationRule {
 
         // Restart the confirmation chain if each of the following conditions are true:
         // 1) it is the start of the current epoch,
-        let observed_jcp = self.current_epoch_observed_justified_checkpoint;
-        let observed_justified_block_slot = self.block_slot(observed_jcp.root, proto_array)?;
+        let observed_justified_block_slot = get_block_slot(
+            self.current_epoch_observed_justified_checkpoint.root,
+            proto_array,
+        )?;
         // 2) epoch of fcr_store.current_epoch_observed_justified_checkpoint.root equals to the previous epoch,
-        let is_observed_justified_block_epoch_ok = observed_justified_block_slot
-            .epoch(E::slots_per_epoch())
-            .saturating_add(1u64)
-            == current_epoch;
+        let is_observed_justified_block_epoch_ok =
+            observed_justified_block_slot.epoch(E::slots_per_epoch()) + 1 == current_epoch;
         // 3) fcr_store.current_epoch_observed_justified_checkpoint equals to unrealized justification of the head,
-        let is_head_unrealized_justified_ok =
-            observed_jcp == self.unrealized_justification_of(head_root, proto_array)?;
+        let is_head_unrealized_justified_ok = self.current_epoch_observed_justified_checkpoint
+            == unrealized_justification_of(head_root, proto_array)?;
         // 4) confirmed block is older than the block of fcr_store.current_epoch_observed_justified_checkpoint.
         let is_confirmed_block_stale =
-            self.block_slot(confirmed_root, proto_array)? < observed_justified_block_slot;
+            get_block_slot(confirmed_root, proto_array)? < observed_justified_block_slot;
         if is_epoch_start
             && is_observed_justified_block_epoch_ok
             && is_head_unrealized_justified_ok
@@ -468,21 +513,16 @@ impl FastConfirmationRule {
         {
             debug!(
                 prev_confirmed = %confirmed_root,
-                justified = %observed_jcp.root,
-                justified_epoch = %observed_jcp.epoch,
+                justified = %self.current_epoch_observed_justified_checkpoint.root,
+                justified_epoch = %self.current_epoch_observed_justified_checkpoint.epoch,
                 "FCR restarted from observed justified"
             );
-            confirmed_root = observed_jcp.root;
+            confirmed_root = self.current_epoch_observed_justified_checkpoint.root;
             metrics::inc_counter(&metrics::FCR_RESTART_FROM_JUSTIFIED);
         }
-        let pre_advance_root = confirmed_root;
 
         // Attempt to further advance the latest confirmed block
-        if self
-            .block_epoch::<E>(confirmed_root, proto_array)?
-            .saturating_add(1u64)
-            >= current_epoch
-        {
+        if get_block_epoch::<E>(confirmed_root, proto_array)? + 1 >= current_epoch {
             confirmed_root = self.find_latest_confirmed_descendant::<E>(
                 confirmed_root,
                 head_root,
@@ -493,19 +533,14 @@ impl FastConfirmationRule {
                 equivocating_indices,
             )?;
         }
-        if confirmed_root != pre_advance_root {
-            metrics::inc_counter(&metrics::FCR_ADVANCE);
-        }
 
         Ok(confirmed_root)
     }
 
     /// Spec: find_latest_confirmed_descendant
     ///
-    /// DIVERGENCE: The spec calls `is_one_confirmed` per block, which calls
-    /// `get_attestation_score` each time — O(B × V × depth). We precompute
-    /// all scores once via `precompute_chain_attestation_scores` and use
-    /// `is_one_confirmed_with_score` per block instead — O(V × depth + B).
+    /// DIVERGENCE: `is_one_confirmed` below is backed by an attestation-score cache instead of
+    /// recomputing `get_attestation_score` per block. The control-flow shape follows the spec.
     #[allow(clippy::too_many_arguments)]
     fn find_latest_confirmed_descendant<E: EthSpec>(
         &self,
@@ -521,84 +556,56 @@ impl FastConfirmationRule {
 
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
         let mut confirmed_root = latest_confirmed_root;
-        let is_epoch_start = is_start_slot_at_epoch::<E>(current_slot);
+        let mut current_attestation_scores = None;
+        let mut honest_ffg_support = None;
+        let mut no_conflicting_checkpoint = None;
 
-        // Precompute attestation scores for the full chain from confirmed → head in one
-        // O(V × depth) pass. Both loops below use these scores instead of calling
-        // get_attestation_score per block (which would be O(B × V × depth) total).
-        let precomputed_scores = {
-            let _s = debug_span!("fcr_precompute").entered();
-            let chain = self.get_ancestor_roots(head_root, latest_confirmed_root, proto_array)?;
-            let terminal_slot = self.block_slot(latest_confirmed_root, proto_array)?;
-            optimizations::precompute_chain_attestation_scores(
-                proto_array,
-                &chain,
-                terminal_slot,
-                &self.current_balance_source,
-                votes,
-                equivocating_indices,
-            )
-        };
-        // FFG support is identical for every FFG check in this run (constant head, slot and
-        // vote set), so compute it once and thread it into the `will_*` checks below — the
-        // same precompute-and-pass-in pattern as the attestation scores above. This avoids
-        // recomputing the O(V) FFG vote pass up to three times per run.
-        let honest_ffg = {
-            let _s = debug_span!("fcr_honest_ffg").entered();
-            self.compute_honest_ffg_support::<E>(
-                head_root,
-                current_slot,
-                proto_array,
-                votes,
-                equivocating_indices,
-            )?
-        };
-
-        // --- Loop 1: Previous epoch blocks ---
-        let prev_head_voting_source_epoch =
-            self.get_voting_source_epoch::<E>(self.previous_slot_head, current_slot, proto_array);
-
-        let confirmed_epoch_check = self
-            .block_epoch::<E>(confirmed_root, proto_array)?
-            .saturating_add(1u64)
-            == current_epoch;
-        let voting_source_check =
-            prev_head_voting_source_epoch.is_some_and(|e| e.saturating_add(2u64) >= current_epoch);
-        let no_conflict = self.will_no_conflicting_checkpoint_be_justified::<E>(
-            head_root,
-            unrealized_justified_checkpoint,
-            current_slot,
-            proto_array,
-            honest_ffg,
-        )?;
-        let uj_prev_head =
-            self.unrealized_justification_epoch_of(self.previous_slot_head, proto_array);
-        let uj_head = self.unrealized_justification_epoch_of(head_root, proto_array);
-        let loop1_guard = confirmed_epoch_check
-            && voting_source_check
-            && (is_epoch_start
-                || (no_conflict
-                    && (uj_prev_head.is_some_and(|e| e.saturating_add(1u64) >= current_epoch)
-                        || uj_head.is_some_and(|e| e.saturating_add(1u64) >= current_epoch))));
-        if loop1_guard {
+        if get_block_epoch::<E>(confirmed_root, proto_array)? + 1 == current_epoch
+            && get_voting_source_epoch::<E>(self.previous_slot_head, current_slot, proto_array)? + 2
+                >= current_epoch
+            && (is_start_slot_at_epoch::<E>(current_slot)
+                || (self.will_no_conflicting_checkpoint_be_justified_cached::<E>(
+                    head_root,
+                    unrealized_justified_checkpoint,
+                    current_slot,
+                    proto_array,
+                    votes,
+                    equivocating_indices,
+                    &mut honest_ffg_support,
+                    &mut no_conflicting_checkpoint,
+                )? && (unrealized_justification_of(self.previous_slot_head, proto_array)?
+                    .epoch
+                    + 1
+                    >= current_epoch
+                    || unrealized_justification_of(head_root, proto_array)?.epoch + 1
+                        >= current_epoch)))
+        {
             let _s = debug_span!("fcr_loop1").entered();
-            let canonical_roots =
-                self.get_ancestor_roots(head_root, confirmed_root, proto_array)?;
+            let canonical_roots = get_ancestor_roots(head_root, confirmed_root, proto_array)?;
 
             for block_root in &canonical_roots {
-                if self.block_epoch::<E>(*block_root, proto_array)? >= current_epoch {
+                let block_epoch = get_block_epoch::<E>(*block_root, proto_array)?;
+
+                if block_epoch == current_epoch {
                     break;
                 }
-                if !self.is_ancestor(self.previous_slot_head, *block_root, proto_array)? {
+
+                if !is_ancestor(self.previous_slot_head, *block_root, proto_array)? {
                     break;
                 }
-                let score = *precomputed_scores
-                    .get(block_root)
-                    .ok_or(Error::MissingPrecomputedScore(*block_root))?;
-                if !self.is_one_confirmed_with_score::<E>(
-                    &self.current_balance_source,
+
+                let attestation_scores = self.current_balance_attestation_scores(
+                    &mut current_attestation_scores,
+                    head_root,
+                    latest_confirmed_root,
+                    proto_array,
+                    votes,
+                    equivocating_indices,
+                )?;
+                if !self.is_one_confirmed::<E>(
+                    self.get_current_balance_source(),
                     *block_root,
-                    score,
+                    attestation_scores,
                     current_slot,
                     proto_array,
                     votes,
@@ -610,37 +617,43 @@ impl FastConfirmationRule {
             }
         }
 
-        // --- Loop 2: Current epoch blocks ---
-        let uj_epoch = self.unrealized_justification_epoch_of(head_root, proto_array);
-        let loop2_guard =
-            is_epoch_start || uj_epoch.is_some_and(|e| e.saturating_add(1u64) >= current_epoch);
-        if loop2_guard {
+        if is_start_slot_at_epoch::<E>(current_slot)
+            || unrealized_justification_of(head_root, proto_array)?.epoch + 1 >= current_epoch
+        {
             let _s = debug_span!("fcr_loop2").entered();
-            let canonical_roots =
-                self.get_ancestor_roots(head_root, confirmed_root, proto_array)?;
+            let canonical_roots = get_ancestor_roots(head_root, confirmed_root, proto_array)?;
 
             let mut tentative_confirmed_root = confirmed_root;
 
             for block_root in &canonical_roots {
-                let block_epoch = self.block_epoch::<E>(*block_root, proto_array)?;
-                let tentative_epoch =
-                    self.block_epoch::<E>(tentative_confirmed_root, proto_array)?;
+                let block_epoch = get_block_epoch::<E>(*block_root, proto_array)?;
+                let tentative_epoch = get_block_epoch::<E>(tentative_confirmed_root, proto_array)?;
 
-                // When crossing into current epoch, check FFG.
                 if block_epoch > tentative_epoch {
-                    let ffg_ok = self.will_current_target_be_justified(honest_ffg)?;
-                    if !ffg_ok {
+                    if !self.will_current_target_be_justified::<E>(
+                        head_root,
+                        current_slot,
+                        proto_array,
+                        votes,
+                        equivocating_indices,
+                        &mut honest_ffg_support,
+                    )? {
                         break;
                     }
                 }
 
-                let score = *precomputed_scores
-                    .get(block_root)
-                    .ok_or(Error::MissingPrecomputedScore(*block_root))?;
-                if !self.is_one_confirmed_with_score::<E>(
-                    &self.current_balance_source,
+                let attestation_scores = self.current_balance_attestation_scores(
+                    &mut current_attestation_scores,
+                    head_root,
+                    latest_confirmed_root,
+                    proto_array,
+                    votes,
+                    equivocating_indices,
+                )?;
+                if !self.is_one_confirmed::<E>(
+                    self.get_current_balance_source(),
                     *block_root,
-                    score,
+                    attestation_scores,
                     current_slot,
                     proto_array,
                     votes,
@@ -651,22 +664,25 @@ impl FastConfirmationRule {
                 tentative_confirmed_root = *block_root;
             }
 
-            // Promote tentative if safe.
-            let tentative_epoch = self.block_epoch::<E>(tentative_confirmed_root, proto_array)?;
-            let tentative_voting_source_epoch = self.get_voting_source_epoch::<E>(
-                tentative_confirmed_root,
-                current_slot,
-                proto_array,
-            );
-
-            let promote_check1 = tentative_epoch == current_epoch;
-            // Reuse `no_conflict` from above: `will_no_conflicting_checkpoint_be_justified` here
-            // takes identical arguments and is deterministic, so its result is unchanged.
-            let promote_check2 = tentative_voting_source_epoch
-                .is_some_and(|e| e.saturating_add(2u64) >= current_epoch)
-                && (is_epoch_start || no_conflict);
-
-            if promote_check1 || promote_check2 {
+            if get_block_epoch::<E>(tentative_confirmed_root, proto_array)? == current_epoch
+                || (get_voting_source_epoch::<E>(
+                    tentative_confirmed_root,
+                    current_slot,
+                    proto_array,
+                )? + 2
+                    >= current_epoch
+                    && (is_start_slot_at_epoch::<E>(current_slot)
+                        || self.will_no_conflicting_checkpoint_be_justified_cached::<E>(
+                            head_root,
+                            unrealized_justified_checkpoint,
+                            current_slot,
+                            proto_array,
+                            votes,
+                            equivocating_indices,
+                            &mut honest_ffg_support,
+                            &mut no_conflicting_checkpoint,
+                        )?))
+            {
                 confirmed_root = tentative_confirmed_root;
             }
         }
@@ -677,6 +693,7 @@ impl FastConfirmationRule {
                 prev = %latest_confirmed_root,
                 "FCR advanced"
             );
+            metrics::inc_counter(&metrics::FCR_ADVANCE);
         }
         Ok(confirmed_root)
     }
@@ -695,61 +712,62 @@ impl FastConfirmationRule {
     ) -> Result<Option<&'static str>, Error> {
         // `Ok(None)` = the confirmed chain is safe (re-confirmable). `Ok(Some(reason))` = it
         // isn't, with `reason` naming which check failed (surfaced as the revert metric label).
-        let observed_jcp = &self.current_epoch_observed_justified_checkpoint;
-        let confirmed_observed_epoch_checkpoint =
-            self.get_checkpoint_for_block::<E>(confirmed_root, observed_jcp.epoch, proto_array)?;
-        if *observed_jcp != confirmed_observed_epoch_checkpoint {
+        if self.current_epoch_observed_justified_checkpoint
+            != get_checkpoint_for_block::<E>(
+                confirmed_root,
+                self.current_epoch_observed_justified_checkpoint.epoch,
+                proto_array,
+            )?
+        {
             return Ok(Some("off_justified_chain"));
         }
 
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
-        let start_root = if observed_jcp.epoch.saturating_add(1u64) >= current_epoch {
-            observed_jcp.root
-        } else {
-            // Limit reconfirmation to the first block of the previous epoch.
-            // If successful, reconfirmation of ancestors is implied.
-            let prev_epoch_start = current_epoch
-                .saturating_sub(1u64)
-                .start_slot(E::slots_per_epoch());
-            let ancestor = self.get_ancestor(confirmed_root, prev_epoch_start, proto_array)?;
-            let ancestor_epoch = self.block_epoch::<E>(ancestor, proto_array)?;
-            if ancestor_epoch.saturating_add(1u64) == current_epoch {
-                // The parent of the first block of the previous epoch.
-                match self.parent_root(ancestor, proto_array) {
-                    Some(r) => r,
-                    None => return Ok(Some("missing_parent")),
-                }
+        let start_root_exclusive =
+            if self.current_epoch_observed_justified_checkpoint.epoch + 1 >= current_epoch {
+                self.current_epoch_observed_justified_checkpoint.root
             } else {
-                // The last block of the epoch before the previous one.
-                ancestor
-            }
-        };
+                // Limit reconfirmation to the first block of the previous epoch.
+                // If successful, reconfirmation of ancestors is implied.
+                let ancestor_at_previous_epoch_start = get_ancestor(
+                    confirmed_root,
+                    compute_start_slot_at_epoch::<E>(current_epoch - 1),
+                    proto_array,
+                )?;
+                if get_block_epoch::<E>(ancestor_at_previous_epoch_start, proto_array)? + 1
+                    == current_epoch
+                {
+                    // The parent of the first block of the previous epoch.
+                    parent_root(ancestor_at_previous_epoch_start, proto_array)?
+                } else {
+                    // The last block of the epoch before the previous one.
+                    ancestor_at_previous_epoch_start
+                }
+            };
 
-        // Precompute scores for the confirmed chain in one O(V × depth) pass.
-        let chain_roots = self.get_ancestor_roots(confirmed_root, start_root, proto_array)?;
-        let terminal_slot = self.block_slot(start_root, proto_array)?;
-        let precomputed_scores = optimizations::precompute_chain_attestation_scores(
+        let chain_roots = get_ancestor_roots(confirmed_root, start_root_exclusive, proto_array)?;
+        let terminal_slot = get_block_slot(start_root_exclusive, proto_array)?;
+        let attestation_scores = AttestationScoreCache::for_chain(
             proto_array,
             &chain_roots,
             terminal_slot,
-            &self.previous_balance_source,
+            self.get_previous_balance_source(),
             votes,
             equivocating_indices,
         );
 
         for root in &chain_roots {
-            let score = *precomputed_scores
-                .get(root)
-                .ok_or(Error::MissingPrecomputedScore(*root))?;
-            if let Some(not_confirmed) = self.one_confirmed_check::<E>(
-                &self.previous_balance_source,
+            let one_confirmation = self.one_confirmation::<E>(
+                self.get_previous_balance_source(),
                 *root,
-                score,
+                &attestation_scores,
                 current_slot,
                 proto_array,
                 votes,
                 equivocating_indices,
-            )? {
+            )?;
+            if !one_confirmation.is_one_confirmed() {
+                let not_confirmed = one_confirmation.not_confirmed();
                 if let Some(ratio) = not_confirmed.support_ratio {
                     metrics::observe(&metrics::FCR_UNCONFIRMED_SUPPORT_RATIO, ratio);
                 }
@@ -766,7 +784,9 @@ impl FastConfirmationRule {
     /// Spec: `get_block_support_between_slots`.
     /// Counts weight of validators whose latest vote is for EXACTLY `block_root`
     /// (not descendants) and whose committee assignment is in [start_slot, end_slot].
-    /// Committee assignments come from the HEAD state (stored in `head_assignments`).
+    /// Equivalent to the spec's `participants` set, but iterates validators with latest
+    /// messages and tests committee membership with precomputed head assignments instead of
+    /// materializing all committee participants for the slot range.
     fn get_block_support_between_slots(
         &self,
         balance_source: &BalanceSourceData,
@@ -778,21 +798,16 @@ impl FastConfirmationRule {
     ) -> Result<u64, Error> {
         let mut score = 0u64;
         for (val_idx, vote) in votes.iter().enumerate() {
-            if vote.current_root() != block_root {
-                continue;
-            }
-            if equivocating_indices.contains(&(val_idx as u64)) {
-                continue;
-            }
             let balance = balance_source.unslashed_balance(val_idx);
-            if balance == 0 {
-                continue;
-            }
-            if self
-                .head_assignments
-                .is_in_range(val_idx, start_slot, end_slot)?
+            // `balance > 0` is the spec's active-and-unslashed validator filter.
+            if balance > 0
+                && self
+                    .head_assignments
+                    .is_in_range(val_idx, start_slot, end_slot)?
+                && vote.current_root() == block_root
+                && !equivocating_indices.contains(&(val_idx as u64))
             {
-                score = score.saturating_add(balance);
+                score += balance;
             }
         }
         Ok(score)
@@ -803,48 +818,107 @@ impl FastConfirmationRule {
     /// the spec and avoid precision loss from divide-first ordering.
     fn compute_proposer_score<E: EthSpec>(&self, balance_source: &BalanceSourceData) -> u64 {
         let committee_weight = balance_source.total_active_balance / E::slots_per_epoch();
-        committee_weight.saturating_mul(self.proposer_score_boost) / 100
+        committee_weight * self.proposer_score_boost / 100
+    }
+
+    /// Spec: `compute_empty_slot_support_discount`.
+    fn compute_empty_slot_support_discount<E: EthSpec>(
+        &self,
+        balance_source: &BalanceSourceData,
+        block_root: Hash256,
+        proto_array: &ProtoArray,
+        votes: &[VoteTracker],
+        equivocating_indices: &BTreeSet<u64>,
+    ) -> Result<u64, Error> {
+        let block_slot = get_block_slot(block_root, proto_array)?;
+        let parent_root = parent_root(block_root, proto_array)?;
+        let parent_slot = get_block_slot(parent_root, proto_array)?;
+
+        if parent_slot + 1 == block_slot {
+            return Ok(0);
+        }
+
+        let parent_support_in_empty_slots = self.get_block_support_between_slots(
+            balance_source,
+            parent_root,
+            parent_slot + 1,
+            block_slot - 1,
+            votes,
+            equivocating_indices,
+        )?;
+
+        let adversarial_weight = self.compute_adversarial_weight::<E>(
+            balance_source,
+            parent_slot + 1,
+            block_slot - 1,
+            equivocating_indices,
+        )?;
+
+        if parent_support_in_empty_slots > adversarial_weight {
+            Ok(parent_support_in_empty_slots - adversarial_weight)
+        } else {
+            Ok(0)
+        }
     }
 
     /// Spec: `get_support_discount`.
     fn get_support_discount<E: EthSpec>(
         &self,
         balance_source: &BalanceSourceData,
-        block_slot: Slot,
-        parent_root: Hash256,
-        parent_slot: Slot,
+        block_root: Hash256,
+        proto_array: &ProtoArray,
         votes: &[VoteTracker],
         equivocating_indices: &BTreeSet<u64>,
     ) -> Result<u64, Error> {
-        // No empty slots before the block.
-        if parent_slot.saturating_add(1u64) == block_slot {
-            return Ok(0);
-        }
-
-        let empty_start = parent_slot.saturating_add(1u64);
-        let empty_end = block_slot.saturating_sub(1u64);
-
-        // Votes for the parent in the empty slot range.
-        // Uses exact vote matching (spec's get_block_support_between_slots),
-        // NOT ancestor matching (spec's get_attestation_score).
-        let parent_support = self.get_block_support_between_slots(
+        self.compute_empty_slot_support_discount::<E>(
             balance_source,
-            parent_root,
-            empty_start,
-            empty_end,
+            block_root,
+            proto_array,
+            votes,
+            equivocating_indices,
+        )
+    }
+
+    /// Spec: `compute_safety_threshold`.
+    fn compute_safety_threshold<E: EthSpec>(
+        &self,
+        balance_source: &BalanceSourceData,
+        block_root: Hash256,
+        current_slot: Slot,
+        proto_array: &ProtoArray,
+        votes: &[VoteTracker],
+        equivocating_indices: &BTreeSet<u64>,
+    ) -> Result<u64, Error> {
+        let parent_root = parent_root(block_root, proto_array)?;
+        let parent_slot = get_block_slot(parent_root, proto_array)?;
+
+        let total_active_balance = balance_source.total_active_balance;
+        let proposer_score = self.compute_proposer_score::<E>(balance_source);
+        let maximum_support = estimate_committee_weight_between_slots::<E>(
+            total_active_balance,
+            parent_slot + 1,
+            current_slot - 1,
+        );
+        let support_discount = self.get_support_discount::<E>(
+            balance_source,
+            block_root,
+            proto_array,
             votes,
             equivocating_indices,
         )?;
-
-        // Adversarial weight in empty slots is NOT discounted.
-        let adversarial = self.compute_adversarial_weight::<E>(
+        let adversarial_weight = self.get_adversarial_weight::<E>(
             balance_source,
-            empty_start,
-            empty_end,
+            block_root,
+            current_slot,
+            proto_array,
             equivocating_indices,
         )?;
 
-        Ok(parent_support.saturating_sub(adversarial))
+        if support_discount < maximum_support + proposer_score + 2 * adversarial_weight {
+            Ok((maximum_support + proposer_score + 2 * adversarial_weight - support_discount) / 2)
+        } else {
+            Ok(0)
+        }
     }
 
     /// Spec: `get_adversarial_weight`.
@@ -856,25 +930,25 @@ impl FastConfirmationRule {
         proto_array: &ProtoArray,
         equivocating_indices: &BTreeSet<u64>,
     ) -> Result<u64, Error> {
-        let block_slot = self.block_slot(block_root, proto_array)?;
-        let Some(parent_root) = self.parent_root(block_root, proto_array) else {
-            return Ok(0);
-        };
-        let parent_epoch = self.block_epoch::<E>(parent_root, proto_array)?;
-        let block_epoch = self.block_epoch::<E>(block_root, proto_array)?;
+        let block_slot = get_block_slot(block_root, proto_array)?;
+        let parent_root = parent_root(block_root, proto_array)?;
+        let block_epoch = get_block_epoch::<E>(block_root, proto_array)?;
 
-        let start_slot = if block_epoch > parent_epoch {
-            block_epoch.start_slot(E::slots_per_epoch())
+        if block_epoch > get_block_epoch::<E>(parent_root, proto_array)? {
+            self.compute_adversarial_weight::<E>(
+                balance_source,
+                compute_start_slot_at_epoch::<E>(block_epoch),
+                current_slot - 1,
+                equivocating_indices,
+            )
         } else {
-            block_slot
-        };
-
-        self.compute_adversarial_weight::<E>(
-            balance_source,
-            start_slot,
-            current_slot.saturating_sub(1u64),
-            equivocating_indices,
-        )
+            self.compute_adversarial_weight::<E>(
+                balance_source,
+                block_slot,
+                current_slot - 1,
+                equivocating_indices,
+            )
+        }
     }
 
     /// Spec: `compute_adversarial_weight`.
@@ -886,12 +960,13 @@ impl FastConfirmationRule {
         end_slot: Slot,
         equivocating_indices: &BTreeSet<u64>,
     ) -> Result<u64, Error> {
+        let total_active_balance = balance_source.total_active_balance;
         let maximum_weight = estimate_committee_weight_between_slots::<E>(
-            balance_source.total_active_balance,
+            total_active_balance,
             start_slot,
             end_slot,
         );
-        let max_adversarial = (maximum_weight / 100).saturating_mul(self.byzantine_threshold);
+        let max_adversarial_weight = maximum_weight / 100 * self.byzantine_threshold;
 
         let equivocation_score = self.get_equivocation_score(
             balance_source,
@@ -900,11 +975,16 @@ impl FastConfirmationRule {
             equivocating_indices,
         )?;
 
-        Ok(max_adversarial.saturating_sub(equivocation_score))
+        if max_adversarial_weight > equivocation_score {
+            Ok(max_adversarial_weight - equivocation_score)
+        } else {
+            Ok(0)
+        }
     }
 
     /// Spec: `get_equivocation_score`.
-    /// Uses HEAD state committee assignments (via `head_assignments.is_in_range`).
+    /// Equivalent to the spec's `active_equivocating_indices`, but tests committee membership
+    /// with precomputed head assignments instead of materializing all committee participants.
     fn get_equivocation_score(
         &self,
         balance_source: &BalanceSourceData,
@@ -913,17 +993,13 @@ impl FastConfirmationRule {
         equivocating_indices: &BTreeSet<u64>,
     ) -> Result<u64, Error> {
         let mut score = 0u64;
-        for &val_idx in equivocating_indices {
-            let idx = val_idx as usize;
-            let balance = balance_source.balance(idx);
-            if balance == 0 {
-                continue;
-            }
-            if self
-                .head_assignments
-                .is_in_range(idx, start_slot, end_slot)?
+        for idx in balance_source.active_indices() {
+            if equivocating_indices.contains(&(idx as u64))
+                && self
+                    .head_assignments
+                    .is_in_range(idx, start_slot, end_slot)?
             {
-                score = score.saturating_add(balance);
+                score += balance_source.balance(idx);
             }
         }
         Ok(score)
@@ -935,39 +1011,57 @@ impl FastConfirmationRule {
 
     /// Spec: `will_no_conflicting_checkpoint_be_justified`.
     #[allow(clippy::too_many_arguments)]
-    ///
-    /// `honest_ffg` is the precomputed `compute_honest_ffg_support` result (identical for
-    /// every FFG check in a single `find_latest_confirmed_descendant` run, so it is computed
-    /// once and threaded in — same pattern as `is_one_confirmed_with_score`'s precomputed
-    /// attestation score). This avoids recomputing the O(V) FFG vote pass per call.
     fn will_no_conflicting_checkpoint_be_justified<E: EthSpec>(
         &self,
         head_root: Hash256,
         unrealized_justified_checkpoint: &Checkpoint,
         current_slot: Slot,
         proto_array: &ProtoArray,
-        honest_ffg: u64,
+        votes: &[VoteTracker],
+        equivocating_indices: &BTreeSet<u64>,
+        honest_ffg_support: &mut Option<u64>,
     ) -> Result<bool, Error> {
-        let current_target = self.get_current_target::<E>(head_root, current_slot, proto_array)?;
-        if current_target == *unrealized_justified_checkpoint {
+        if get_current_target::<E>(head_root, current_slot, proto_array)?
+            == *unrealized_justified_checkpoint
+        {
             return Ok(true);
         }
 
-        let total_active = self.head_balance_source.total_active_balance;
+        let total_active_balance = self.head_balance_source.total_active_balance;
+        let honest_ffg_support = self.compute_honest_ffg_support_cached::<E>(
+            head_root,
+            current_slot,
+            proto_array,
+            votes,
+            equivocating_indices,
+            honest_ffg_support,
+        )?;
 
-        // 3 * honest_ffg > 1 * total_active (i.e. honest strictly > 1/3)
-        Ok(3u128 * honest_ffg as u128 > total_active as u128)
+        Ok(3u128 * honest_ffg_support as u128 > total_active_balance as u128)
     }
 
     /// Spec: `will_current_target_be_justified`.
-    ///
-    /// `honest_ffg` is the precomputed `compute_honest_ffg_support` result (see
-    /// `will_no_conflicting_checkpoint_be_justified`).
-    fn will_current_target_be_justified(&self, honest_ffg: u64) -> Result<bool, Error> {
-        let total_active = self.head_balance_source.total_active_balance;
+    #[allow(clippy::too_many_arguments)]
+    fn will_current_target_be_justified<E: EthSpec>(
+        &self,
+        head_root: Hash256,
+        current_slot: Slot,
+        proto_array: &ProtoArray,
+        votes: &[VoteTracker],
+        equivocating_indices: &BTreeSet<u64>,
+        honest_ffg_support: &mut Option<u64>,
+    ) -> Result<bool, Error> {
+        let total_active_balance = self.head_balance_source.total_active_balance;
+        let honest_ffg_support = self.compute_honest_ffg_support_cached::<E>(
+            head_root,
+            current_slot,
+            proto_array,
+            votes,
+            equivocating_indices,
+            honest_ffg_support,
+        )?;
 
-        // 3 * honest_ffg >= 2 * total_active (i.e. honest > 2/3)
-        Ok(3u128 * honest_ffg as u128 >= 2u128 * total_active as u128)
+        Ok(3u128 * honest_ffg_support as u128 >= 2u128 * total_active_balance as u128)
     }
 
     /// Spec: `get_current_target_score` — estimates FFG support for current epoch target.
@@ -983,46 +1077,30 @@ impl FastConfirmationRule {
         votes: &[VoteTracker],
         equivocating_indices: &BTreeSet<u64>,
     ) -> Result<u64, Error> {
-        let current_target = self.get_current_target::<E>(head_root, current_slot, proto_array)?;
-        let bs = &self.head_balance_source;
+        let target = get_current_target::<E>(head_root, current_slot, proto_array)?;
         let mut score = 0u64;
 
         // Memoize get_checkpoint_for_block by (vote root, vote epoch): most validators share a
         // small set of (root, epoch) pairs, so each O(depth) ancestor walk runs at most once
         // across the validator set rather than once per validator.
-        let mut memo: optimizations::RootMemo<(Hash256, Epoch), Option<Checkpoint>> =
+        let mut memo: optimizations::RootMemo<(Hash256, Epoch), Checkpoint> =
             optimizations::RootMemo::new();
 
-        for (val_idx, vote) in votes.iter().enumerate() {
-            // Skip validators without a vote (spec: `i in store.latest_messages`).
+        // Spec: iterate `unslashed_and_active_indices`; zero roots mean no latest message.
+        for val_idx in self.head_balance_source.unslashed_and_active_indices() {
+            let Some(vote) = votes.get(val_idx) else {
+                continue;
+            };
             let vote_root = vote.current_root();
-            if vote_root.is_zero() {
-                continue;
-            }
-            if equivocating_indices.contains(&(val_idx as u64)) {
-                continue;
-            }
-            // Spec sums over `unslashed_and_active_indices`: exclude slashed validators.
-            // `unslashed_balance` returns 0 for slashed (and inactive) validators, so the
-            // `== 0` skip below covers both the slashed and the active-set filters.
-            let balance = bs.unslashed_balance(val_idx);
-            if balance == 0 {
-                continue;
-            }
-            // Spec: get_checkpoint_for_block(store, latest_messages[i].root,
-            //        get_latest_message_epoch(latest_messages[i]))
-            // Use the VOTE's epoch, not the current epoch.
-            let vote_epoch = vote.latest_message_slot().epoch(E::slots_per_epoch());
-            let vote_target = memo.get_or_try_insert_with((vote_root, vote_epoch), || {
-                match self.get_checkpoint_for_block::<E>(vote_root, vote_epoch, proto_array) {
-                    Ok(cp) => Ok(Some(cp)),
-                    // Vote references a block pruned from proto_array — skip it.
-                    Err(Error::CheckpointBlockNotFound { .. }) => Ok(None),
-                    Err(e) => Err(e),
-                }
-            })?;
-            if vote_target.is_some_and(|t| t == current_target) {
-                score = score.saturating_add(balance);
+            if !vote_root.is_zero() && !equivocating_indices.contains(&(val_idx as u64)) && {
+                // Spec: get_checkpoint_for_block(store, latest_messages[i].root,
+                //        get_latest_message_epoch(latest_messages[i]))
+                let vote_epoch = vote.latest_message_slot().epoch(E::slots_per_epoch());
+                memo.get_or_try_insert_with((vote_root, vote_epoch), || {
+                    get_checkpoint_for_block::<E>(vote_root, vote_epoch, proto_array)
+                })? == target
+            } {
+                score += self.head_balance_source.balance(val_idx);
             }
         }
         Ok(score)
@@ -1038,9 +1116,9 @@ impl FastConfirmationRule {
         equivocating_indices: &BTreeSet<u64>,
     ) -> Result<u64, Error> {
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
-        let total_active = self.head_balance_source.total_active_balance;
+        let total_active_balance = self.head_balance_source.total_active_balance;
 
-        let ffg_support = self.get_current_target_score::<E>(
+        let ffg_support_for_checkpoint = self.get_current_target_score::<E>(
             head_root,
             current_slot,
             proto_array,
@@ -1048,320 +1126,390 @@ impl FastConfirmationRule {
             equivocating_indices,
         )?;
 
-        let epoch_start = current_epoch.start_slot(E::slots_per_epoch());
         let ffg_weight_till_now = estimate_committee_weight_between_slots::<E>(
-            total_active,
-            epoch_start,
-            current_slot.saturating_sub(1u64),
+            total_active_balance,
+            compute_start_slot_at_epoch::<E>(current_epoch),
+            current_slot - 1,
         );
 
-        let remaining_ffg_weight = total_active.saturating_sub(ffg_weight_till_now);
-        let remaining_honest = (remaining_ffg_weight / 100)
-            .saturating_mul(100u64.saturating_sub(self.byzantine_threshold));
+        let remaining_ffg_weight = total_active_balance - ffg_weight_till_now;
+        let remaining_honest_ffg_weight =
+            remaining_ffg_weight / 100 * (100 - self.byzantine_threshold);
 
         // Compute potential adversarial weight (accounts for slashed validators).
         let adversarial_weight = self.compute_adversarial_weight::<E>(
             &self.head_balance_source,
-            epoch_start,
-            current_slot.saturating_sub(1u64),
+            compute_start_slot_at_epoch::<E>(current_epoch),
+            current_slot - 1,
             equivocating_indices,
         )?;
-        let min_honest_support = ffg_support.saturating_sub(adversarial_weight);
+        let min_honest_ffg_support = ffg_support_for_checkpoint
+            - std::cmp::min(adversarial_weight, ffg_support_for_checkpoint);
 
-        Ok(min_honest_support.saturating_add(remaining_honest))
+        Ok(min_honest_ffg_support + remaining_honest_ffg_weight)
     }
 
-    // -----------------------------------------------------------------------
-    // Proto-array accessors (read-only)
-    // -----------------------------------------------------------------------
-
-    fn block_slot(&self, root: Hash256, proto_array: &ProtoArray) -> Result<Slot, Error> {
-        proto_array
-            .block_slot(root)
-            .ok_or(Error::NodeNotFound(root))
-    }
-
-    fn block_epoch<E: EthSpec>(
-        &self,
-        root: Hash256,
-        proto_array: &ProtoArray,
-    ) -> Result<types::Epoch, Error> {
-        proto_array
-            .block_slot(root)
-            .map(|slot| slot.epoch(E::slots_per_epoch()))
-            .ok_or(Error::BlockEpochNone(root))
-    }
-
-    fn parent_root(&self, root: Hash256, proto_array: &ProtoArray) -> Option<Hash256> {
-        proto_array.parent_root(root)
-    }
-
-    /// Return `true` if the block's execution payload is `Optimistic` or `Invalid`.
-    /// Pre-bellatrix `Irrelevant` payloads and missing nodes are treated as not
-    /// optimistic (the spec MUST applies post-merge). A missing node will be
-    /// rejected later by `block_slot`, so this returning `false` here is safe.
-    fn is_optimistic_or_invalid(&self, root: Hash256, proto_array: &ProtoArray) -> bool {
-        proto_array
-            .execution_status_of(root)
-            .is_some_and(|s| s.is_optimistic_or_invalid())
-    }
-
-    fn is_ancestor(
-        &self,
-        block_root: Hash256,
-        ancestor_root: Hash256,
-        proto_array: &ProtoArray,
-    ) -> Result<bool, Error> {
-        let ancestor_slot = self.block_slot(ancestor_root, proto_array)?;
-        Ok(proto_array
-            .iter_block_roots(&block_root)
-            .any(|(root, slot)| slot <= ancestor_slot && root == ancestor_root))
-    }
-
-    /// Spec: `get_ancestor(store, block_root, slot)`.
-    /// Returns the root of the latest block at or before `slot` on the chain of `block_root`.
-    fn get_ancestor(
-        &self,
-        block_root: Hash256,
-        slot: Slot,
-        proto_array: &ProtoArray,
-    ) -> Result<Hash256, Error> {
-        proto_array
-            .ancestor_at_slot(block_root, slot)
-            .ok_or(Error::AncestorNotFound {
-                block: block_root,
-                slot,
-            })
-    }
-
-    /// Get ordered ancestor roots from `terminal_root` (exclusive) to `block_root` (inclusive).
-    ///
-    /// Returns an empty vector if `terminal_root` is not in the chain of `block_root`.
-    fn get_ancestor_roots(
-        &self,
-        block_root: Hash256,
-        terminal_root: Hash256,
-        proto_array: &ProtoArray,
-    ) -> Result<Vec<Hash256>, Error> {
-        let terminal_slot = self.block_slot(terminal_root, proto_array)?;
-        let mut roots = Vec::new();
-
-        for (root, slot) in proto_array.iter_block_roots(&block_root) {
-            if root == terminal_root {
-                roots.reverse();
-                return Ok(roots);
-            }
-            if slot <= terminal_slot {
-                return Ok(Vec::new());
-            }
-            roots.push(root);
-        }
-
-        Ok(Vec::new())
-    }
-
-    /// Get the unrealized justified checkpoint for a block.
-    fn unrealized_justification_of(
-        &self,
-        root: Hash256,
-        proto_array: &ProtoArray,
-    ) -> Result<Checkpoint, Error> {
-        proto_array
-            .indices
-            .get(&root)
-            .and_then(|&idx| proto_array.nodes.get(idx))
-            .and_then(|n| n.unrealized_justified_checkpoint())
-            .ok_or(Error::UnrealizedJustificationNotFound(root))
-    }
-
-    fn unrealized_justification_epoch_of(
-        &self,
-        root: Hash256,
-        proto_array: &ProtoArray,
-    ) -> Option<types::Epoch> {
-        proto_array
-            .indices
-            .get(&root)
-            .and_then(|&idx| proto_array.nodes.get(idx))
-            .and_then(|n| n.unrealized_justified_checkpoint())
-            .map(|cp| cp.epoch)
-    }
-
-    /// Implements `get_voting_source` — returns the checkpoint used for fork choice voting.
-    /// When `current_epoch > block_epoch`, returns unrealized justified checkpoint (pulled-up).
-    /// Otherwise, returns the block's own justified checkpoint.
-    fn get_voting_source_epoch<E: EthSpec>(
-        &self,
-        root: Hash256,
-        current_slot: Slot,
-        proto_array: &ProtoArray,
-    ) -> Option<types::Epoch> {
-        let node = proto_array
-            .indices
-            .get(&root)
-            .and_then(|&idx| proto_array.nodes.get(idx))?;
-        let current_epoch = current_slot.epoch(E::slots_per_epoch());
-        let block_epoch = node.slot().epoch(E::slots_per_epoch());
-        if current_epoch > block_epoch {
-            node.unrealized_justified_checkpoint().map(|cp| cp.epoch)
-        } else {
-            Some(node.justified_checkpoint().epoch)
-        }
-    }
-
-    /// Get current epoch target checkpoint.
-    fn get_current_target<E: EthSpec>(
-        &self,
-        head_root: Hash256,
-        current_slot: Slot,
-        proto_array: &ProtoArray,
-    ) -> Result<Checkpoint, Error> {
-        let current_epoch = current_slot.epoch(E::slots_per_epoch());
-        self.get_checkpoint_for_block::<E>(head_root, current_epoch, proto_array)
-    }
-
-    /// Get checkpoint block root at the given epoch for the chain ending at `block_root`.
-    fn get_checkpoint_for_block<E: EthSpec>(
-        &self,
-        block_root: Hash256,
-        epoch: types::Epoch,
-        proto_array: &ProtoArray,
-    ) -> Result<Checkpoint, Error> {
-        let cp_root = self.get_checkpoint_block_root::<E>(block_root, epoch, proto_array)?;
-        Ok(Checkpoint {
-            epoch,
-            root: cp_root,
-        })
-    }
-
-    /// Find the block root at the epoch boundary for the given chain.
-    fn get_checkpoint_block_root<E: EthSpec>(
-        &self,
-        block_root: Hash256,
-        epoch: types::Epoch,
-        proto_array: &ProtoArray,
-    ) -> Result<Hash256, Error> {
-        let epoch_start_slot = epoch.start_slot(E::slots_per_epoch());
-        proto_array
-            .iter_block_roots(&block_root)
-            .find(|(_, slot)| *slot <= epoch_start_slot)
-            .map(|(root, _)| root)
-            .ok_or(Error::CheckpointBlockNotFound {
-                block: block_root,
-                epoch,
-            })
-    }
-
-    /// Spec: `is_one_confirmed` — uses a precomputed attestation score from
-    /// `precompute_chain_attestation_scores` instead of iterating all validators.
-    ///
-    /// Spec MUST: returns `false` if the block's execution status is optimistic
-    /// or invalid (i.e. not VALID per Optimistic-sync), so an unvalidated payload
-    /// can never be fed to the EL as `safe_block_hash`.
+    /// Spec: `is_one_confirmed`.
     #[allow(clippy::too_many_arguments)]
-    fn is_one_confirmed_with_score<E: EthSpec>(
+    fn is_one_confirmed<E: EthSpec>(
         &self,
         balance_source: &BalanceSourceData,
         block_root: Hash256,
-        attestation_score: u64,
+        attestation_scores: &AttestationScoreCache,
         current_slot: Slot,
         proto_array: &ProtoArray,
         votes: &[VoteTracker],
         equivocating_indices: &BTreeSet<u64>,
     ) -> Result<bool, Error> {
+        // Spec MUST: return false if the block's execution status is not VALID.
         Ok(self
-            .one_confirmed_check::<E>(
+            .one_confirmation::<E>(
                 balance_source,
                 block_root,
-                attestation_score,
+                attestation_scores,
                 current_slot,
                 proto_array,
                 votes,
                 equivocating_indices,
             )?
-            .is_none())
+            .is_one_confirmed())
     }
 
-    /// Like `is_one_confirmed_with_score` but returns `None` when the block is one-confirmed,
-    /// otherwise the revert reason and (for the below-threshold case) the
-    /// `support / safety_threshold` ratio used by the `unconfirmed_block` diagnostic histogram.
-    #[allow(clippy::too_many_arguments)]
-    fn one_confirmed_check<E: EthSpec>(
+    // -----------------------------------------------------------------------
+    // Implementation caches / diagnostics
+    // -----------------------------------------------------------------------
+
+    /// Lazy current-balance attestation score cache.
+    fn current_balance_attestation_scores<'a>(
         &self,
-        balance_source: &BalanceSourceData,
-        block_root: Hash256,
-        attestation_score: u64,
+        cache: &'a mut Option<AttestationScoreCache>,
+        head_root: Hash256,
+        latest_confirmed_root: Hash256,
+        proto_array: &ProtoArray,
+        votes: &[VoteTracker],
+        equivocating_indices: &BTreeSet<u64>,
+    ) -> Result<&'a AttestationScoreCache, Error> {
+        if cache.is_none() {
+            let _s = debug_span!("fcr_precompute_current_scores").entered();
+            let chain = get_ancestor_roots(head_root, latest_confirmed_root, proto_array)?;
+            let terminal_slot = get_block_slot(latest_confirmed_root, proto_array)?;
+            *cache = Some(AttestationScoreCache::for_chain(
+                proto_array,
+                &chain,
+                terminal_slot,
+                self.get_current_balance_source(),
+                votes,
+                equivocating_indices,
+            ));
+        }
+        Ok(cache
+            .as_ref()
+            .expect("current balance attestation score cache initialized"))
+    }
+
+    /// Lazy FFG support cache for one descendant search.
+    #[allow(clippy::too_many_arguments)]
+    fn compute_honest_ffg_support_cached<E: EthSpec>(
+        &self,
+        head_root: Hash256,
         current_slot: Slot,
         proto_array: &ProtoArray,
         votes: &[VoteTracker],
         equivocating_indices: &BTreeSet<u64>,
-    ) -> Result<Option<NotOneConfirmed>, Error> {
-        if self.is_optimistic_or_invalid(block_root, proto_array) {
-            return Ok(Some(NotOneConfirmed {
-                reason: "unconfirmed_optimistic",
-                support_ratio: None,
-            }));
+        honest_ffg_support: &mut Option<u64>,
+    ) -> Result<u64, Error> {
+        if let Some(honest_ffg) = *honest_ffg_support {
+            return Ok(honest_ffg);
         }
-
-        let block_slot = self.block_slot(block_root, proto_array)?;
-        let Some(parent_root) = self.parent_root(block_root, proto_array) else {
-            return Ok(Some(NotOneConfirmed {
-                reason: "unconfirmed_missing_parent",
-                support_ratio: None,
-            }));
-        };
-        let parent_slot = self.block_slot(parent_root, proto_array)?;
-
-        let support = attestation_score;
-        let proposer_score = self.compute_proposer_score::<E>(balance_source);
-        let maximum_support = estimate_committee_weight_between_slots::<E>(
-            balance_source.total_active_balance,
-            parent_slot.saturating_add(1u64),
-            current_slot.saturating_sub(1u64),
-        );
-        let support_discount = self.get_support_discount::<E>(
-            balance_source,
-            block_slot,
-            parent_root,
-            parent_slot,
+        let _s = debug_span!("fcr_honest_ffg").entered();
+        let honest_ffg = self.compute_honest_ffg_support::<E>(
+            head_root,
+            current_slot,
+            proto_array,
             votes,
             equivocating_indices,
         )?;
-        let adversarial_weight = self.get_adversarial_weight::<E>(
-            balance_source,
-            block_root,
+        *honest_ffg_support = Some(honest_ffg);
+        Ok(honest_ffg)
+    }
+
+    /// Lazy no-conflicting-checkpoint cache for one descendant search.
+    #[allow(clippy::too_many_arguments)]
+    fn will_no_conflicting_checkpoint_be_justified_cached<E: EthSpec>(
+        &self,
+        head_root: Hash256,
+        unrealized_justified_checkpoint: &Checkpoint,
+        current_slot: Slot,
+        proto_array: &ProtoArray,
+        votes: &[VoteTracker],
+        equivocating_indices: &BTreeSet<u64>,
+        honest_ffg_support: &mut Option<u64>,
+        no_conflicting_checkpoint: &mut Option<bool>,
+    ) -> Result<bool, Error> {
+        if let Some(will_not_conflict) = *no_conflicting_checkpoint {
+            return Ok(will_not_conflict);
+        }
+        let will_not_conflict = self.will_no_conflicting_checkpoint_be_justified::<E>(
+            head_root,
+            unrealized_justified_checkpoint,
             current_slot,
             proto_array,
+            votes,
             equivocating_indices,
+            honest_ffg_support,
         )?;
+        *no_conflicting_checkpoint = Some(will_not_conflict);
+        Ok(will_not_conflict)
+    }
 
-        // Spec: compute_safety_threshold
-        // safety_threshold = (maximum_support + proposer_score + 2 * adversarial_weight - support_discount) / 2
-        // with an underflow guard
-        let numerator_without_discount = maximum_support
-            .saturating_add(proposer_score)
-            .saturating_add(adversarial_weight.saturating_mul(2));
-        let safety_threshold = if support_discount < numerator_without_discount {
-            numerator_without_discount.saturating_sub(support_discount) / 2
-        } else {
-            0
-        };
+    /// Cached `is_one_confirmed` evaluation for metrics.
+    #[allow(clippy::too_many_arguments)]
+    fn one_confirmation<E: EthSpec>(
+        &self,
+        balance_source: &BalanceSourceData,
+        block_root: Hash256,
+        attestation_scores: &AttestationScoreCache,
+        current_slot: Slot,
+        proto_array: &ProtoArray,
+        votes: &[VoteTracker],
+        equivocating_indices: &BTreeSet<u64>,
+    ) -> Result<OneConfirmation, Error> {
+        let optimistic_or_invalid = is_optimistic_or_invalid(block_root, proto_array)?;
+        if optimistic_or_invalid {
+            return Ok(OneConfirmation {
+                optimistic_or_invalid,
+                support: 0,
+                safety_threshold: 0,
+            });
+        }
 
-        if support > safety_threshold {
-            Ok(None)
-        } else {
-            // The ratio is meaningless when the threshold underflow-guards to 0.
-            let support_ratio =
-                (safety_threshold > 0).then(|| support as f64 / safety_threshold as f64);
-            Ok(Some(NotOneConfirmed {
-                reason: "unconfirmed_below_threshold",
-                support_ratio,
-            }))
+        Ok(OneConfirmation {
+            optimistic_or_invalid,
+            support: get_attestation_score(block_root, attestation_scores)?,
+            safety_threshold: self.compute_safety_threshold::<E>(
+                balance_source,
+                block_root,
+                current_slot,
+                proto_array,
+                votes,
+                equivocating_indices,
+            )?,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free functions: proto-array/store helpers
+// ---------------------------------------------------------------------------
+
+/// Spec: `get_block_slot`.
+fn get_block_slot(root: Hash256, proto_array: &ProtoArray) -> Result<Slot, Error> {
+    proto_array
+        .block_slot(root)
+        .ok_or(Error::NodeNotFound(root))
+}
+
+/// Spec: `get_block_epoch`.
+fn get_block_epoch<E: EthSpec>(
+    root: Hash256,
+    proto_array: &ProtoArray,
+) -> Result<types::Epoch, Error> {
+    proto_array
+        .block_slot(root)
+        .map(|slot| slot.epoch(E::slots_per_epoch()))
+        .ok_or(Error::BlockEpochNone(root))
+}
+
+fn parent_root(root: Hash256, proto_array: &ProtoArray) -> Result<Hash256, Error> {
+    let node = proto_array
+        .indices
+        .get(&root)
+        .and_then(|&idx| proto_array.nodes.get(idx))
+        .ok_or(Error::NodeNotFound(root))?;
+    let parent_idx = node.parent().ok_or(Error::ParentRootNotFound(root))?;
+    proto_array
+        .nodes
+        .get(parent_idx)
+        .map(|parent| parent.root())
+        .ok_or(Error::ParentRootNotFound(root))
+}
+
+/// Return `true` if the block's execution payload is `Optimistic` or `Invalid`.
+/// Pre-bellatrix `Irrelevant` payloads and missing nodes are treated as not
+/// optimistic (the spec MUST applies post-merge). A missing node will be
+/// rejected later by `get_block_slot`, so this returning `false` here is safe.
+fn is_optimistic_or_invalid(root: Hash256, proto_array: &ProtoArray) -> Result<bool, Error> {
+    let node = proto_array
+        .indices
+        .get(&root)
+        .and_then(|&idx| proto_array.nodes.get(idx))
+        .ok_or(Error::NodeNotFound(root))?;
+    Ok(node
+        .execution_status()
+        .ok()
+        .is_some_and(|s| s.is_optimistic_or_invalid()))
+}
+
+/// Spec: `is_ancestor`.
+fn is_ancestor(
+    block_root: Hash256,
+    ancestor_root: Hash256,
+    proto_array: &ProtoArray,
+) -> Result<bool, Error> {
+    let ancestor_slot = get_block_slot(ancestor_root, proto_array)?;
+    Ok(proto_array
+        .iter_block_roots(&block_root)
+        .any(|(root, slot)| slot <= ancestor_slot && root == ancestor_root))
+}
+
+/// Spec: `get_ancestor`.
+fn get_ancestor(
+    block_root: Hash256,
+    slot: Slot,
+    proto_array: &ProtoArray,
+) -> Result<Hash256, Error> {
+    proto_array
+        .ancestor_at_slot(block_root, slot)
+        .ok_or(Error::AncestorNotFound {
+            block: block_root,
+            slot,
+        })
+}
+
+/// Spec: `get_ancestor_roots`.
+fn get_ancestor_roots(
+    block_root: Hash256,
+    terminal_root: Hash256,
+    proto_array: &ProtoArray,
+) -> Result<Vec<Hash256>, Error> {
+    let terminal_slot = get_block_slot(terminal_root, proto_array)?;
+    let mut roots = Vec::new();
+
+    for (root, slot) in proto_array.iter_block_roots(&block_root) {
+        if root == terminal_root {
+            roots.reverse();
+            return Ok(roots);
+        }
+        if slot <= terminal_slot {
+            return Ok(Vec::new());
+        }
+        roots.push(root);
+    }
+
+    Ok(Vec::new())
+}
+
+fn unrealized_justification_of(
+    root: Hash256,
+    proto_array: &ProtoArray,
+) -> Result<Checkpoint, Error> {
+    let node = proto_array
+        .indices
+        .get(&root)
+        .and_then(|&idx| proto_array.nodes.get(idx))
+        .ok_or(Error::NodeNotFound(root))?;
+    node.unrealized_justified_checkpoint()
+        .ok_or(Error::UnrealizedJustificationNotFound(root))
+}
+
+/// Spec: `get_voting_source`.
+fn get_voting_source_epoch<E: EthSpec>(
+    root: Hash256,
+    current_slot: Slot,
+    proto_array: &ProtoArray,
+) -> Result<types::Epoch, Error> {
+    let node = proto_array
+        .indices
+        .get(&root)
+        .and_then(|&idx| proto_array.nodes.get(idx))
+        .ok_or(Error::NodeNotFound(root))?;
+    let current_epoch = current_slot.epoch(E::slots_per_epoch());
+    let block_epoch = node.slot().epoch(E::slots_per_epoch());
+    if current_epoch > block_epoch {
+        node.unrealized_justified_checkpoint()
+            .map(|cp| cp.epoch)
+            .ok_or(Error::UnrealizedJustificationNotFound(root))
+    } else {
+        Ok(node.justified_checkpoint().epoch)
+    }
+}
+
+/// Spec: `get_current_target`.
+fn get_current_target<E: EthSpec>(
+    head_root: Hash256,
+    current_slot: Slot,
+    proto_array: &ProtoArray,
+) -> Result<Checkpoint, Error> {
+    let current_epoch = current_slot.epoch(E::slots_per_epoch());
+    get_checkpoint_for_block::<E>(head_root, current_epoch, proto_array)
+}
+
+/// Spec: `get_checkpoint_for_block`.
+fn get_checkpoint_for_block<E: EthSpec>(
+    block_root: Hash256,
+    epoch: types::Epoch,
+    proto_array: &ProtoArray,
+) -> Result<Checkpoint, Error> {
+    Ok(Checkpoint {
+        epoch,
+        root: get_checkpoint_block_root::<E>(block_root, epoch, proto_array)?,
+    })
+}
+
+/// Spec: `get_checkpoint_block`.
+fn get_checkpoint_block_root<E: EthSpec>(
+    block_root: Hash256,
+    epoch: types::Epoch,
+    proto_array: &ProtoArray,
+) -> Result<Hash256, Error> {
+    proto_array
+        .iter_block_roots(&block_root)
+        .find(|(_, slot)| *slot <= compute_start_slot_at_epoch::<E>(epoch))
+        .map(|(root, _)| root)
+        .ok_or(Error::CheckpointBlockNotFound {
+            block: block_root,
+            epoch,
+        })
+}
+
+/// Spec: `get_attestation_score`.
+///
+/// Served from a chain score cache to avoid one validator pass per candidate block.
+fn get_attestation_score(
+    block_root: Hash256,
+    attestation_scores: &AttestationScoreCache,
+) -> Result<u64, Error> {
+    attestation_scores.get_attestation_score(block_root)
+}
+
+struct OneConfirmation {
+    optimistic_or_invalid: bool,
+    support: u64,
+    safety_threshold: u64,
+}
+
+impl OneConfirmation {
+    fn is_one_confirmed(&self) -> bool {
+        !self.optimistic_or_invalid && self.support > self.safety_threshold
+    }
+
+    fn not_confirmed(&self) -> NotOneConfirmed {
+        if self.optimistic_or_invalid {
+            return NotOneConfirmed {
+                reason: "unconfirmed_optimistic",
+                support_ratio: None,
+            };
+        }
+
+        NotOneConfirmed {
+            reason: "unconfirmed_below_threshold",
+            support_ratio: (self.safety_threshold > 0)
+                .then(|| self.support as f64 / self.safety_threshold as f64),
         }
     }
 }
 
-/// Outcome of a failed one-confirmed check (see `one_confirmed_check`).
+/// Outcome of a failed one-confirmed check.
 struct NotOneConfirmed {
     /// Revert reason tag, surfaced as the `FCR_REVERT_TO_FINALIZED` label.
     reason: &'static str,
@@ -1376,14 +1524,19 @@ struct NotOneConfirmed {
 
 /// Spec: `is_start_slot_at_epoch`.
 fn is_start_slot_at_epoch<E: EthSpec>(slot: Slot) -> bool {
-    slot.as_u64().is_multiple_of(E::slots_per_epoch())
+    slot.as_u64() % E::slots_per_epoch() == 0
+}
+
+/// Spec: `compute_start_slot_at_epoch`.
+fn compute_start_slot_at_epoch<E: EthSpec>(epoch: Epoch) -> Slot {
+    epoch.start_slot(E::slots_per_epoch())
 }
 
 /// Spec: `is_full_validator_set_covered`.
 fn is_full_validator_set_covered<E: EthSpec>(start_slot: Slot, end_slot: Slot) -> bool {
     let spe = E::slots_per_epoch();
-    let start_full_epoch = start_slot.as_u64().div_ceil(spe);
-    let end_full_epoch = end_slot.as_u64().saturating_add(1) / spe;
+    let start_full_epoch = (start_slot + (spe - 1)).epoch(spe);
+    let end_full_epoch = (end_slot + 1).epoch(spe);
     start_full_epoch < end_full_epoch
 }
 
@@ -1393,8 +1546,8 @@ fn is_full_validator_set_covered<E: EthSpec>(start_slot: Slot, end_slot: Slot) -
 /// conservatively over-estimate committee weight; flooring would under-estimate and
 /// weaken the safety threshold.
 fn adjust_committee_weight_estimate_to_ensure_safety(estimate: u64) -> u64 {
-    let ceil = estimate.saturating_add(999) / 1000;
-    ceil.saturating_mul(1000u64.saturating_add(COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR))
+    let ceil = (estimate + 999) / 1000;
+    ceil * (1000 + COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR)
 }
 
 /// Spec: `estimate_committee_weight_between_slots`.
@@ -1418,7 +1571,7 @@ fn estimate_committee_weight_between_slots<E: EthSpec>(
 
     if start_epoch == end_epoch {
         let num_slots = end_slot.as_u64() - start_slot.as_u64() + 1;
-        return (total_active_balance / spe).saturating_mul(num_slots);
+        return (total_active_balance / spe) * num_slots;
     }
 
     // Cross-epoch boundary but not covering a full epoch.
@@ -1429,14 +1582,13 @@ fn estimate_committee_weight_between_slots<E: EthSpec>(
     let num_slots_in_end_epoch = slots_since_end_epoch + 1;
     let remaining_slots_in_end_epoch = spe - num_slots_in_end_epoch;
 
-    let start_epoch_weight = (total_active_balance / spe).saturating_mul(num_slots_in_start_epoch);
-    let end_epoch_weight = (total_active_balance / spe).saturating_mul(num_slots_in_end_epoch);
+    let start_epoch_weight = (total_active_balance / spe) * num_slots_in_start_epoch;
+    let end_epoch_weight = (total_active_balance / spe) * num_slots_in_end_epoch;
 
-    let start_epoch_weight_pro_rated =
-        (start_epoch_weight / spe).saturating_mul(remaining_slots_in_end_epoch);
+    let start_epoch_weight_pro_rated = (start_epoch_weight / spe) * remaining_slots_in_end_epoch;
 
     adjust_committee_weight_estimate_to_ensure_safety(
-        start_epoch_weight_pro_rated.saturating_add(end_epoch_weight),
+        start_epoch_weight_pro_rated + end_epoch_weight,
     )
 }
 

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -81,6 +81,8 @@ pub enum Error {
         current_slot_epoch: Epoch,
         state_epoch: Epoch,
     },
+    /// A computed index was out of bounds. Indicates a broken internal invariant, not bad input.
+    IndexOutOfBounds(usize),
     ArithError(ArithError),
 }
 
@@ -321,7 +323,7 @@ impl FastConfirmationRule {
         let (slashed, per_epoch) = BalanceSourceData::build_for_epochs(state, &epochs)?;
 
         if let Some(i) = head_i {
-            let eb = &per_epoch[i];
+            let eb = per_epoch.get(i).ok_or(Error::IndexOutOfBounds(i))?;
             self.head_balance_source = BalanceSourceData::from_parts(
                 head_checkpoint,
                 eb.effective_balances.clone(),
@@ -330,7 +332,7 @@ impl FastConfirmationRule {
             );
         }
         if let Some(i) = current_i {
-            let eb = &per_epoch[i];
+            let eb = per_epoch.get(i).ok_or(Error::IndexOutOfBounds(i))?;
             self.current_balance_source = BalanceSourceData::from_parts(
                 current_cp,
                 eb.effective_balances.clone(),
@@ -339,7 +341,7 @@ impl FastConfirmationRule {
             );
         }
         if let Some(i) = previous_i {
-            let eb = &per_epoch[i];
+            let eb = per_epoch.get(i).ok_or(Error::IndexOutOfBounds(i))?;
             self.previous_balance_source = BalanceSourceData::from_parts(
                 previous_cp,
                 eb.effective_balances.clone(),

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -336,13 +336,16 @@ impl FastConfirmationRule {
     ) -> Result<(), Error> {
         let _span = debug_span!("fcr_update_variables", slot = %current_slot).entered();
 
+        // Track head changes (including within a slot, e.g. a late block or reorg).
+        if self.current_slot_head != head_root {
+            self.previous_slot_head = self.current_slot_head;
+            self.current_slot_head = head_root;
+            // TODO: Rebuild head_assignments
+        }
+
         // Spec: update_fast_confirmation_variables is called once per slot,
         // at the attestation deadline. Guard against duplicate calls within the same slot.
         if self.last_update_slot.is_none_or(|s| current_slot > s) {
-            // Rotate slot heads.
-            self.previous_slot_head = self.current_slot_head;
-            self.current_slot_head = head_root;
-
             // At last slot of epoch: snapshot greatest unrealized justified.
             if is_start_slot_at_epoch::<E>(current_slot.safe_add(1)?) {
                 self.previous_epoch_greatest_unrealized_checkpoint =

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -48,6 +48,7 @@ mod slot_assignments;
 
 pub use balance_source::BalanceSourceData;
 use optimizations::AttestationScoreCache;
+pub use optimizations::CheckpointAndBalance;
 use slot_assignments::SlotAssignments;
 pub use slot_assignments::UNSET_SLOT;
 
@@ -124,17 +125,15 @@ pub struct FastConfirmationRule {
     pub confirmed_root: Hash256,
 
     // === Tracking state (spec's 6 new store fields) ===
-    pub previous_epoch_observed_justified_checkpoint: Checkpoint,
-    pub current_epoch_observed_justified_checkpoint: Checkpoint,
+    /// Spec `previous_epoch_observed_justified_checkpoint` with its `get_previous_balance_source`
+    /// snapshot; used to re-confirm.
+    pub previous_epoch_observed_justified: CheckpointAndBalance,
+    /// Spec `current_epoch_observed_justified_checkpoint` with its `get_current_balance_source`
+    /// snapshot; used to advance.
+    pub current_epoch_observed_justified: CheckpointAndBalance,
     pub previous_epoch_greatest_unrealized_checkpoint: Checkpoint,
     pub previous_slot_head: Hash256,
     pub current_slot_head: Hash256,
-
-    // === Balance source snapshots (paired with the observed-justified checkpoints) ===
-    /// Snapshot at `previous_epoch_observed_justified_checkpoint`; used to re-confirm.
-    pub previous_balance_source: BalanceSourceData,
-    /// Snapshot at `current_epoch_observed_justified_checkpoint`; used to advance.
-    pub current_balance_source: BalanceSourceData,
 
     // === Config ===
     pub byzantine_threshold: u64,
@@ -186,13 +185,17 @@ impl FastConfirmationRule {
         let byzantine_threshold = byzantine_threshold.min(Self::MAX_BYZANTINE_THRESHOLD);
         Self {
             confirmed_root: finalized_checkpoint.root,
-            previous_epoch_observed_justified_checkpoint: finalized_checkpoint,
-            current_epoch_observed_justified_checkpoint: finalized_checkpoint,
+            previous_epoch_observed_justified: CheckpointAndBalance::new(
+                finalized_checkpoint,
+                BalanceSourceData::default(),
+            ),
+            current_epoch_observed_justified: CheckpointAndBalance::new(
+                finalized_checkpoint,
+                BalanceSourceData::default(),
+            ),
             previous_epoch_greatest_unrealized_checkpoint: finalized_checkpoint,
             previous_slot_head: finalized_checkpoint.root,
             current_slot_head: finalized_checkpoint.root,
-            previous_balance_source: BalanceSourceData::default(),
-            current_balance_source: BalanceSourceData::default(),
             byzantine_threshold,
             proposer_score_boost,
             head_assignments: SlotAssignments::new(),
@@ -264,10 +267,10 @@ impl FastConfirmationRule {
 
         // Current/previous sources: keyed on the observed-justified checkpoints; rebuilt when
         // those rotate (epoch boundary).
-        let current_cp = self.current_epoch_observed_justified_checkpoint;
-        let previous_cp = self.previous_epoch_observed_justified_checkpoint;
-        let current_stale = self.current_balance_source.checkpoint != current_cp;
-        let previous_stale = self.previous_balance_source.checkpoint != previous_cp;
+        let current_cp = self.current_epoch_observed_justified.checkpoint();
+        let previous_cp = self.previous_epoch_observed_justified.checkpoint();
+        let current_stale = self.current_epoch_observed_justified.is_stale();
+        let previous_stale = self.previous_epoch_observed_justified.is_stale();
 
         if !head_stale && !current_stale && !previous_stale {
             return Ok(());
@@ -295,20 +298,26 @@ impl FastConfirmationRule {
         }
         if let Some(i) = current_i {
             let eb = per_epoch.get(i).ok_or(Error::IndexOutOfBounds(i))?;
-            self.current_balance_source = BalanceSourceData::from_parts(
+            self.current_epoch_observed_justified = CheckpointAndBalance::new(
                 current_cp,
-                eb.effective_balances.clone(),
-                eb.total_active_balance,
-                slashed.clone(),
+                BalanceSourceData::from_parts(
+                    current_cp,
+                    eb.effective_balances.clone(),
+                    eb.total_active_balance,
+                    slashed.clone(),
+                ),
             );
         }
         if let Some(i) = previous_i {
             let eb = per_epoch.get(i).ok_or(Error::IndexOutOfBounds(i))?;
-            self.previous_balance_source = BalanceSourceData::from_parts(
+            self.previous_epoch_observed_justified = CheckpointAndBalance::new(
                 previous_cp,
-                eb.effective_balances.clone(),
-                eb.total_active_balance,
-                slashed,
+                BalanceSourceData::from_parts(
+                    previous_cp,
+                    eb.effective_balances.clone(),
+                    eb.total_active_balance,
+                    slashed,
+                ),
             );
         }
 
@@ -377,12 +386,12 @@ impl FastConfirmationRule {
 
     /// Spec: `get_previous_balance_source`.
     fn get_previous_balance_source(&self) -> &BalanceSourceData {
-        &self.previous_balance_source
+        self.previous_epoch_observed_justified.balances()
     }
 
     /// Spec: `get_current_balance_source`.
     fn get_current_balance_source(&self) -> &BalanceSourceData {
-        &self.current_balance_source
+        self.current_epoch_observed_justified.balances()
     }
 
     /// Spec: `update_fast_confirmation_variables`.
@@ -409,10 +418,17 @@ impl FastConfirmationRule {
 
             // At first slot of epoch: rotate observed justified checkpoints.
             if is_start_slot_at_epoch::<E>(current_slot) {
-                self.previous_epoch_observed_justified_checkpoint =
-                    self.current_epoch_observed_justified_checkpoint;
-                self.current_epoch_observed_justified_checkpoint =
-                    self.previous_epoch_greatest_unrealized_checkpoint;
+                // Rotate the (checkpoint, balances) unit together: `previous` adopts `current`'s
+                // snapshot — spec's `previous_balance_source = checkpoint_states[previous_cp]` and
+                // `previous_cp` becomes the old `current_cp`, so they are equal by definition.
+                // Carrying it over (instead of re-deriving) avoids an O(V) rebuild of `previous`.
+                // `current` is retargeted to the new observed-justified checkpoint; its balances are
+                // rebuilt below (the placeholder is stale until then).
+                let new_current_checkpoint = self.previous_epoch_greatest_unrealized_checkpoint;
+                self.previous_epoch_observed_justified = std::mem::replace(
+                    &mut self.current_epoch_observed_justified,
+                    CheckpointAndBalance::new(new_current_checkpoint, BalanceSourceData::default()),
+                );
             }
 
             self.last_update_slot = Some(current_slot);
@@ -475,7 +491,7 @@ impl FastConfirmationRule {
         // Restart the confirmation chain if each of the following conditions are true:
         // 1) it is the start of the current epoch,
         let observed_justified_block_slot = get_block_slot(
-            self.current_epoch_observed_justified_checkpoint.root,
+            self.current_epoch_observed_justified.checkpoint().root,
             proto_array,
         )?;
         // 2) epoch of fcr_store.current_epoch_observed_justified_checkpoint.root equals to the previous epoch,
@@ -484,7 +500,7 @@ impl FastConfirmationRule {
             .safe_add(1)?
             == current_epoch;
         // 3) fcr_store.current_epoch_observed_justified_checkpoint equals to unrealized justification of the head,
-        let is_head_unrealized_justified_ok = self.current_epoch_observed_justified_checkpoint
+        let is_head_unrealized_justified_ok = self.current_epoch_observed_justified.checkpoint()
             == unrealized_justification_of(head_root, proto_array)?;
         // 4) confirmed block is older than the block of fcr_store.current_epoch_observed_justified_checkpoint.
         let is_confirmed_block_stale =
@@ -496,11 +512,11 @@ impl FastConfirmationRule {
         {
             debug!(
                 prev_confirmed = %confirmed_root,
-                justified = %self.current_epoch_observed_justified_checkpoint.root,
-                justified_epoch = %self.current_epoch_observed_justified_checkpoint.epoch,
+                justified = %self.current_epoch_observed_justified.checkpoint().root,
+                justified_epoch = %self.current_epoch_observed_justified.checkpoint().epoch,
                 "FCR restarted from observed justified"
             );
-            confirmed_root = self.current_epoch_observed_justified_checkpoint.root;
+            confirmed_root = self.current_epoch_observed_justified.checkpoint().root;
             metrics::inc_counter(&metrics::FCR_RESTART_FROM_JUSTIFIED);
         }
 
@@ -694,10 +710,10 @@ impl FastConfirmationRule {
     ) -> Result<Option<&'static str>, Error> {
         // `Ok(None)` = the confirmed chain is safe (re-confirmable). `Ok(Some(reason))` = it
         // isn't, with `reason` naming which check failed (surfaced as the revert metric label).
-        if self.current_epoch_observed_justified_checkpoint
+        if self.current_epoch_observed_justified.checkpoint()
             != get_checkpoint_for_block::<E>(
                 confirmed_root,
-                self.current_epoch_observed_justified_checkpoint.epoch,
+                self.current_epoch_observed_justified.checkpoint().epoch,
                 proto_array,
             )?
         {
@@ -706,12 +722,13 @@ impl FastConfirmationRule {
 
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
         let start_root_exclusive = if self
-            .current_epoch_observed_justified_checkpoint
+            .current_epoch_observed_justified
+            .checkpoint
             .epoch
             .safe_add(1)?
             >= current_epoch
         {
-            self.current_epoch_observed_justified_checkpoint.root
+            self.current_epoch_observed_justified.checkpoint().root
         } else {
             // Limit reconfirmation to the first block of the previous epoch.
             // If successful, reconfirmation of ancestors is implied.

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -47,12 +47,13 @@ pub mod optimizations;
 mod slot_assignments;
 
 pub use balance_source::BalanceSourceData;
+use optimizations::AttestationScoreCache;
 use slot_assignments::SlotAssignments;
 pub use slot_assignments::UNSET_SLOT;
 
 use proto_array::core::{ProtoArray, VoteTracker};
 use safe_arith::{ArithError, SafeArith};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 use tracing::{debug, debug_span};
 use types::{BeaconState, Checkpoint, Epoch, EthSpec, Hash256, Slot};
 
@@ -105,44 +106,6 @@ fn dedup_epoch_index(epochs: &mut Vec<Epoch>, e: Epoch) -> usize {
             epochs.push(e);
             index
         }
-    }
-}
-
-/// Cached implementation of the spec's `get_attestation_score`.
-///
-/// The Python spec computes `get_attestation_score(store, node, balance_source)` independently
-/// for each candidate block. Lighthouse computes the same scores for a canonical chain segment in
-/// one pass and then serves individual `get_attestation_score` calls from this cache.
-struct AttestationScoreCache {
-    scores: HashMap<Hash256, u64>,
-}
-
-impl AttestationScoreCache {
-    fn for_chain(
-        proto_array: &ProtoArray,
-        chain: &[Hash256],
-        terminal_slot: Slot,
-        balance_source: &BalanceSourceData,
-        votes: &[VoteTracker],
-        equivocating_indices: &BTreeSet<u64>,
-    ) -> Result<Self, Error> {
-        Ok(Self {
-            scores: optimizations::precompute_chain_attestation_scores(
-                proto_array,
-                chain,
-                terminal_slot,
-                balance_source,
-                votes,
-                equivocating_indices,
-            )?,
-        })
-    }
-
-    fn get_attestation_score(&self, block_root: Hash256) -> Result<u64, Error> {
-        self.scores
-            .get(&block_root)
-            .copied()
-            .ok_or(Error::MissingPrecomputedScore(block_root))
     }
 }
 

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -162,11 +162,12 @@ impl FastConfirmationRule {
     /// Maximum valid value for `byzantine_threshold` (25%).
     const MAX_BYZANTINE_THRESHOLD: u64 = 25;
 
-    /// Initialize FCR from an anchor (finalized) checkpoint.
-    ///
-    /// `byzantine_threshold` is clamped to [0, 25].
-    pub fn new(
+    /// Initialize FCR from the finalized checkpoint and head `state`, building all three balance
+    /// sources up front. Head is anchored to `finalized_checkpoint` as a placeholder and re-anchored
+    /// to its dependent root on the first tick. `byzantine_threshold` is clamped to [0, 25].
+    pub fn new<E: EthSpec>(
         finalized_checkpoint: Checkpoint,
+        state: &BeaconState<E>,
         byzantine_threshold: u64,
         proposer_score_boost: u64,
     ) -> Self {
@@ -175,11 +176,11 @@ impl FastConfirmationRule {
             confirmed_root: finalized_checkpoint.root,
             previous_epoch_observed_justified: CheckpointAndBalance::new(
                 finalized_checkpoint,
-                BalanceSourceData::default(),
+                BalanceSourceData::for_epoch(state, state.previous_epoch(), finalized_checkpoint),
             ),
             current_epoch_observed_justified: CheckpointAndBalance::new(
                 finalized_checkpoint,
-                BalanceSourceData::default(),
+                BalanceSourceData::for_epoch(state, state.current_epoch(), finalized_checkpoint),
             ),
             previous_epoch_greatest_unrealized_checkpoint: finalized_checkpoint,
             previous_slot_head: finalized_checkpoint.root,
@@ -187,7 +188,11 @@ impl FastConfirmationRule {
             byzantine_threshold,
             proposer_score_boost,
             head_assignments: SlotAssignments::new(),
-            head_balance_source: BalanceSourceData::default(),
+            head_balance_source: BalanceSourceData::for_epoch(
+                state,
+                state.current_epoch(),
+                finalized_checkpoint,
+            ),
             last_update_slot: None,
             spec_test_mode: false,
         }
@@ -214,14 +219,8 @@ impl FastConfirmationRule {
         self.head_balance_source = balance_source;
     }
 
-    /// Rebuild the head / current / previous balance sources from `state`.
-    ///
-    /// Each source keeps its own cache key and is rebuilt only when stale (the previous
-    /// `rebuild_head_balance_source` + `update_balance_sources`). When more than one is stale —
-    /// e.g. at an epoch boundary — they are built from a **single** validator-set pass
-    /// (`build_for_epochs`) instead of one O(V) iteration per source. The head and current
-    /// sources usually resolve to the same epoch, so their per-validator data is computed once
-    /// and shared. Per-source semantics are unchanged.
+    /// Rebuild the head balance source when its dependent root changed. Current/previous are
+    /// rebuilt at the rotation, not here.
     fn rebuild_balance_sources<E: EthSpec>(
         &mut self,
         state: &BeaconState<E>,
@@ -229,12 +228,8 @@ impl FastConfirmationRule {
     ) -> Result<(), Error> {
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
 
-        // Head source: keyed on the dependent root (block at the last slot of the previous
-        // epoch). Two chains share the same validator-set view at `current_epoch` iff they
-        // share this root, so it is the right chain-identity cache key. A re-org that pivots
-        // before the previous-epoch boundary changes it, forcing a rebuild.
-        // Last slot of the previous epoch; clamps to genesis (slot 0) at epoch 0, which has no
-        // previous epoch.
+        // Head source is keyed on the dependent root (last block of the previous epoch) — the
+        // chain-identity that fixes the validator-set view, so a reorg past that boundary rebuilds.
         let head_dependent_slot =
             compute_start_slot_at_epoch::<E>(current_epoch).saturating_sub(1u64);
         let head_checkpoint = Checkpoint {
@@ -250,14 +245,11 @@ impl FastConfirmationRule {
         } else {
             state.current_epoch()
         };
-        // Only the head source is rebuilt here. The current/previous observed-justified sources are
-        // built together with their checkpoints at the epoch-boundary rotation in
-        // `update_fast_confirmation_variables`, so they are never stale between rebuilds.
         let head_stale = self.head_balance_source.checkpoint != head_checkpoint
             || self.head_balance_source.effective_balances.is_empty();
         if head_stale {
             self.head_balance_source =
-                BalanceSourceData::for_epoch(state, head_epoch, head_checkpoint)?;
+                BalanceSourceData::for_epoch(state, head_epoch, head_checkpoint);
         }
 
         Ok(())
@@ -357,19 +349,16 @@ impl FastConfirmationRule {
                     *unrealized_justified_checkpoint;
             }
 
-            // At first slot of epoch: rotate observed justified checkpoints together with their
-            // balances. `previous` adopts `current`'s snapshot — spec's
-            // `previous_balance_source = checkpoint_states[previous_cp]` and `previous_cp` becomes
-            // the old `current_cp`, so they are equal by definition (carrying it over avoids an O(V)
-            // re-derive). `current` is rebuilt for the new observed-justified checkpoint in one step,
-            // so the (checkpoint, balances) pair is always coherent.
+            // At first slot of epoch: rotate the (checkpoint, balances) pairs. `previous` takes
+            // `current`'s snapshot (spec-equal, no O(V) re-derive); `current` is rebuilt for the new
+            // checkpoint in one step so the pair stays coherent.
             if is_start_slot_at_epoch::<E>(current_slot) {
                 let new_current_cp = self.previous_epoch_greatest_unrealized_checkpoint;
                 self.previous_epoch_observed_justified =
                     self.current_epoch_observed_justified.clone();
                 self.current_epoch_observed_justified = CheckpointAndBalance::new(
                     new_current_cp,
-                    BalanceSourceData::for_epoch(state, state.current_epoch(), new_current_cp)?,
+                    BalanceSourceData::for_epoch(state, state.current_epoch(), new_current_cp),
                 );
             }
 

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -219,42 +219,6 @@ impl FastConfirmationRule {
         self.head_balance_source = balance_source;
     }
 
-    /// Rebuild the head balance source when its dependent root changed. Current/previous are
-    /// rebuilt at the rotation, not here.
-    fn rebuild_balance_sources<E: EthSpec>(
-        &mut self,
-        state: &BeaconState<E>,
-        current_slot: Slot,
-    ) -> Result<(), Error> {
-        let current_epoch = current_slot.epoch(E::slots_per_epoch());
-
-        // Head source is keyed on the dependent root (last block of the previous epoch) — the
-        // chain-identity that fixes the validator-set view, so a reorg past that boundary rebuilds.
-        let head_dependent_slot =
-            compute_start_slot_at_epoch::<E>(current_epoch).saturating_sub(1u64);
-        let head_checkpoint = Checkpoint {
-            epoch: current_epoch,
-            root: *state
-                .get_block_root(head_dependent_slot)
-                .map_err(|e| Error::CommitteeCache(format!("dep_root lookup: {e:?}")))?,
-        };
-        let head_epoch = if state.current_epoch() < current_epoch {
-            state
-                .next_epoch()
-                .map_err(|e| Error::CommitteeCache(format!("{e:?}")))?
-        } else {
-            state.current_epoch()
-        };
-        let head_stale = self.head_balance_source.checkpoint != head_checkpoint
-            || self.head_balance_source.effective_balances.is_empty();
-        if head_stale {
-            self.head_balance_source =
-                BalanceSourceData::for_epoch(state, head_epoch, head_checkpoint);
-        }
-
-        Ok(())
-    }
-
     /// Top-level entry point. Spec: `on_fast_confirmation(fcr_store)`.
     ///
     /// Called after head selection, while the fork-choice read lock is held.
@@ -332,9 +296,29 @@ impl FastConfirmationRule {
                 let _span = debug_span!("fcr_rebuild_assignments").entered();
                 self.head_assignments.rebuild::<E>(state, current_slot)?;
             }
-            {
+
+            // Head balance source is keyed on the dependent root (last block of the previous
+            // epoch); rebuild it when a reorg past that boundary changes it.
+            let current_epoch = current_slot.epoch(E::slots_per_epoch());
+            let head_dependent_slot =
+                compute_start_slot_at_epoch::<E>(current_epoch).saturating_sub(1u64);
+            let head_checkpoint = Checkpoint {
+                epoch: current_epoch,
+                root: *state
+                    .get_block_root(head_dependent_slot)
+                    .map_err(|e| Error::CommitteeCache(format!("dep_root lookup: {e:?}")))?,
+            };
+            if self.head_balance_source.checkpoint != head_checkpoint {
                 let _span = debug_span!("fcr_rebuild_balances").entered();
-                self.rebuild_balance_sources::<E>(state, current_slot)?;
+                let head_epoch = if state.current_epoch() < current_epoch {
+                    state
+                        .next_epoch()
+                        .map_err(|e| Error::CommitteeCache(format!("{e:?}")))?
+                } else {
+                    state.current_epoch()
+                };
+                self.head_balance_source =
+                    BalanceSourceData::for_epoch(state, head_epoch, head_checkpoint);
             }
         }
 

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -301,8 +301,11 @@ impl FastConfirmationRule {
             let current_epoch = current_slot.epoch(E::slots_per_epoch());
             let head_dependent_root = dependent_root::<E>(state, current_epoch)?;
             if self.head_balance_source.dependent_root != head_dependent_root {
-                let _span = debug_span!("fcr_rebuild_head_caches").entered();
-                self.head_assignments = SlotAssignments::for_state::<E>(state, current_slot)?;
+                // Two distinct O(V) builds — span each so the cost is individually attributable.
+                self.head_assignments = {
+                    let _span = debug_span!("fcr_rebuild_assignments").entered();
+                    SlotAssignments::for_state::<E>(state, current_slot)?
+                };
                 let head_epoch = if state.current_epoch() < current_epoch {
                     state
                         .next_epoch()
@@ -310,8 +313,10 @@ impl FastConfirmationRule {
                 } else {
                     state.current_epoch()
                 };
-                self.head_balance_source =
-                    BalanceSourceData::for_epoch(state, head_epoch, head_dependent_root);
+                self.head_balance_source = {
+                    let _span = debug_span!("fcr_rebuild_head_balance").entered();
+                    BalanceSourceData::for_epoch(state, head_epoch, head_dependent_root)
+                };
             }
         }
 
@@ -332,10 +337,11 @@ impl FastConfirmationRule {
                 let dep_root = dependent_root::<E>(state, state.current_epoch())?;
                 self.previous_epoch_observed_justified =
                     self.current_epoch_observed_justified.clone();
-                self.current_epoch_observed_justified = CheckpointAndBalance::new(
-                    new_current_cp,
-                    BalanceSourceData::for_epoch(state, state.current_epoch(), dep_root),
-                );
+                self.current_epoch_observed_justified =
+                    CheckpointAndBalance::new(new_current_cp, {
+                        let _span = debug_span!("fcr_rebuild_current_balance").entered();
+                        BalanceSourceData::for_epoch(state, state.current_epoch(), dep_root)
+                    });
             }
 
             self.last_update_slot = Some(current_slot);

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -34,9 +34,10 @@
 //!    walks into ~tens. Keyed on the root prefix via an identity hasher to avoid
 //!    SipHashing 32-byte roots per validator (full key stored for collision safety).
 //!
-//! 4. **Single-pass balance rebuild** (`BalanceSourceData::build_for_epochs`): the
-//!    head/current/previous balance sources are rebuilt from one validator-set iteration
-//!    over the (usually two) distinct epochs rather than one iteration each.
+//! 4. **Snapshot balance sources** (`BalanceSourceData`): the current/previous observed-justified
+//!    sources are rebuilt only at the epoch-boundary rotation (bundled with their checkpoint in
+//!    `CheckpointAndBalance`), and the head source only when its dependent root changes — instead
+//!    of re-scanning the validator set every slot.
 //!
 //! The visible algorithm deliberately keeps the spec function names and control-flow shape;
 //! the caches are implementation details behind those helpers.
@@ -96,19 +97,6 @@ impl From<ArithError> for Error {
 
 /// Per-mille adjustment factor for committee weight estimates that don't cover a full epoch.
 const COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR: u64 = 5;
-
-/// Index of `e` in `epochs`, appending it if absent. Used to dedup the (few) epochs needed by
-/// a fused balance-source rebuild so coinciding sources share one validator pass.
-fn dedup_epoch_index(epochs: &mut Vec<Epoch>, e: Epoch) -> usize {
-    match epochs.iter().position(|x| *x == e) {
-        Some(i) => i,
-        None => {
-            let index = epochs.len();
-            epochs.push(e);
-            index
-        }
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Data types
@@ -262,63 +250,14 @@ impl FastConfirmationRule {
         } else {
             state.current_epoch()
         };
+        // Only the head source is rebuilt here. The current/previous observed-justified sources are
+        // built together with their checkpoints at the epoch-boundary rotation in
+        // `update_fast_confirmation_variables`, so they are never stale between rebuilds.
         let head_stale = self.head_balance_source.checkpoint != head_checkpoint
             || self.head_balance_source.effective_balances.is_empty();
-
-        // Current/previous sources: keyed on the observed-justified checkpoints; rebuilt when
-        // those rotate (epoch boundary).
-        let current_cp = self.current_epoch_observed_justified.checkpoint();
-        let previous_cp = self.previous_epoch_observed_justified.checkpoint();
-        let current_stale = self.current_epoch_observed_justified.is_stale();
-        let previous_stale = self.previous_epoch_observed_justified.is_stale();
-
-        if !head_stale && !current_stale && !previous_stale {
-            return Ok(());
-        }
-
-        // Collect the distinct epochs needed by the stale sources (head & current coincide in
-        // the common case), then resolve all balances in one pass.
-        let mut epochs: Vec<Epoch> = Vec::with_capacity(3);
-        let head_i = head_stale.then(|| dedup_epoch_index(&mut epochs, head_epoch));
-        let current_i =
-            current_stale.then(|| dedup_epoch_index(&mut epochs, state.current_epoch()));
-        let previous_i =
-            previous_stale.then(|| dedup_epoch_index(&mut epochs, state.previous_epoch()));
-
-        let (slashed, per_epoch) = BalanceSourceData::build_for_epochs(state, &epochs)?;
-
-        if let Some(i) = head_i {
-            let eb = per_epoch.get(i).ok_or(Error::IndexOutOfBounds(i))?;
-            self.head_balance_source = BalanceSourceData::from_parts(
-                head_checkpoint,
-                eb.effective_balances.clone(),
-                eb.total_active_balance,
-                slashed.clone(),
-            );
-        }
-        if let Some(i) = current_i {
-            let eb = per_epoch.get(i).ok_or(Error::IndexOutOfBounds(i))?;
-            self.current_epoch_observed_justified = CheckpointAndBalance::new(
-                current_cp,
-                BalanceSourceData::from_parts(
-                    current_cp,
-                    eb.effective_balances.clone(),
-                    eb.total_active_balance,
-                    slashed.clone(),
-                ),
-            );
-        }
-        if let Some(i) = previous_i {
-            let eb = per_epoch.get(i).ok_or(Error::IndexOutOfBounds(i))?;
-            self.previous_epoch_observed_justified = CheckpointAndBalance::new(
-                previous_cp,
-                BalanceSourceData::from_parts(
-                    previous_cp,
-                    eb.effective_balances.clone(),
-                    eb.total_active_balance,
-                    slashed,
-                ),
-            );
+        if head_stale {
+            self.head_balance_source =
+                BalanceSourceData::for_epoch(state, head_epoch, head_checkpoint)?;
         }
 
         Ok(())
@@ -347,6 +286,7 @@ impl FastConfirmationRule {
             head_root,
             unrealized_justified_checkpoint,
             current_slot,
+            state,
         )?;
 
         // Rebuild committee assignments from the head state.
@@ -400,6 +340,7 @@ impl FastConfirmationRule {
         head_root: Hash256,
         unrealized_justified_checkpoint: &Checkpoint,
         current_slot: Slot,
+        state: &BeaconState<E>,
     ) -> Result<(), Error> {
         let _span = debug_span!("fcr_update_variables", slot = %current_slot).entered();
 
@@ -416,18 +357,20 @@ impl FastConfirmationRule {
                     *unrealized_justified_checkpoint;
             }
 
-            // At first slot of epoch: rotate observed justified checkpoints.
+            // At first slot of epoch: rotate observed justified checkpoints together with their
+            // balances. `previous` adopts `current`'s snapshot — spec's
+            // `previous_balance_source = checkpoint_states[previous_cp]` and `previous_cp` becomes
+            // the old `current_cp`, so they are equal by definition (carrying it over avoids an O(V)
+            // re-derive). `current` is rebuilt for the new observed-justified checkpoint in one step,
+            // so the (checkpoint, balances) pair is always coherent.
             if is_start_slot_at_epoch::<E>(current_slot) {
-                // Rotate the (checkpoint, balances) unit: `previous` adopts `current`'s snapshot —
-                // spec's `previous_balance_source = checkpoint_states[previous_cp]` and `previous_cp`
-                // becomes the old `current_cp`, so they are equal by definition. Carrying it over
-                // (instead of re-deriving) avoids an O(V) rebuild of `previous`. `current` keeps its
-                // balances but retargets to the new observed-justified checkpoint, marking them stale
-                // until `rebuild_balance_sources` refreshes them below.
+                let new_current_cp = self.previous_epoch_greatest_unrealized_checkpoint;
                 self.previous_epoch_observed_justified =
                     self.current_epoch_observed_justified.clone();
-                self.current_epoch_observed_justified
-                    .retarget(self.previous_epoch_greatest_unrealized_checkpoint);
+                self.current_epoch_observed_justified = CheckpointAndBalance::new(
+                    new_current_cp,
+                    BalanceSourceData::for_epoch(state, state.current_epoch(), new_current_cp)?,
+                );
             }
 
             self.last_update_slot = Some(current_slot);

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -281,19 +281,6 @@ impl FastConfirmationRule {
             state,
         )?;
 
-        // Rebuild committee assignments from the head state.
-        {
-            let _span = debug_span!("fcr_rebuild_assignments").entered();
-            self.head_assignments.rebuild::<E>(state, current_slot)?;
-        }
-
-        // Rebuild the head/current/previous balance sources (whichever are stale) in one
-        // shared validator-set pass.
-        {
-            let _span = debug_span!("fcr_rebuild_balances").entered();
-            self.rebuild_balance_sources::<E>(state, current_slot)?;
-        }
-
         if !self.spec_test_mode {
             let _span = debug_span!("fcr_get_latest_confirmed").entered();
             self.confirmed_root = self.get_latest_confirmed::<E>(
@@ -336,11 +323,19 @@ impl FastConfirmationRule {
     ) -> Result<(), Error> {
         let _span = debug_span!("fcr_update_variables", slot = %current_slot).entered();
 
-        // Track head changes (including within a slot, e.g. a late block or reorg).
+        // Track head changes (including within a slot, e.g. a late block or reorg) and rebuild the
+        // head-derived caches — committee assignments and the head balance source — for the new head.
         if self.current_slot_head != head_root {
             self.previous_slot_head = self.current_slot_head;
             self.current_slot_head = head_root;
-            // TODO: Rebuild head_assignments
+            {
+                let _span = debug_span!("fcr_rebuild_assignments").entered();
+                self.head_assignments.rebuild::<E>(state, current_slot)?;
+            }
+            {
+                let _span = debug_span!("fcr_rebuild_balances").entered();
+                self.rebuild_balance_sources::<E>(state, current_slot)?;
+            }
         }
 
         // Spec: update_fast_confirmation_variables is called once per slot,

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -1116,7 +1116,8 @@ impl FastConfirmationRule {
         equivocating_indices: &BTreeSet<u64>,
     ) -> Result<u64, Error> {
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
-        let total_active_balance = self.head_balance_source.total_active_balance;
+        let balance_source = &self.head_balance_source;
+        let total_active_balance = balance_source.total_active_balance;
 
         let ffg_support_for_checkpoint = self.get_current_target_score::<E>(
             head_root,
@@ -1138,7 +1139,7 @@ impl FastConfirmationRule {
 
         // Compute potential adversarial weight (accounts for slashed validators).
         let adversarial_weight = self.compute_adversarial_weight::<E>(
-            &self.head_balance_source,
+            balance_source,
             compute_start_slot_at_epoch::<E>(current_epoch),
             current_slot - 1,
             equivocating_indices,

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -418,17 +418,16 @@ impl FastConfirmationRule {
 
             // At first slot of epoch: rotate observed justified checkpoints.
             if is_start_slot_at_epoch::<E>(current_slot) {
-                // Rotate the (checkpoint, balances) unit together: `previous` adopts `current`'s
-                // snapshot — spec's `previous_balance_source = checkpoint_states[previous_cp]` and
-                // `previous_cp` becomes the old `current_cp`, so they are equal by definition.
-                // Carrying it over (instead of re-deriving) avoids an O(V) rebuild of `previous`.
-                // `current` is retargeted to the new observed-justified checkpoint; its balances are
-                // rebuilt below (the placeholder is stale until then).
-                let new_current_checkpoint = self.previous_epoch_greatest_unrealized_checkpoint;
-                self.previous_epoch_observed_justified = std::mem::replace(
-                    &mut self.current_epoch_observed_justified,
-                    CheckpointAndBalance::new(new_current_checkpoint, BalanceSourceData::default()),
-                );
+                // Rotate the (checkpoint, balances) unit: `previous` adopts `current`'s snapshot —
+                // spec's `previous_balance_source = checkpoint_states[previous_cp]` and `previous_cp`
+                // becomes the old `current_cp`, so they are equal by definition. Carrying it over
+                // (instead of re-deriving) avoids an O(V) rebuild of `previous`. `current` keeps its
+                // balances but retargets to the new observed-justified checkpoint, marking them stale
+                // until `rebuild_balance_sources` refreshes them below.
+                self.previous_epoch_observed_justified =
+                    self.current_epoch_observed_justified.clone();
+                self.current_epoch_observed_justified
+                    .retarget(self.previous_epoch_greatest_unrealized_checkpoint);
             }
 
             self.last_update_slot = Some(current_slot);
@@ -723,7 +722,7 @@ impl FastConfirmationRule {
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
         let start_root_exclusive = if self
             .current_epoch_observed_justified
-            .checkpoint
+            .checkpoint()
             .epoch
             .safe_add(1)?
             >= current_epoch

--- a/consensus/fast_confirmation/src/metrics.rs
+++ b/consensus/fast_confirmation/src/metrics.rs
@@ -74,9 +74,3 @@ pub(crate) static FCR_ADVANCE: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
         "Count of FCR advances of the confirmed root to a descendant",
     )
 });
-pub static FCR_BALANCE_SOURCE_AGE_EPOCHS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
-    try_create_int_gauge(
-        "beacon_fcr_balance_source_age_epochs",
-        "Age of the current balance source in epochs (current_epoch - balance_source_epoch)",
-    )
-});

--- a/consensus/fast_confirmation/src/optimizations.rs
+++ b/consensus/fast_confirmation/src/optimizations.rs
@@ -69,11 +69,8 @@ impl AttestationScoreCache {
         })
     }
 
-    pub(crate) fn get_attestation_score(&self, block_root: Hash256) -> Result<u64, Error> {
-        self.scores
-            .get(&block_root)
-            .copied()
-            .ok_or(Error::MissingPrecomputedScore(block_root))
+    pub(crate) fn get_attestation_score(&self, block_root: Hash256) -> Option<u64> {
+        self.scores.get(&block_root).copied()
     }
 }
 

--- a/consensus/fast_confirmation/src/optimizations.rs
+++ b/consensus/fast_confirmation/src/optimizations.rs
@@ -181,7 +181,10 @@ pub fn precompute_chain_attestation_scores(
             continue;
         }
         if let Some(pos) = projector.project(vote_root) {
-            score_at_position[pos] = score_at_position[pos].safe_add(balance)?;
+            let score = score_at_position
+                .get_mut(pos)
+                .ok_or(Error::IndexOutOfBounds(pos))?;
+            *score = score.safe_add(balance)?;
         }
     }
 

--- a/consensus/fast_confirmation/src/optimizations.rs
+++ b/consensus/fast_confirmation/src/optimizations.rs
@@ -4,8 +4,9 @@
 //! per-block `get_attestation_score`) via a faster algorithm. They are deliberately kept out of
 //! `lib.rs` so that module reads as the spec algorithm.
 
-use crate::BalanceSourceData;
+use crate::{BalanceSourceData, Error};
 use proto_array::core::{ProtoArray, VoteTracker};
+use safe_arith::SafeArith;
 use std::collections::{BTreeSet, HashMap};
 use types::{Epoch, Hash256, Slot};
 
@@ -165,7 +166,7 @@ pub fn precompute_chain_attestation_scores(
     balance_source: &BalanceSourceData,
     votes: &[VoteTracker],
     equivocating_indices: &BTreeSet<u64>,
-) -> HashMap<Hash256, u64> {
+) -> Result<HashMap<Hash256, u64>, Error> {
     let chain_len = chain.len();
     let mut score_at_position = vec![0u64; chain_len];
     let mut projector = ChainProjector::new(proto_array, chain, terminal_slot);
@@ -180,7 +181,7 @@ pub fn precompute_chain_attestation_scores(
             continue;
         }
         if let Some(pos) = projector.project(vote_root) {
-            score_at_position[pos] += balance;
+            score_at_position[pos] = score_at_position[pos].safe_add(balance)?;
         }
     }
 
@@ -188,8 +189,8 @@ pub fn precompute_chain_attestation_scores(
     let mut scores = HashMap::with_capacity(chain_len);
     let mut running = 0u64;
     for i in (0..chain_len).rev() {
-        running += score_at_position[i];
+        running = running.safe_add(score_at_position[i])?;
         scores.insert(chain[i], running);
     }
-    scores
+    Ok(scores)
 }

--- a/consensus/fast_confirmation/src/optimizations.rs
+++ b/consensus/fast_confirmation/src/optimizations.rs
@@ -8,7 +8,41 @@ use crate::{BalanceSourceData, Error};
 use proto_array::core::{ProtoArray, VoteTracker};
 use safe_arith::SafeArith;
 use std::collections::{BTreeSet, HashMap};
-use types::{Epoch, Hash256, Slot};
+use types::{Checkpoint, Epoch, Hash256, Slot};
+
+/// An observed-justified checkpoint paired with the balance snapshot anchored to it.
+///
+/// The fields are private and can only be set together through [`Self::new`], so the spec tracking
+/// variable and its `get_*_balance_source` data cannot drift apart by accident. The balances carry
+/// their own `checkpoint` (the one they were built for); [`Self::is_stale`] reports when that lags
+/// the tracked `checkpoint` and a rebuild is due.
+#[derive(Clone, Debug)]
+pub struct CheckpointAndBalance {
+    checkpoint: Checkpoint,
+    balances: BalanceSourceData,
+}
+
+impl CheckpointAndBalance {
+    pub fn new(checkpoint: Checkpoint, balances: BalanceSourceData) -> Self {
+        Self {
+            checkpoint,
+            balances,
+        }
+    }
+
+    pub fn checkpoint(&self) -> Checkpoint {
+        self.checkpoint
+    }
+
+    pub fn balances(&self) -> &BalanceSourceData {
+        &self.balances
+    }
+
+    /// `true` when the cached balances were built for a different checkpoint than the tracked one.
+    pub(crate) fn is_stale(&self) -> bool {
+        self.balances.checkpoint != self.checkpoint
+    }
+}
 
 /// Cached implementation of the spec's `get_attestation_score`.
 ///

--- a/consensus/fast_confirmation/src/optimizations.rs
+++ b/consensus/fast_confirmation/src/optimizations.rs
@@ -10,6 +10,44 @@ use safe_arith::SafeArith;
 use std::collections::{BTreeSet, HashMap};
 use types::{Epoch, Hash256, Slot};
 
+/// Cached implementation of the spec's `get_attestation_score`.
+///
+/// The Python spec computes `get_attestation_score(store, node, balance_source)` independently
+/// for each candidate block. Lighthouse computes the same scores for a canonical chain segment in
+/// one pass and then serves individual `get_attestation_score` calls from this cache.
+pub(crate) struct AttestationScoreCache {
+    scores: HashMap<Hash256, u64>,
+}
+
+impl AttestationScoreCache {
+    pub(crate) fn for_chain(
+        proto_array: &ProtoArray,
+        chain: &[Hash256],
+        terminal_slot: Slot,
+        balance_source: &BalanceSourceData,
+        votes: &[VoteTracker],
+        equivocating_indices: &BTreeSet<u64>,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            scores: precompute_chain_attestation_scores(
+                proto_array,
+                chain,
+                terminal_slot,
+                balance_source,
+                votes,
+                equivocating_indices,
+            )?,
+        })
+    }
+
+    pub(crate) fn get_attestation_score(&self, block_root: Hash256) -> Result<u64, Error> {
+        self.scores
+            .get(&block_root)
+            .copied()
+            .ok_or(Error::MissingPrecomputedScore(block_root))
+    }
+}
+
 /// Identity hasher for `u64` keys that are already well-distributed (block-root byte prefixes).
 /// The per-vote memos resolve each vote's root/checkpoint at most once across the whole validator
 /// set; keying them on a root prefix with this no-op hasher avoids SipHashing a 32-byte `Hash256`

--- a/consensus/fast_confirmation/src/optimizations.rs
+++ b/consensus/fast_confirmation/src/optimizations.rs
@@ -42,6 +42,11 @@ impl CheckpointAndBalance {
     pub(crate) fn is_stale(&self) -> bool {
         self.balances.checkpoint != self.checkpoint
     }
+
+    /// Point at a new checkpoint, keeping the existing balances (now stale until the next rebuild).
+    pub(crate) fn retarget(&mut self, checkpoint: Checkpoint) {
+        self.checkpoint = checkpoint;
+    }
 }
 
 /// Cached implementation of the spec's `get_attestation_score`.

--- a/consensus/fast_confirmation/src/optimizations.rs
+++ b/consensus/fast_confirmation/src/optimizations.rs
@@ -37,16 +37,6 @@ impl CheckpointAndBalance {
     pub fn balances(&self) -> &BalanceSourceData {
         &self.balances
     }
-
-    /// `true` when the cached balances were built for a different checkpoint than the tracked one.
-    pub(crate) fn is_stale(&self) -> bool {
-        self.balances.checkpoint != self.checkpoint
-    }
-
-    /// Point at a new checkpoint, keeping the existing balances (now stale until the next rebuild).
-    pub(crate) fn retarget(&mut self, checkpoint: Checkpoint) {
-        self.checkpoint = checkpoint;
-    }
 }
 
 /// Cached implementation of the spec's `get_attestation_score`.

--- a/consensus/fast_confirmation/src/optimizations.rs
+++ b/consensus/fast_confirmation/src/optimizations.rs
@@ -180,7 +180,7 @@ pub fn precompute_chain_attestation_scores(
             continue;
         }
         if let Some(pos) = projector.project(vote_root) {
-            score_at_position[pos] = score_at_position[pos].saturating_add(balance);
+            score_at_position[pos] += balance;
         }
     }
 
@@ -188,7 +188,7 @@ pub fn precompute_chain_attestation_scores(
     let mut scores = HashMap::with_capacity(chain_len);
     let mut running = 0u64;
     for i in (0..chain_len).rev() {
-        running = running.saturating_add(score_at_position[i]);
+        running += score_at_position[i];
         scores.insert(chain[i], running);
     }
     scores

--- a/consensus/fast_confirmation/src/slot_assignments.rs
+++ b/consensus/fast_confirmation/src/slot_assignments.rs
@@ -2,7 +2,7 @@
 
 use crate::Error;
 use safe_arith::SafeArith;
-use types::{BeaconState, EthSpec, RelativeEpoch, Slot};
+use types::{BeaconState, EthSpec, Hash256, RelativeEpoch, Slot};
 
 /// Per-validator committee slot assignments across a 3-epoch window.
 ///
@@ -33,6 +33,8 @@ use types::{BeaconState, EthSpec, RelativeEpoch, Slot};
 pub(crate) struct SlotAssignments {
     /// Flat array of slot assignments. Length = `validator_count * 3`.
     slots: Vec<Slot>,
+    /// Shuffling decision root the table was built for. The owner rebuilds when it changes.
+    dependent_root: Hash256,
 }
 
 /// Number of epoch columns in the slot assignment table.
@@ -43,9 +45,9 @@ const NUM_EPOCH_COLUMNS: usize = 3;
 pub const UNSET_SLOT: Slot = Slot::new(u64::MAX);
 
 impl SlotAssignments {
-    /// Create an empty assignment table.
-    pub(crate) fn new() -> Self {
-        Self { slots: Vec::new() }
+    /// Shuffling decision root this table was built for.
+    pub(crate) fn dependent_root(&self) -> Hash256 {
+        self.dependent_root
     }
 
     /// Get the assigned slot for a validator in a given column (0, 1, or 2).
@@ -85,91 +87,44 @@ impl SlotAssignments {
         Ok(false)
     }
 
-    /// Set assignments from external data. Intended for synthetic-data benchmarks;
-    /// not used in production.
-    ///
-    /// `assignments` must be in the canonical 3-column layout:
-    /// `assignments.len() == validator_count * 3`. Use `UNSET_SLOT` to mark
-    /// columns that should be treated as having no assignment.
-    pub(crate) fn test_set_from(&mut self, assignments: Vec<Slot>) {
-        self.slots = assignments;
-    }
-
-    /// Build assignments from a beacon state for `current_slot`, from scratch.
+    /// Build assignments from a beacon state for `current_slot`, tagged with `dependent_root`.
     ///
     /// Computes the 3-epoch window `[previous, current, next]` and fills assignments from the
     /// state's committee caches; validators with no committee duty in a column are left `UNSET_SLOT`.
-    /// The caller rebuilds (replaces) the table whenever the head's dependent root changes, so this
-    /// keeps no cache key of its own.
+    /// The owner rebuilds (replaces) the table whenever `dependent_root` changes.
     ///
     /// # Performance
     ///
     /// Instead of calling `get_attestation_duties()` per validator (O(N × C) where C =
     /// committees per epoch), we iterate the committee cache's shuffled list directly and
     /// derive slot from shuffled position in O(1). Total cost: O(N) per epoch column.
-    pub(crate) fn for_state<E: EthSpec>(
+    pub(crate) fn new<E: EthSpec>(
         state: &BeaconState<E>,
-        current_slot: Slot,
+        dependent_root: Hash256,
     ) -> Result<Self, Error> {
         let validator_count = state.validators().len();
-        let current_slot_epoch = current_slot.epoch(E::slots_per_epoch());
-        let state_current = state.current_epoch();
-
-        // The state's committee caches cover [previous, current, next] epochs.
-        // FCR queries assignments for slots up to current_slot, so the state must
-        // cover current_slot's epoch. The state's next epoch is current + 1,
-        // so we accept states where current_slot_epoch <= state_current + 1.
-        let state_next = state
-            .next_epoch()
-            .map_err(|e| Error::CommitteeCache(format!("{e:?}")))?;
-        if current_slot_epoch > state_next {
-            return Err(Error::StaleStateForAssignments {
-                current_slot_epoch,
-                state_epoch: state_current,
-            });
-        }
-
-        // Use the state's available epochs to determine the window.
-        let state_prev = state.previous_epoch();
-        let desired_epochs = [state_prev, state_current, state_next];
-
         let total_columns = validator_count.safe_mul(NUM_EPOCH_COLUMNS)?;
         let mut new_slots = vec![UNSET_SLOT; total_columns];
 
-        // Fill from the committee caches by iterating the shuffled list directly.
+        // Fill from the committee caches by iterating each epoch's shuffled list directly.
         // This is O(active_validators) per epoch instead of O(validators × committees).
-        let slots_per_epoch = E::slots_per_epoch();
-        for relative_epoch in [
-            RelativeEpoch::Previous,
-            RelativeEpoch::Current,
-            RelativeEpoch::Next,
+        for (col, relative_epoch, epoch) in [
+            (0, RelativeEpoch::Previous, state.previous_epoch()),
+            (1, RelativeEpoch::Current, state.current_epoch()),
+            (2, RelativeEpoch::Next, state.current_epoch().safe_add(1)?),
         ] {
-            let duty_epoch = match relative_epoch {
-                RelativeEpoch::Previous => state.previous_epoch(),
-                RelativeEpoch::Current => state.current_epoch(),
-                RelativeEpoch::Next => state
-                    .next_epoch()
-                    .map_err(|e| Error::CommitteeCache(format!("{e:?}")))?,
-            };
-            // `duty_epoch` is `state.{previous,current,next}_epoch()` and `desired_epochs` is built
-            // from exactly those, so the position is always found.
-            let col = desired_epochs
-                .iter()
-                .position(|e| *e == duty_epoch)
-                .expect("duty_epoch is one of desired_epochs by construction");
-
             let committee_cache = state
                 .committee_cache(relative_epoch)
                 .map_err(|e| Error::CommitteeCache(format!("{e:?}")))?;
 
             let shuffling = committee_cache.shuffling();
             let committees_per_slot = committee_cache.committees_per_slot() as usize;
-            let epoch_start = duty_epoch.start_slot(slots_per_epoch);
+            let epoch_start = epoch.start_slot(E::slots_per_epoch());
 
             // Each position in the shuffled list maps to a committee, which maps to a slot.
             // committee_index_in_epoch = position * total_committees / shuffling_len
             // slot_offset = committee_index_in_epoch / committees_per_slot
-            let total_committees = committees_per_slot.safe_mul(slots_per_epoch as usize)?;
+            let total_committees = committees_per_slot.safe_mul(E::slots_per_epoch() as usize)?;
             let shuffling_len = shuffling.len();
 
             for (position, &val_idx) in shuffling.iter().enumerate() {
@@ -185,7 +140,10 @@ impl SlotAssignments {
             }
         }
 
-        Ok(Self { slots: new_slots })
+        Ok(Self {
+            slots: new_slots,
+            dependent_root,
+        })
     }
 }
 
@@ -193,7 +151,7 @@ impl SlotAssignments {
 mod tests {
     use super::*;
     use state_processing::per_slot_processing;
-    use types::{Epoch, MinimalEthSpec};
+    use types::{Epoch, Hash256, MinimalEthSpec};
 
     type E = MinimalEthSpec;
 
@@ -253,85 +211,9 @@ mod tests {
     }
 
     #[test]
-    fn rebuild_with_genesis_state_at_genesis_slot() {
+    fn builds_from_genesis_state() {
         let (state, _spec) = genesis_state(64);
-        // State at epoch 0, current_slot in epoch 0 — should work.
-        SlotAssignments::for_state::<E>(&state, Slot::new(1))
-            .expect("genesis state covers epoch 0");
-    }
-
-    #[test]
-    fn rebuild_with_genesis_state_at_next_epoch_slot() {
-        let (state, _spec) = genesis_state(64);
-        // State at epoch 0, current_slot in epoch 1 — should work
-        // because state's next epoch (1) covers current_slot's epoch.
-        let epoch_1_slot = E::slots_per_epoch(); // slot 8 for minimal
-        SlotAssignments::for_state::<E>(&state, Slot::new(epoch_1_slot))
-            .expect("genesis state's next epoch covers epoch 1");
-    }
-
-    #[test]
-    fn rebuild_rejects_stale_state() {
-        let (state, _spec) = genesis_state(64);
-
-        // State at epoch 0 (covers [0, 0, 1]), current_slot in epoch 2.
-        // Epoch 2 > state's next epoch (1) — should fail.
-        let epoch_2_slot = E::slots_per_epoch() * 2; // slot 16 for minimal
-        let result = SlotAssignments::for_state::<E>(&state, Slot::new(epoch_2_slot));
-        assert!(
-            matches!(
-                result,
-                Err(Error::StaleStateForAssignments {
-                    current_slot_epoch,
-                    state_epoch,
-                }) if current_slot_epoch == Epoch::new(2) && state_epoch == Epoch::new(0)
-            ),
-            "expected StaleStateForAssignments, got {:?}",
-            result
-        );
-    }
-
-    #[test]
-    fn rebuild_rejects_state_3_epochs_behind() {
-        let (state, _spec) = genesis_state(64);
-
-        // State at epoch 0, current_slot in epoch 5 — clearly stale.
-        let epoch_5_slot = E::slots_per_epoch() * 5;
-        let result = SlotAssignments::for_state::<E>(&state, Slot::new(epoch_5_slot));
-        assert!(
-            matches!(result, Err(Error::StaleStateForAssignments { .. })),
-            "expected StaleStateForAssignments for 5-epoch gap, got {:?}",
-            result
-        );
-    }
-
-    #[test]
-    fn rebuild_advanced_state_covers_later_epochs() {
-        let (mut state, spec) = genesis_state(64);
-
-        // Advance state to epoch 2 (slot 16 for minimal).
-        let epoch_2_start = E::slots_per_epoch() * 2;
-        advance_state(&mut state, Slot::new(epoch_2_start), &spec);
-
-        assert_eq!(state.current_epoch(), Epoch::new(2));
-
-        // current_slot in epoch 2 — should work (state covers [1, 2, 3]).
-        SlotAssignments::for_state::<E>(&state, Slot::new(epoch_2_start + 1))
-            .expect("state at epoch 2 covers epoch 2");
-
-        // current_slot in epoch 3 — should also work (state's next = 3).
-        let epoch_3_start = E::slots_per_epoch() * 3;
-        SlotAssignments::for_state::<E>(&state, Slot::new(epoch_3_start))
-            .expect("state at epoch 2 covers epoch 3 via next");
-
-        // current_slot in epoch 4 — should fail.
-        let epoch_4_start = E::slots_per_epoch() * 4;
-        let result = SlotAssignments::for_state::<E>(&state, Slot::new(epoch_4_start));
-        assert!(
-            matches!(result, Err(Error::StaleStateForAssignments { .. })),
-            "state at epoch 2 can't cover epoch 4, got {:?}",
-            result
-        );
+        SlotAssignments::new::<E>(&state, Hash256::ZERO).expect("builds from genesis state");
     }
 
     #[test]
@@ -342,9 +224,7 @@ mod tests {
         let epoch_2_start = E::slots_per_epoch() * 2;
         advance_state(&mut state, Slot::new(epoch_2_start), &spec);
 
-        // Build with current_slot in epoch 2.
-        let sa = SlotAssignments::for_state::<E>(&state, Slot::new(epoch_2_start + 1))
-            .expect("build should succeed");
+        let sa = SlotAssignments::new::<E>(&state, Hash256::ZERO).expect("build should succeed");
 
         // Every validator should have an assignment in at least the current epoch.
         let validator_count = state.validators().len();
@@ -388,7 +268,7 @@ mod tests {
         let (state, _spec) = genesis_state(64);
 
         // State at epoch 0, covers epochs [0, 0, 1].
-        let sa = SlotAssignments::for_state::<E>(&state, Slot::new(1)).expect("should build");
+        let sa = SlotAssignments::new::<E>(&state, Hash256::ZERO).expect("should build");
 
         // Query for a slot in epoch 5 — no validator should match.
         let far_slot = Slot::new(E::slots_per_epoch() * 5);

--- a/consensus/fast_confirmation/src/slot_assignments.rs
+++ b/consensus/fast_confirmation/src/slot_assignments.rs
@@ -45,63 +45,20 @@ const NUM_EPOCH_COLUMNS: usize = 3;
 pub const UNSET_SLOT: Slot = Slot::new(u64::MAX);
 
 impl SlotAssignments {
-    /// Shuffling decision root this table was built for.
-    pub(crate) fn dependent_root(&self) -> Hash256 {
-        self.dependent_root
-    }
-
-    /// Get the assigned slot for a validator in a given column (0, 1, or 2).
-    fn get(&self, val_idx: usize, col: usize) -> Option<Slot> {
-        let idx = val_idx
-            .safe_mul(NUM_EPOCH_COLUMNS)
-            .ok()?
-            .safe_add(col)
-            .ok()?;
-        self.slots.get(idx).copied()
-    }
-
-    /// Check if a validator is assigned to any committee in the slot range `[start, end]`.
-    ///
-    /// Iterates over all 3 epoch columns and returns `true` if any assigned slot
-    /// falls within the range (inclusive). Columns with no assignment (`UNSET_SLOT`,
-    /// or an out-of-range index) are treated as "not in range".
-    pub(crate) fn is_in_range(
-        &self,
-        val_idx: usize,
-        start_slot: Slot,
-        end_slot: Slot,
-    ) -> Result<bool, Error> {
-        for col in 0..NUM_EPOCH_COLUMNS {
-            let Some(slot) = self.get(val_idx, col) else {
-                continue;
-            };
-            // UNSET_SLOT means no assignment in this epoch column (inactive validator
-            // or epoch not yet loaded). Treat as "not in range".
-            if slot == UNSET_SLOT {
-                continue;
-            }
-            if slot >= start_slot && slot <= end_slot {
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
-
-    /// Build assignments from a beacon state for `current_slot`, tagged with `dependent_root`.
+    /// Build assignments from a beacon state, tagged with the dependent root it derives for the
+    /// state's current epoch.
     ///
     /// Computes the 3-epoch window `[previous, current, next]` and fills assignments from the
     /// state's committee caches; validators with no committee duty in a column are left `UNSET_SLOT`.
-    /// The owner rebuilds (replaces) the table whenever `dependent_root` changes.
+    /// The owner rebuilds (replaces) the table whenever that dependent root changes.
     ///
     /// # Performance
     ///
     /// Instead of calling `get_attestation_duties()` per validator (O(N × C) where C =
     /// committees per epoch), we iterate the committee cache's shuffled list directly and
     /// derive slot from shuffled position in O(1). Total cost: O(N) per epoch column.
-    pub(crate) fn new<E: EthSpec>(
-        state: &BeaconState<E>,
-        dependent_root: Hash256,
-    ) -> Result<Self, Error> {
+    pub(crate) fn new<E: EthSpec>(state: &BeaconState<E>) -> Result<Self, Error> {
+        let dependent_root = crate::dependent_root::<E>(state, state.current_epoch())?;
         let validator_count = state.validators().len();
         let total_columns = validator_count.safe_mul(NUM_EPOCH_COLUMNS)?;
         let mut new_slots = vec![UNSET_SLOT; total_columns];
@@ -145,13 +102,55 @@ impl SlotAssignments {
             dependent_root,
         })
     }
+
+    /// Shuffling decision root this table was built for.
+    pub(crate) fn dependent_root(&self) -> Hash256 {
+        self.dependent_root
+    }
+
+    /// Get the assigned slot for a validator in a given column (0, 1, or 2).
+    fn get(&self, val_idx: usize, col: usize) -> Option<Slot> {
+        let idx = val_idx
+            .safe_mul(NUM_EPOCH_COLUMNS)
+            .ok()?
+            .safe_add(col)
+            .ok()?;
+        self.slots.get(idx).copied()
+    }
+
+    /// Check if a validator is assigned to any committee in the slot range `[start, end]`.
+    ///
+    /// Iterates over all 3 epoch columns and returns `true` if any assigned slot
+    /// falls within the range (inclusive). Columns with no assignment (`UNSET_SLOT`,
+    /// or an out-of-range index) are treated as "not in range".
+    pub(crate) fn is_in_range(
+        &self,
+        val_idx: usize,
+        start_slot: Slot,
+        end_slot: Slot,
+    ) -> Result<bool, Error> {
+        for col in 0..NUM_EPOCH_COLUMNS {
+            let Some(slot) = self.get(val_idx, col) else {
+                continue;
+            };
+            // UNSET_SLOT means no assignment in this epoch column (inactive validator
+            // or epoch not yet loaded). Treat as "not in range".
+            if slot == UNSET_SLOT {
+                continue;
+            }
+            if slot >= start_slot && slot <= end_slot {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use state_processing::per_slot_processing;
-    use types::{Epoch, Hash256, MinimalEthSpec};
+    use types::{Epoch, MinimalEthSpec};
 
     type E = MinimalEthSpec;
 
@@ -213,7 +212,7 @@ mod tests {
     #[test]
     fn builds_from_genesis_state() {
         let (state, _spec) = genesis_state(64);
-        SlotAssignments::new::<E>(&state, Hash256::ZERO).expect("builds from genesis state");
+        SlotAssignments::new::<E>(&state).expect("builds from genesis state");
     }
 
     #[test]
@@ -224,7 +223,7 @@ mod tests {
         let epoch_2_start = E::slots_per_epoch() * 2;
         advance_state(&mut state, Slot::new(epoch_2_start), &spec);
 
-        let sa = SlotAssignments::new::<E>(&state, Hash256::ZERO).expect("build should succeed");
+        let sa = SlotAssignments::new::<E>(&state).expect("build should succeed");
 
         // Every validator should have an assignment in at least the current epoch.
         let validator_count = state.validators().len();
@@ -268,7 +267,7 @@ mod tests {
         let (state, _spec) = genesis_state(64);
 
         // State at epoch 0, covers epochs [0, 0, 1].
-        let sa = SlotAssignments::new::<E>(&state, Hash256::ZERO).expect("should build");
+        let sa = SlotAssignments::new::<E>(&state).expect("should build");
 
         // Query for a slot in epoch 5 — no validator should match.
         let far_slot = Slot::new(E::slots_per_epoch() * 5);

--- a/consensus/fast_confirmation/src/slot_assignments.rs
+++ b/consensus/fast_confirmation/src/slot_assignments.rs
@@ -2,7 +2,7 @@
 
 use crate::Error;
 use safe_arith::SafeArith;
-use types::{BeaconState, Epoch, EthSpec, RelativeEpoch, Slot};
+use types::{BeaconState, Epoch, EthSpec, Hash256, RelativeEpoch, Slot};
 
 /// Per-validator committee slot assignments across a 3-epoch window.
 ///
@@ -35,6 +35,10 @@ pub(crate) struct SlotAssignments {
     slots: Vec<Slot>,
     /// The 3 epochs covered by columns 0, 1, 2 (typically `[current-2, current-1, current]`).
     epochs: [Epoch; NUM_EPOCH_COLUMNS],
+    /// Shuffling decision root (block at the last slot of the state's previous epoch) that fixes the
+    /// committee shufflings for all three columns. Part of the cache key so a reorg that changes the
+    /// shuffling — same epoch numbers, different chain — invalidates the table.
+    dependent_root: Hash256,
 }
 
 /// Number of epoch columns in the slot assignment table.
@@ -50,6 +54,7 @@ impl SlotAssignments {
         Self {
             slots: Vec::new(),
             epochs: [Epoch::new(0); NUM_EPOCH_COLUMNS],
+            dependent_root: Hash256::ZERO,
         }
     }
 
@@ -103,10 +108,11 @@ impl SlotAssignments {
     /// Rebuild assignments from a beacon state for the given slot.
     ///
     /// Computes the 3-epoch window `[current-2, current-1, current]` and fills
-    /// assignments from the state's committee caches. Preserves old assignments
-    /// that still fall within the new window (epoch column remapping).
+    /// assignments from the state's committee caches; validators with no committee duty in a column
+    /// are left `UNSET_SLOT`.
     ///
-    /// Returns early (cache hit) if the epoch window and validator count haven't changed.
+    /// Returns early (cache hit) when the epoch window, the shuffling decision root, and the
+    /// validator count are all unchanged.
     ///
     /// # Performance
     ///
@@ -140,32 +146,37 @@ impl SlotAssignments {
         let state_prev = state.previous_epoch();
         let desired_epochs = [state_prev, state_current, state_next];
 
+        // Shuffling decision root for this state: the block at the last slot of the previous epoch.
+        // Sharing it means sharing all earlier shuffling-decision history, so it uniquely fixes the
+        // committee shufflings for [prev, current, next]. Keying on it makes the cache reorg-safe.
+        // The genesis epoch has no previous-epoch block; its shuffling is fixed by genesis, so a
+        // constant sentinel is a sufficient (and reorg-free) key there.
+        let dependent_root = if state_current == 0 {
+            Hash256::ZERO
+        } else {
+            let dependent_slot = state_current.start_slot(E::slots_per_epoch()).safe_sub(1)?;
+            *state
+                .get_block_root(dependent_slot)
+                .map_err(|e| Error::CommitteeCache(format!("dep_root lookup: {e:?}")))?
+        };
+
         let total_columns = validator_count.safe_mul(NUM_EPOCH_COLUMNS)?;
 
-        // Fast path: skip if epoch window and validator count are unchanged.
-        if self.epochs == desired_epochs && self.slots.len() == total_columns {
+        // Fast path: skip if the epoch window, shuffling decision root, and validator count are all
+        // unchanged. The decision root invalidates the cache when a reorg changes the shuffling
+        // without changing the epoch numbers.
+        if self.epochs == desired_epochs
+            && self.dependent_root == dependent_root
+            && self.slots.len() == total_columns
+        {
             return Ok(());
         }
 
+        // Recompute every column from the current state's committee caches. Validators not in a
+        // column's shuffling stay `UNSET_SLOT` (no committee duty that epoch) — we deliberately do
+        // not carry forward old assignments, since a reorg can change the shuffling for the same
+        // epoch number and stale entries would corrupt the support calculation.
         let mut new_slots = vec![UNSET_SLOT; total_columns];
-
-        // Preserve old assignments that overlap the new epoch window.
-        if self.slots.len() == total_columns {
-            for val_idx in 0..validator_count {
-                for (old_col, old_epoch) in self.epochs.iter().enumerate() {
-                    if let Some(new_col) = desired_epochs.iter().position(|e| e == old_epoch) {
-                        let new_idx = val_idx.safe_mul(NUM_EPOCH_COLUMNS)?.safe_add(new_col)?;
-                        let old_idx = val_idx.safe_mul(NUM_EPOCH_COLUMNS)?.safe_add(old_col)?;
-                        *new_slots
-                            .get_mut(new_idx)
-                            .ok_or(Error::IndexOutOfBounds(new_idx))? = *self
-                            .slots
-                            .get(old_idx)
-                            .ok_or(Error::IndexOutOfBounds(old_idx))?;
-                    }
-                }
-            }
-        }
 
         // Fill from the committee caches by iterating the shuffled list directly.
         // This is O(active_validators) per epoch instead of O(validators × committees).
@@ -218,6 +229,7 @@ impl SlotAssignments {
 
         self.slots = new_slots;
         self.epochs = desired_epochs;
+        self.dependent_root = dependent_root;
         Ok(())
     }
 }

--- a/consensus/fast_confirmation/src/slot_assignments.rs
+++ b/consensus/fast_confirmation/src/slot_assignments.rs
@@ -154,8 +154,14 @@ impl SlotAssignments {
             for val_idx in 0..validator_count {
                 for (old_col, old_epoch) in self.epochs.iter().enumerate() {
                     if let Some(new_col) = desired_epochs.iter().position(|e| e == old_epoch) {
-                        new_slots[val_idx.safe_mul(NUM_EPOCH_COLUMNS)?.safe_add(new_col)?] =
-                            self.slots[val_idx.safe_mul(NUM_EPOCH_COLUMNS)?.safe_add(old_col)?];
+                        let new_idx = val_idx.safe_mul(NUM_EPOCH_COLUMNS)?.safe_add(new_col)?;
+                        let old_idx = val_idx.safe_mul(NUM_EPOCH_COLUMNS)?.safe_add(old_col)?;
+                        *new_slots
+                            .get_mut(new_idx)
+                            .ok_or(Error::IndexOutOfBounds(new_idx))? = *self
+                            .slots
+                            .get(old_idx)
+                            .ok_or(Error::IndexOutOfBounds(old_idx))?;
                     }
                 }
             }
@@ -204,7 +210,8 @@ impl SlotAssignments {
                 let slot_offset = committee_index.safe_div(committees_per_slot)?;
                 let slot = epoch_start.safe_add(slot_offset as u64)?;
                 if val_idx < validator_count {
-                    new_slots[val_idx.safe_mul(NUM_EPOCH_COLUMNS)?.safe_add(col)?] = slot;
+                    let idx = val_idx.safe_mul(NUM_EPOCH_COLUMNS)?.safe_add(col)?;
+                    *new_slots.get_mut(idx).ok_or(Error::IndexOutOfBounds(idx))? = slot;
                 }
             }
         }

--- a/consensus/fast_confirmation/src/slot_assignments.rs
+++ b/consensus/fast_confirmation/src/slot_assignments.rs
@@ -72,7 +72,7 @@ impl SlotAssignments {
         ] {
             let committee_cache = state
                 .committee_cache(relative_epoch)
-                .map_err(|e| Error::CommitteeCache(format!("{e:?}")))?;
+                .map_err(|e| Error::CommitteeCacheUninitialized(format!("{e:?}")))?;
 
             let shuffling = committee_cache.shuffling();
             let committees_per_slot = committee_cache.committees_per_slot() as usize;

--- a/consensus/fast_confirmation/src/slot_assignments.rs
+++ b/consensus/fast_confirmation/src/slot_assignments.rs
@@ -2,7 +2,7 @@
 
 use crate::Error;
 use safe_arith::SafeArith;
-use types::{BeaconState, Epoch, EthSpec, Hash256, RelativeEpoch, Slot};
+use types::{BeaconState, EthSpec, RelativeEpoch, Slot};
 
 /// Per-validator committee slot assignments across a 3-epoch window.
 ///
@@ -22,8 +22,8 @@ use types::{BeaconState, Epoch, EthSpec, Hash256, RelativeEpoch, Slot};
 ///
 /// Stored flat: `[slot_a, slot_b, slot_c, slot_d, slot_e, slot_f, ...]`
 ///
-/// Access: `slots[validator_index * 3 + column]` where column 0/1/2 maps to
-/// the epoch at `epochs[column]`.
+/// Access: `slots[validator_index * 3 + column]` where column 0/1/2 is the
+/// `[previous, current, next]` epoch of the state it was built from.
 ///
 /// # Sentinel
 ///
@@ -33,12 +33,6 @@ use types::{BeaconState, Epoch, EthSpec, Hash256, RelativeEpoch, Slot};
 pub(crate) struct SlotAssignments {
     /// Flat array of slot assignments. Length = `validator_count * 3`.
     slots: Vec<Slot>,
-    /// The 3 epochs covered by columns 0, 1, 2 (typically `[current-2, current-1, current]`).
-    epochs: [Epoch; NUM_EPOCH_COLUMNS],
-    /// Shuffling decision root (block at the last slot of the state's previous epoch) that fixes the
-    /// committee shufflings for all three columns. Part of the cache key so a reorg that changes the
-    /// shuffling — same epoch numbers, different chain — invalidates the table.
-    dependent_root: Hash256,
 }
 
 /// Number of epoch columns in the slot assignment table.
@@ -51,11 +45,7 @@ pub const UNSET_SLOT: Slot = Slot::new(u64::MAX);
 impl SlotAssignments {
     /// Create an empty assignment table.
     pub(crate) fn new() -> Self {
-        Self {
-            slots: Vec::new(),
-            epochs: [Epoch::new(0); NUM_EPOCH_COLUMNS],
-            dependent_root: Hash256::ZERO,
-        }
+        Self { slots: Vec::new() }
     }
 
     /// Get the assigned slot for a validator in a given column (0, 1, or 2).
@@ -105,25 +95,22 @@ impl SlotAssignments {
         self.slots = assignments;
     }
 
-    /// Rebuild assignments from a beacon state for the given slot.
+    /// Build assignments from a beacon state for `current_slot`, from scratch.
     ///
-    /// Computes the 3-epoch window `[current-2, current-1, current]` and fills
-    /// assignments from the state's committee caches; validators with no committee duty in a column
-    /// are left `UNSET_SLOT`.
-    ///
-    /// Returns early (cache hit) when the epoch window, the shuffling decision root, and the
-    /// validator count are all unchanged.
+    /// Computes the 3-epoch window `[previous, current, next]` and fills assignments from the
+    /// state's committee caches; validators with no committee duty in a column are left `UNSET_SLOT`.
+    /// The caller rebuilds (replaces) the table whenever the head's dependent root changes, so this
+    /// keeps no cache key of its own.
     ///
     /// # Performance
     ///
     /// Instead of calling `get_attestation_duties()` per validator (O(N × C) where C =
     /// committees per epoch), we iterate the committee cache's shuffled list directly and
     /// derive slot from shuffled position in O(1). Total cost: O(N) per epoch column.
-    pub(crate) fn rebuild<E: EthSpec>(
-        &mut self,
+    pub(crate) fn for_state<E: EthSpec>(
         state: &BeaconState<E>,
         current_slot: Slot,
-    ) -> Result<(), Error> {
+    ) -> Result<Self, Error> {
         let validator_count = state.validators().len();
         let current_slot_epoch = current_slot.epoch(E::slots_per_epoch());
         let state_current = state.current_epoch();
@@ -146,36 +133,7 @@ impl SlotAssignments {
         let state_prev = state.previous_epoch();
         let desired_epochs = [state_prev, state_current, state_next];
 
-        // Shuffling decision root for this state: the block at the last slot of the previous epoch.
-        // Sharing it means sharing all earlier shuffling-decision history, so it uniquely fixes the
-        // committee shufflings for [prev, current, next]. Keying on it makes the cache reorg-safe.
-        // The genesis epoch has no previous-epoch block; its shuffling is fixed by genesis, so a
-        // constant sentinel is a sufficient (and reorg-free) key there.
-        let dependent_root = if state_current == 0 {
-            Hash256::ZERO
-        } else {
-            let dependent_slot = state_current.start_slot(E::slots_per_epoch()).safe_sub(1)?;
-            *state
-                .get_block_root(dependent_slot)
-                .map_err(|e| Error::CommitteeCache(format!("dep_root lookup: {e:?}")))?
-        };
-
         let total_columns = validator_count.safe_mul(NUM_EPOCH_COLUMNS)?;
-
-        // Fast path: skip if the epoch window, shuffling decision root, and validator count are all
-        // unchanged. The decision root invalidates the cache when a reorg changes the shuffling
-        // without changing the epoch numbers.
-        if self.epochs == desired_epochs
-            && self.dependent_root == dependent_root
-            && self.slots.len() == total_columns
-        {
-            return Ok(());
-        }
-
-        // Recompute every column from the current state's committee caches. Validators not in a
-        // column's shuffling stay `UNSET_SLOT` (no committee duty that epoch) — we deliberately do
-        // not carry forward old assignments, since a reorg can change the shuffling for the same
-        // epoch number and stale entries would corrupt the support calculation.
         let mut new_slots = vec![UNSET_SLOT; total_columns];
 
         // Fill from the committee caches by iterating the shuffled list directly.
@@ -227,10 +185,7 @@ impl SlotAssignments {
             }
         }
 
-        self.slots = new_slots;
-        self.epochs = desired_epochs;
-        self.dependent_root = dependent_root;
-        Ok(())
+        Ok(Self { slots: new_slots })
     }
 }
 
@@ -238,7 +193,7 @@ impl SlotAssignments {
 mod tests {
     use super::*;
     use state_processing::per_slot_processing;
-    use types::MinimalEthSpec;
+    use types::{Epoch, MinimalEthSpec};
 
     type E = MinimalEthSpec;
 
@@ -300,39 +255,29 @@ mod tests {
     #[test]
     fn rebuild_with_genesis_state_at_genesis_slot() {
         let (state, _spec) = genesis_state(64);
-        let mut sa = SlotAssignments::new();
-
         // State at epoch 0, current_slot in epoch 0 — should work.
-        sa.rebuild::<E>(&state, Slot::new(1))
+        SlotAssignments::for_state::<E>(&state, Slot::new(1))
             .expect("genesis state covers epoch 0");
-
-        // Verify epoch window: [prev=0, current=0, next=1].
-        assert_eq!(sa.epochs[0], Epoch::new(0));
-        assert_eq!(sa.epochs[1], Epoch::new(0));
-        assert_eq!(sa.epochs[2], Epoch::new(1));
     }
 
     #[test]
     fn rebuild_with_genesis_state_at_next_epoch_slot() {
         let (state, _spec) = genesis_state(64);
-        let mut sa = SlotAssignments::new();
-
         // State at epoch 0, current_slot in epoch 1 — should work
         // because state's next epoch (1) covers current_slot's epoch.
         let epoch_1_slot = E::slots_per_epoch(); // slot 8 for minimal
-        sa.rebuild::<E>(&state, Slot::new(epoch_1_slot))
+        SlotAssignments::for_state::<E>(&state, Slot::new(epoch_1_slot))
             .expect("genesis state's next epoch covers epoch 1");
     }
 
     #[test]
     fn rebuild_rejects_stale_state() {
         let (state, _spec) = genesis_state(64);
-        let mut sa = SlotAssignments::new();
 
         // State at epoch 0 (covers [0, 0, 1]), current_slot in epoch 2.
         // Epoch 2 > state's next epoch (1) — should fail.
         let epoch_2_slot = E::slots_per_epoch() * 2; // slot 16 for minimal
-        let result = sa.rebuild::<E>(&state, Slot::new(epoch_2_slot));
+        let result = SlotAssignments::for_state::<E>(&state, Slot::new(epoch_2_slot));
         assert!(
             matches!(
                 result,
@@ -349,11 +294,10 @@ mod tests {
     #[test]
     fn rebuild_rejects_state_3_epochs_behind() {
         let (state, _spec) = genesis_state(64);
-        let mut sa = SlotAssignments::new();
 
         // State at epoch 0, current_slot in epoch 5 — clearly stale.
         let epoch_5_slot = E::slots_per_epoch() * 5;
-        let result = sa.rebuild::<E>(&state, Slot::new(epoch_5_slot));
+        let result = SlotAssignments::for_state::<E>(&state, Slot::new(epoch_5_slot));
         assert!(
             matches!(result, Err(Error::StaleStateForAssignments { .. })),
             "expected StaleStateForAssignments for 5-epoch gap, got {:?}",
@@ -364,7 +308,6 @@ mod tests {
     #[test]
     fn rebuild_advanced_state_covers_later_epochs() {
         let (mut state, spec) = genesis_state(64);
-        let mut sa = SlotAssignments::new();
 
         // Advance state to epoch 2 (slot 16 for minimal).
         let epoch_2_start = E::slots_per_epoch() * 2;
@@ -373,17 +316,17 @@ mod tests {
         assert_eq!(state.current_epoch(), Epoch::new(2));
 
         // current_slot in epoch 2 — should work (state covers [1, 2, 3]).
-        sa.rebuild::<E>(&state, Slot::new(epoch_2_start + 1))
+        SlotAssignments::for_state::<E>(&state, Slot::new(epoch_2_start + 1))
             .expect("state at epoch 2 covers epoch 2");
 
         // current_slot in epoch 3 — should also work (state's next = 3).
         let epoch_3_start = E::slots_per_epoch() * 3;
-        sa.rebuild::<E>(&state, Slot::new(epoch_3_start))
+        SlotAssignments::for_state::<E>(&state, Slot::new(epoch_3_start))
             .expect("state at epoch 2 covers epoch 3 via next");
 
         // current_slot in epoch 4 — should fail.
         let epoch_4_start = E::slots_per_epoch() * 4;
-        let result = sa.rebuild::<E>(&state, Slot::new(epoch_4_start));
+        let result = SlotAssignments::for_state::<E>(&state, Slot::new(epoch_4_start));
         assert!(
             matches!(result, Err(Error::StaleStateForAssignments { .. })),
             "state at epoch 2 can't cover epoch 4, got {:?}",
@@ -394,20 +337,14 @@ mod tests {
     #[test]
     fn rebuild_populates_assignments_for_correct_epochs() {
         let (mut state, spec) = genesis_state(64);
-        let mut sa = SlotAssignments::new();
 
         // Advance state to epoch 2.
         let epoch_2_start = E::slots_per_epoch() * 2;
         advance_state(&mut state, Slot::new(epoch_2_start), &spec);
 
-        // Rebuild with current_slot in epoch 2.
-        sa.rebuild::<E>(&state, Slot::new(epoch_2_start + 1))
-            .expect("rebuild should succeed");
-
-        // Epoch window should be [1, 2, 3].
-        assert_eq!(sa.epochs[0], Epoch::new(1));
-        assert_eq!(sa.epochs[1], Epoch::new(2));
-        assert_eq!(sa.epochs[2], Epoch::new(3));
+        // Build with current_slot in epoch 2.
+        let sa = SlotAssignments::for_state::<E>(&state, Slot::new(epoch_2_start + 1))
+            .expect("build should succeed");
 
         // Every validator should have an assignment in at least the current epoch.
         let validator_count = state.validators().len();
@@ -449,10 +386,9 @@ mod tests {
     #[test]
     fn is_in_range_returns_false_for_uncovered_epochs() {
         let (state, _spec) = genesis_state(64);
-        let mut sa = SlotAssignments::new();
 
         // State at epoch 0, covers epochs [0, 0, 1].
-        sa.rebuild::<E>(&state, Slot::new(1)).expect("should build");
+        let sa = SlotAssignments::for_state::<E>(&state, Slot::new(1)).expect("should build");
 
         // Query for a slot in epoch 5 — no validator should match.
         let far_slot = Slot::new(E::slots_per_epoch() * 5);

--- a/consensus/fast_confirmation/src/slot_assignments.rs
+++ b/consensus/fast_confirmation/src/slot_assignments.rs
@@ -1,6 +1,7 @@
 //! Per-validator committee slot assignment table used by the Fast Confirmation Rule.
 
 use crate::Error;
+use safe_arith::SafeArith;
 use types::{BeaconState, Epoch, EthSpec, RelativeEpoch, Slot};
 
 /// Per-validator committee slot assignments across a 3-epoch window.
@@ -54,7 +55,12 @@ impl SlotAssignments {
 
     /// Get the assigned slot for a validator in a given column (0, 1, or 2).
     fn get(&self, val_idx: usize, col: usize) -> Option<Slot> {
-        self.slots.get(val_idx * NUM_EPOCH_COLUMNS + col).copied()
+        let idx = val_idx
+            .safe_mul(NUM_EPOCH_COLUMNS)
+            .ok()?
+            .safe_add(col)
+            .ok()?;
+        self.slots.get(idx).copied()
     }
 
     /// Check if a validator is assigned to any committee in the slot range `[start, end]`.
@@ -134,21 +140,22 @@ impl SlotAssignments {
         let state_prev = state.previous_epoch();
         let desired_epochs = [state_prev, state_current, state_next];
 
+        let total_columns = validator_count.safe_mul(NUM_EPOCH_COLUMNS)?;
+
         // Fast path: skip if epoch window and validator count are unchanged.
-        if self.epochs == desired_epochs && self.slots.len() == validator_count * NUM_EPOCH_COLUMNS
-        {
+        if self.epochs == desired_epochs && self.slots.len() == total_columns {
             return Ok(());
         }
 
-        let mut new_slots = vec![UNSET_SLOT; validator_count * NUM_EPOCH_COLUMNS];
+        let mut new_slots = vec![UNSET_SLOT; total_columns];
 
         // Preserve old assignments that overlap the new epoch window.
-        if self.slots.len() == validator_count * NUM_EPOCH_COLUMNS {
+        if self.slots.len() == total_columns {
             for val_idx in 0..validator_count {
                 for (old_col, old_epoch) in self.epochs.iter().enumerate() {
                     if let Some(new_col) = desired_epochs.iter().position(|e| e == old_epoch) {
-                        new_slots[val_idx * NUM_EPOCH_COLUMNS + new_col] =
-                            self.slots[val_idx * NUM_EPOCH_COLUMNS + old_col];
+                        new_slots[val_idx.safe_mul(NUM_EPOCH_COLUMNS)?.safe_add(new_col)?] =
+                            self.slots[val_idx.safe_mul(NUM_EPOCH_COLUMNS)?.safe_add(old_col)?];
                     }
                 }
             }
@@ -187,15 +194,17 @@ impl SlotAssignments {
             // Each position in the shuffled list maps to a committee, which maps to a slot.
             // committee_index_in_epoch = position * total_committees / shuffling_len
             // slot_offset = committee_index_in_epoch / committees_per_slot
-            let total_committees = committees_per_slot * slots_per_epoch as usize;
+            let total_committees = committees_per_slot.safe_mul(slots_per_epoch as usize)?;
             let shuffling_len = shuffling.len();
 
             for (position, &val_idx) in shuffling.iter().enumerate() {
-                let committee_index = position * total_committees / shuffling_len;
-                let slot_offset = committee_index / committees_per_slot;
-                let slot = epoch_start + slot_offset as u64;
+                let committee_index = position
+                    .safe_mul(total_committees)?
+                    .safe_div(shuffling_len)?;
+                let slot_offset = committee_index.safe_div(committees_per_slot)?;
+                let slot = epoch_start.safe_add(slot_offset as u64)?;
                 if val_idx < validator_count {
-                    new_slots[val_idx * NUM_EPOCH_COLUMNS + col] = slot;
+                    new_slots[val_idx.safe_mul(NUM_EPOCH_COLUMNS)?.safe_add(col)?] = slot;
                 }
             }
         }

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -1366,7 +1366,7 @@ impl<E: EthSpec> Tester<E> {
         expected: Checkpoint,
     ) -> Result<(), Error> {
         let actual = self.get_fcr_field("previous_epoch_observed_justified_checkpoint", |fcr| {
-            fcr.previous_epoch_observed_justified_checkpoint
+            fcr.previous_epoch_observed_justified.checkpoint
         })?;
         check_equal(
             "previous_epoch_observed_justified_checkpoint",
@@ -1380,7 +1380,7 @@ impl<E: EthSpec> Tester<E> {
         expected: Checkpoint,
     ) -> Result<(), Error> {
         let actual = self.get_fcr_field("current_epoch_observed_justified_checkpoint", |fcr| {
-            fcr.current_epoch_observed_justified_checkpoint
+            fcr.current_epoch_observed_justified.checkpoint
         })?;
         check_equal(
             "current_epoch_observed_justified_checkpoint",

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -1366,7 +1366,7 @@ impl<E: EthSpec> Tester<E> {
         expected: Checkpoint,
     ) -> Result<(), Error> {
         let actual = self.get_fcr_field("previous_epoch_observed_justified_checkpoint", |fcr| {
-            fcr.previous_epoch_observed_justified.checkpoint
+            fcr.previous_epoch_observed_justified.checkpoint()
         })?;
         check_equal(
             "previous_epoch_observed_justified_checkpoint",
@@ -1380,7 +1380,7 @@ impl<E: EthSpec> Tester<E> {
         expected: Checkpoint,
     ) -> Result<(), Error> {
         let actual = self.get_fcr_field("current_epoch_observed_justified_checkpoint", |fcr| {
-            fcr.current_epoch_observed_justified.checkpoint
+            fcr.current_epoch_observed_justified.checkpoint()
         })?;
         check_equal(
             "current_epoch_observed_justified_checkpoint",


### PR DESCRIPTION
Aligns the Fast Confirmation Rule implementation with the consensus-specs reference, on top of the PR #8951 tip (`fcr`).

## Changes
- **Align FCR implementation with consensus spec** — restructures `lib.rs` to track spec vocabulary and structure: introduces `AttestationScoreCache`, splits the support-discount/safety-threshold computation, and renames the confirmation entry points (`one_confirmation` + `OneConfirmation`/`NotOneConfirmed`). Tree-walk helpers (`get_block_slot`, `parent_root`, `is_optimistic_or_invalid`, `is_ancestor`, `get_ancestor*`) become free functions returning `Result` instead of swallowing errors as `Option`.
- **`fcr_pulled_up_head_state`** (`canonical_head.rs`) now prefers a cached state at the epoch start and pulls a previous-epoch head exactly to the spec target slot, fixing the earlier "pulled-up head state" divergence (removes the `TODO(fcr)`).
- **`balance_source.rs`** — adds `active_indices()` / `unslashed_and_active_indices()` helpers.
- **Refine FCR support balance access** and **Fix FCR benchmark head balances** — small follow-ups so `fcr_bench` exercises realistic head balances.
- **Fix clippy lints** — `collapsible_if`, `is_multiple_of`, `div_ceil`.

## Notes
This is a spec-conformance rewrite, not behavior-preserving — the pulled-up-state change and `Option`→`Result` conversions can alter outputs/error paths. `make lint-full` passes (pre-push hook).