### PR TITLE
FCR: benchmark harness + memoize the honest-FFG-support sweep

### DIFF
--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -281,7 +281,8 @@ fn build_chain(num_validators: usize) -> BenchData {
     }
 }
 
-const VALIDATOR_SET_SIZES: [usize; 5] = [64, 16_000, 100_000, 500_000, 1_000_000];
+/// Real networks start around 100k validators; 16k is kept only as a sub-floor scaling reference.
+const VALIDATOR_SET_SIZES: [usize; 4] = [16_000, 100_000, 500_000, 1_000_000];
 
 /// A representative chain head + slot for the slot-agnostic building-block benchmarks below
 /// (the `epoch_catch_up` configuration, where the FFG sweep is live).

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -2,6 +2,10 @@
 //!
 //! Measures performance of the core FCR algorithms at various validator set sizes
 //! using a synthetic linear chain built via `ProtoArrayForkChoice`.
+//!
+//! All benchmarks run on `MainnetEthSpec` (32 slots/epoch). The chain spans two epochs so the
+//! FCR state machine has a real epoch boundary to act on, and `get_latest_confirmed` is measured
+//! at both an epoch-boundary slot and a mid-epoch slot (see `bench_get_latest_confirmed`).
 
 use std::collections::BTreeSet;
 use std::time::Duration;
@@ -17,8 +21,26 @@ type E = MainnetEthSpec;
 
 const GWEI_PER_ETH: u64 = 1_000_000_000;
 const BALANCE: u64 = 32 * GWEI_PER_ETH;
-/// Number of blocks in the linear chain (genesis + 9 more).
-const NUM_BLOCKS: usize = 10;
+
+/// Last block in the chain (epoch 1 for MainnetEthSpec). The chain is linear: slots 0..=HEAD_SLOT.
+const HEAD_SLOT: u64 = 63;
+/// Epoch-1 boundary block; the FCR's current-epoch observed-justified checkpoint points here.
+const OBSERVED_JUSTIFIED_SLOT: u64 = 32;
+/// Recent already-confirmed block (epoch 1), so `get_latest_confirmed` runs the full precompute
+/// path (`get_block_epoch(confirmed) + 1 >= current_epoch`) instead of reverting to finalized.
+const CONFIRMED_SLOT: u64 = 40;
+
+/// `current_slot` at the start of epoch 2: drives the epoch-boundary branches of
+/// `get_latest_confirmed` (`is_confirmed_chain_safe`, restart-from-justified).
+const EPOCH_BOUNDARY_SLOT: u64 = 64;
+/// `current_slot` mid epoch 2: drives the FFG sweep (`will_no_conflicting_checkpoint_be_justified`
+/// → `get_current_target_score`), which the epoch-boundary slot short-circuits.
+const MID_EPOCH_SLOT: u64 = 66;
+
+/// Deterministic block root for a given slot (linear chain): slot `s` → `s + 1`.
+fn block_root_at(slot: u64) -> Hash256 {
+    Hash256::from_low_u64_be(slot + 1)
+}
 
 /// All data needed to run an FCR benchmark iteration.
 struct BenchData {
@@ -29,27 +51,32 @@ struct BenchData {
     head_root: Hash256,
     finalized_checkpoint: Checkpoint,
     unrealized_justified_checkpoint: Checkpoint,
-    current_slot: Slot,
     equivocating_indices: BTreeSet<u64>,
     block_roots: Vec<Hash256>,
 }
 
-/// Build a synthetic linear chain with `num_validators` all voting for the head.
+/// Build a synthetic two-epoch linear chain with `num_validators` voting for scattered recent
+/// blocks, and an FCR seeded so `get_latest_confirmed` exercises the full per-slot work.
 ///
-/// Chain layout (all in epoch 0 for MainnetEthSpec):
-///   genesis(slot 0) → block_1(slot 1) → ... → block_9(slot 9)
-///   current_slot = 10
-///   finalized = justified = genesis
-///   All validators vote for head (slot 9)
+/// Chain layout (MainnetEthSpec, 32 slots/epoch):
+///   genesis(slot 0) → block_1(slot 1) → ... → block_63(slot 63), head = slot 63 (epoch 1)
+///   finalized = justified = genesis; current-epoch observed-justified = epoch-1 boundary (slot 32)
+///   confirmed = slot 40 (epoch 1). FCR is evaluated at current slots in epoch 2.
 fn build_chain(num_validators: usize) -> BenchData {
     let spec = E::default_spec();
-    let genesis_root = Hash256::from_low_u64_be(1);
+    let slots_per_epoch = E::slots_per_epoch();
+    let genesis_root = block_root_at(0);
 
-    let finalized_checkpoint = Checkpoint {
+    let genesis_checkpoint = Checkpoint {
         epoch: Epoch::new(0),
         root: genesis_root,
     };
-    let justified_checkpoint = finalized_checkpoint;
+    let observed_justified_checkpoint = Checkpoint {
+        epoch: Epoch::new(1),
+        root: block_root_at(OBSERVED_JUSTIFIED_SLOT),
+    };
+    let finalized_checkpoint = genesis_checkpoint;
+    let justified_checkpoint = genesis_checkpoint;
 
     let shuffling_id = AttestationShufflingId::from_components(Epoch::new(0), genesis_root);
 
@@ -71,24 +98,33 @@ fn build_chain(num_validators: usize) -> BenchData {
 
     let mut block_roots = vec![genesis_root];
 
-    // Add blocks at slots 1 through NUM_BLOCKS-1.
-    for i in 1..NUM_BLOCKS {
-        let root = Hash256::from_low_u64_be((i + 1) as u64);
-        let parent_root = block_roots[i - 1];
-        let slot = Slot::new(i as u64);
+    for slot_u in 1..=HEAD_SLOT {
+        let slot = Slot::new(slot_u);
+        let epoch = slot.epoch(slots_per_epoch);
+        let root = block_root_at(slot_u);
+        let parent_root = block_roots[(slot_u - 1) as usize];
+        // Target is the block at the first slot of this block's epoch.
+        let target_root = block_root_at(epoch.as_u64() * slots_per_epoch);
+        // Epoch-0 blocks have nothing justified beyond genesis; epoch-1 blocks see the epoch-1
+        // boundary as unrealized-justified, matching the FCR's observed-justified checkpoint.
+        let unrealized_justified_checkpoint = if epoch == Epoch::new(0) {
+            genesis_checkpoint
+        } else {
+            observed_justified_checkpoint
+        };
 
         let block = Block {
             slot,
             root,
             parent_root: Some(parent_root),
             state_root: Hash256::zero(),
-            target_root: genesis_root, // epoch 0 target
+            target_root,
             current_epoch_shuffling_id: shuffling_id.clone(),
             next_epoch_shuffling_id: shuffling_id.clone(),
             justified_checkpoint,
             finalized_checkpoint,
             execution_status: ExecutionStatus::irrelevant(),
-            unrealized_justified_checkpoint: Some(justified_checkpoint),
+            unrealized_justified_checkpoint: Some(unrealized_justified_checkpoint),
             unrealized_finalized_checkpoint: Some(finalized_checkpoint),
             execution_payload_parent_hash: None,
             execution_payload_block_hash: None,
@@ -102,13 +138,11 @@ fn build_chain(num_validators: usize) -> BenchData {
         block_roots.push(root);
     }
 
-    let head_root = *block_roots.last().unwrap();
-    let current_slot = Slot::new(NUM_BLOCKS as u64);
+    let head_root = block_root_at(HEAD_SLOT);
 
-    // Model mainnet: each validator last attested in a different recent slot, so
-    // validators vote for different recent block roots, scattered by validator index.
-    // This defeats a single-entry vote-root cache (the realistic case), unlike an
-    // all-vote-for-head scenario which is the trivial best case.
+    // Model mainnet: each validator last attested in a different recent slot, so validators vote
+    // for different recent block roots, scattered by validator index. This defeats a single-entry
+    // vote-root cache (the realistic case), unlike an all-vote-for-head trivial best case.
     let voteable = &block_roots[1..]; // non-genesis blocks
     for val_idx in 0..num_validators {
         let voted = voteable[val_idx % voteable.len()];
@@ -126,28 +160,42 @@ fn build_chain(num_validators: usize) -> BenchData {
         &balances,
         Hash256::zero(), // no proposer boost
         &BTreeSet::new(),
-        current_slot,
+        Slot::new(EPOCH_BOUNDARY_SLOT),
         &spec,
     )
     .expect("find head");
 
-    // Extract proto_array and votes.
     let proto_array = fc.core_proto_array().clone();
     let votes = fc.votes().to_vec();
 
-    // Build balance source.
     let total_active_balance = BALANCE.saturating_mul(num_validators as u64);
     let balance_source = BalanceSourceData {
-        dependent_root: justified_checkpoint.root,
+        dependent_root: observed_justified_checkpoint.root,
         total_active_balance,
         effective_balances: vec![BALANCE; num_validators],
         slashed: vec![false; num_validators],
     };
 
     // Build FCR state. `new` builds head assignments/balances from the state; the bench overwrites
-    // balances below, so a committee-cache-ready empty state suffices.
-    let unrealized_justified_checkpoint = justified_checkpoint;
+    // balances and the slot-tracking variables below, so a small committee-cache-ready state
+    // suffices (its assignments aren't on the O(V) cost path).
     let mut seed_state = BeaconState::<E>::new(0, Default::default(), &spec);
+    for _ in 0..E::slots_per_epoch() {
+        seed_state
+            .validators_mut()
+            .push(Validator {
+                effective_balance: spec.max_effective_balance,
+                activation_epoch: Epoch::new(0),
+                exit_epoch: spec.far_future_epoch,
+                withdrawable_epoch: spec.far_future_epoch,
+                ..Default::default()
+            })
+            .expect("push validator");
+        seed_state
+            .balances_mut()
+            .push(spec.max_effective_balance)
+            .expect("push balance");
+    }
     for relative_epoch in [
         RelativeEpoch::Previous,
         RelativeEpoch::Current,
@@ -161,11 +209,12 @@ fn build_chain(num_validators: usize) -> BenchData {
         .expect("fcr initialization");
     fcr.previous_slot_head = head_root;
     fcr.current_slot_head = head_root;
+    fcr.confirmed_root = block_root_at(CONFIRMED_SLOT);
     fcr.test_set_head_balance_source(balance_source.clone());
     fcr.current_epoch_observed_justified =
-        CheckpointAndBalance::new(justified_checkpoint, balance_source.clone());
+        CheckpointAndBalance::new(observed_justified_checkpoint, balance_source.clone());
     fcr.previous_epoch_observed_justified =
-        CheckpointAndBalance::new(justified_checkpoint, balance_source.clone());
+        CheckpointAndBalance::new(genesis_checkpoint, balance_source.clone());
 
     BenchData {
         proto_array,
@@ -174,22 +223,24 @@ fn build_chain(num_validators: usize) -> BenchData {
         fcr,
         head_root,
         finalized_checkpoint,
-        unrealized_justified_checkpoint,
-        current_slot,
+        unrealized_justified_checkpoint: observed_justified_checkpoint,
         equivocating_indices: BTreeSet::new(),
         block_roots,
     }
 }
 
+const VALIDATOR_SET_SIZES: [usize; 5] = [64, 16_000, 100_000, 500_000, 1_000_000];
+
 // ---------------------------------------------------------------------------
 // Benchmarks
 // ---------------------------------------------------------------------------
 
-/// FFG scoring function: counts target checkpoint support.
+/// FFG scoring function: counts target checkpoint support. This is the epoch-boundary FFG sweep
+/// (`get_current_target_score`); its cost is O(V) regardless of the current slot.
 fn bench_get_current_target_score(c: &mut Criterion) {
     let mut group = c.benchmark_group("get_current_target_score");
 
-    for &n in &[64, 16_000, 100_000, 500_000, 1_000_000] {
+    for &n in &VALIDATOR_SET_SIZES {
         let data = build_chain(n);
 
         if n >= 100_000 {
@@ -200,7 +251,7 @@ fn bench_get_current_target_score(c: &mut Criterion) {
             b.iter(|| {
                 data.fcr.get_current_target_score::<E>(
                     data.head_root,
-                    data.current_slot,
+                    Slot::new(EPOCH_BOUNDARY_SLOT),
                     &data.proto_array,
                     &data.votes,
                     &data.equivocating_indices,
@@ -211,11 +262,12 @@ fn bench_get_current_target_score(c: &mut Criterion) {
     group.finish();
 }
 
-/// Batch precomputation of attestation scores for the full chain.
+/// Batch precomputation of attestation scores for the full chain. Runs on every FCR tick; its
+/// cost is O(V × depth) regardless of the current slot.
 fn bench_precompute_chain_scores(c: &mut Criterion) {
     let mut group = c.benchmark_group("precompute_chain_scores");
 
-    for &n in &[64, 16_000, 100_000, 500_000, 1_000_000] {
+    for &n in &VALIDATOR_SET_SIZES {
         let data = build_chain(n);
         let genesis_root = data.block_roots[0];
         // `block_roots[1..]` is exactly `get_ancestor_roots(head, genesis)` for this linear chain.
@@ -244,30 +296,38 @@ fn bench_precompute_chain_scores(c: &mut Criterion) {
     group.finish();
 }
 
-/// Full confirmation algorithm: the complete production code path.
+/// Full confirmation algorithm (the complete production code path), measured at both an
+/// epoch-boundary current slot and a mid-epoch current slot. The boundary slot drives
+/// `is_confirmed_chain_safe`/restart-from-justified while short-circuiting the FFG sweep; the
+/// mid-epoch slot drives the FFG sweep instead. Both run the O(V × depth) precompute.
 fn bench_get_latest_confirmed(c: &mut Criterion) {
     let mut group = c.benchmark_group("get_latest_confirmed");
 
-    for &n in &[64, 16_000, 100_000, 500_000, 1_000_000] {
+    for &n in &VALIDATOR_SET_SIZES {
         let data = build_chain(n);
 
         if n >= 100_000 {
             group.sample_size(10);
         }
 
-        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
-            b.iter(|| {
-                data.fcr.get_latest_confirmed::<E>(
-                    data.head_root,
-                    &data.finalized_checkpoint,
-                    &data.unrealized_justified_checkpoint,
-                    data.current_slot,
-                    &data.proto_array,
-                    &data.votes,
-                    &data.equivocating_indices,
-                )
-            })
-        });
+        for (slot_context, current_slot) in [
+            ("epoch_boundary", EPOCH_BOUNDARY_SLOT),
+            ("mid_epoch", MID_EPOCH_SLOT),
+        ] {
+            group.bench_with_input(BenchmarkId::new(slot_context, n), &n, |b, _| {
+                b.iter(|| {
+                    data.fcr.get_latest_confirmed::<E>(
+                        data.head_root,
+                        &data.finalized_checkpoint,
+                        &data.unrealized_justified_checkpoint,
+                        Slot::new(current_slot),
+                        &data.proto_array,
+                        &data.votes,
+                        &data.equivocating_indices,
+                    )
+                })
+            });
+        }
     }
     group.finish();
 }

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -1,11 +1,12 @@
 //! Benchmarks for the Fast Confirmation Rule (FCR).
 //!
-//! Measures performance of the core FCR algorithms at various validator set sizes
-//! using a synthetic linear chain built via `ProtoArrayForkChoice`.
+//! Measures performance of the core FCR algorithms at various validator set sizes using a
+//! synthetic linear chain built via `ProtoArrayForkChoice`.
 //!
-//! All benchmarks run on `MainnetEthSpec` (32 slots/epoch). The chain spans two epochs so the
-//! FCR state machine has a real epoch boundary to act on, and `get_latest_confirmed` is measured
-//! at both an epoch-boundary slot and a mid-epoch slot (see `bench_get_latest_confirmed`).
+//! All benchmarks run on `MainnetEthSpec` (32 slots/epoch). The chain spans three epochs so the
+//! FCR state machine has a real epoch boundary and a fully-populated previous epoch to act on.
+//! `get_latest_confirmed` is measured across a table of realistic (chain position, FCR run slot)
+//! scenarios — see `SCENARIOS`.
 
 use std::collections::BTreeSet;
 use std::time::Duration;
@@ -22,46 +23,105 @@ type E = MainnetEthSpec;
 const GWEI_PER_ETH: u64 = 1_000_000_000;
 const BALANCE: u64 = 32 * GWEI_PER_ETH;
 
-/// Last block in the chain (epoch 1 for MainnetEthSpec). The chain is linear: slots 0..=HEAD_SLOT.
-const HEAD_SLOT: u64 = 63;
-/// Epoch-1 boundary block; the FCR's current-epoch observed-justified checkpoint points here.
+/// Linear chain spans slots 0..=CHAIN_TIP_SLOT, i.e. epochs 0, 1 and into epoch 2.
+const CHAIN_TIP_SLOT: u64 = 69;
+/// Epoch-1 boundary block; the FCR's current-epoch observed-justified checkpoint points here, so
+/// every scenario below runs with `current_epoch == 2`.
 const OBSERVED_JUSTIFIED_SLOT: u64 = 32;
-/// Recent already-confirmed block (epoch 1), so `get_latest_confirmed` runs the full precompute
-/// path (`get_block_epoch(confirmed) + 1 >= current_epoch`) instead of reverting to finalized.
-const CONFIRMED_SLOT: u64 = 40;
 
-/// `current_slot` at the start of epoch 2: drives the epoch-boundary branches of
-/// `get_latest_confirmed` (`is_confirmed_chain_safe`, restart-from-justified).
-const EPOCH_BOUNDARY_SLOT: u64 = 64;
-/// `current_slot` mid epoch 2: drives the FFG sweep (`will_no_conflicting_checkpoint_be_justified`
-/// → `get_current_target_score`), which the epoch-boundary slot short-circuits.
-const MID_EPOCH_SLOT: u64 = 66;
+/// A realistic FCR evaluation: where the chain head and last-confirmed block sit, and the
+/// wall-clock slot at which FCR runs. All scenarios sit in epoch 2 (current_epoch = 2).
+struct Scenario {
+    /// Short, descriptive name used in the benchmark id.
+    name: &'static str,
+    /// Slot of the fork-choice head block (where the chain is).
+    head_slot: u64,
+    /// Wall-clock slot at which FCR runs (where we run the FCR).
+    current_slot: u64,
+    /// Slot of the latest already-confirmed block.
+    confirmed_slot: u64,
+}
+
+/// Realistic spectrum, cheapest → most expensive. The FFG sweep (`get_current_target_score`) is
+/// the dominant cost and only runs at a non-boundary slot while the confirmed block still lags in
+/// the previous epoch.
+const SCENARIOS: &[Scenario] = &[
+    // Healthy steady state: head and confirmation both deep in the current epoch. Confirmed is in
+    // the current epoch, so the FFG sweep is gated off and the precompute walk is short — the
+    // common ~97% case.
+    Scenario {
+        name: "steady_mid_epoch",
+        head_slot: 69,
+        current_slot: 70,
+        confirmed_slot: 66,
+    },
+    // First slot of the epoch: confirmation is still a full epoch behind, but the boundary slot
+    // short-circuits the FFG sweep, so this runs the precompute + is_confirmed_chain_safe only.
+    Scenario {
+        name: "epoch_first_slot",
+        head_slot: 63,
+        current_slot: 64,
+        confirmed_slot: 40,
+    },
+    // A couple slots into the epoch, confirmation catching up: the FFG sweep fires — the worst
+    // case that occurs every epoch on a healthy network.
+    Scenario {
+        name: "epoch_catch_up",
+        head_slot: 65,
+        current_slot: 66,
+        confirmed_slot: 40,
+    },
+    // First slots of the epoch missed (no current-epoch block yet, head still in the previous
+    // epoch): the FFG-sweep window is extended several slots past the boundary.
+    Scenario {
+        name: "missed_epoch_start",
+        head_slot: 63,
+        current_slot: 68,
+        confirmed_slot: 40,
+    },
+];
 
 /// Deterministic block root for a given slot (linear chain): slot `s` → `s + 1`.
 fn block_root_at(slot: u64) -> Hash256 {
     Hash256::from_low_u64_be(slot + 1)
 }
 
-/// All data needed to run an FCR benchmark iteration.
+/// Shared chain + FCR state for a given validator-set size. The FCR's per-scenario fields
+/// (confirmed root, slot heads) are set by `apply_scenario` before each measurement.
 struct BenchData {
     proto_array: ProtoArray,
     votes: Vec<VoteTracker>,
     balance_source: BalanceSourceData,
     fcr: FastConfirmationRule,
-    head_root: Hash256,
     finalized_checkpoint: Checkpoint,
+    /// Head's unrealized justification — the epoch-1 boundary, shared by all scenarios.
     unrealized_justified_checkpoint: Checkpoint,
+    observed_justified_checkpoint: Checkpoint,
+    genesis_checkpoint: Checkpoint,
     equivocating_indices: BTreeSet<u64>,
     block_roots: Vec<Hash256>,
 }
 
-/// Build a synthetic two-epoch linear chain with `num_validators` voting for scattered recent
-/// blocks, and an FCR seeded so `get_latest_confirmed` exercises the full per-slot work.
-///
-/// Chain layout (MainnetEthSpec, 32 slots/epoch):
-///   genesis(slot 0) → block_1(slot 1) → ... → block_63(slot 63), head = slot 63 (epoch 1)
-///   finalized = justified = genesis; current-epoch observed-justified = epoch-1 boundary (slot 32)
-///   confirmed = slot 40 (epoch 1). FCR is evaluated at current slots in epoch 2.
+impl BenchData {
+    /// Point the FCR's confirmed root and head-tracking variables at a scenario's chain position.
+    /// `get_latest_confirmed` is `&self`, so this is the only mutation and it happens between
+    /// measurements.
+    fn apply_scenario(&mut self, scenario: &Scenario) {
+        let head_root = block_root_at(scenario.head_slot);
+        self.fcr.previous_slot_head = head_root;
+        self.fcr.current_slot_head = head_root;
+        self.fcr.confirmed_root = block_root_at(scenario.confirmed_slot);
+        self.fcr.current_epoch_observed_justified = CheckpointAndBalance::new(
+            self.observed_justified_checkpoint,
+            self.balance_source.clone(),
+        );
+        self.fcr.previous_epoch_observed_justified =
+            CheckpointAndBalance::new(self.genesis_checkpoint, self.balance_source.clone());
+    }
+}
+
+/// Build the synthetic chain (slots 0..=CHAIN_TIP_SLOT) with `num_validators` voting for scattered
+/// recent blocks, plus an FCR seeded with the shared balances/checkpoints.
 fn build_chain(num_validators: usize) -> BenchData {
     let spec = E::default_spec();
     let slots_per_epoch = E::slots_per_epoch();
@@ -98,14 +158,14 @@ fn build_chain(num_validators: usize) -> BenchData {
 
     let mut block_roots = vec![genesis_root];
 
-    for slot_u in 1..=HEAD_SLOT {
+    for slot_u in 1..=CHAIN_TIP_SLOT {
         let slot = Slot::new(slot_u);
         let epoch = slot.epoch(slots_per_epoch);
         let root = block_root_at(slot_u);
         let parent_root = block_roots[(slot_u - 1) as usize];
         // Target is the block at the first slot of this block's epoch.
         let target_root = block_root_at(epoch.as_u64() * slots_per_epoch);
-        // Epoch-0 blocks have nothing justified beyond genesis; epoch-1 blocks see the epoch-1
+        // Epoch-0 blocks have nothing justified beyond genesis; later blocks see the epoch-1
         // boundary as unrealized-justified, matching the FCR's observed-justified checkpoint.
         let unrealized_justified_checkpoint = if epoch == Epoch::new(0) {
             genesis_checkpoint
@@ -138,8 +198,6 @@ fn build_chain(num_validators: usize) -> BenchData {
         block_roots.push(root);
     }
 
-    let head_root = block_root_at(HEAD_SLOT);
-
     // Model mainnet: each validator last attested in a different recent slot, so validators vote
     // for different recent block roots, scattered by validator index. This defeats a single-entry
     // vote-root cache (the realistic case), unlike an all-vote-for-head trivial best case.
@@ -160,7 +218,7 @@ fn build_chain(num_validators: usize) -> BenchData {
         &balances,
         Hash256::zero(), // no proposer boost
         &BTreeSet::new(),
-        Slot::new(EPOCH_BOUNDARY_SLOT),
+        Slot::new(CHAIN_TIP_SLOT),
         &spec,
     )
     .expect("find head");
@@ -176,9 +234,9 @@ fn build_chain(num_validators: usize) -> BenchData {
         slashed: vec![false; num_validators],
     };
 
-    // Build FCR state. `new` builds head assignments/balances from the state; the bench overwrites
-    // balances and the slot-tracking variables below, so a small committee-cache-ready state
-    // suffices (its assignments aren't on the O(V) cost path).
+    // `new` builds head assignments/balances from the state; the bench overwrites balances and
+    // slot-tracking variables, so a small committee-cache-ready state suffices (its assignments
+    // aren't on the O(V) cost path).
     let mut seed_state = BeaconState::<E>::new(0, Default::default(), &spec);
     for _ in 0..E::slots_per_epoch() {
         seed_state
@@ -207,29 +265,28 @@ fn build_chain(num_validators: usize) -> BenchData {
     }
     let mut fcr = FastConfirmationRule::new(finalized_checkpoint, &seed_state, 25, 40)
         .expect("fcr initialization");
-    fcr.previous_slot_head = head_root;
-    fcr.current_slot_head = head_root;
-    fcr.confirmed_root = block_root_at(CONFIRMED_SLOT);
     fcr.test_set_head_balance_source(balance_source.clone());
-    fcr.current_epoch_observed_justified =
-        CheckpointAndBalance::new(observed_justified_checkpoint, balance_source.clone());
-    fcr.previous_epoch_observed_justified =
-        CheckpointAndBalance::new(genesis_checkpoint, balance_source.clone());
 
     BenchData {
         proto_array,
         votes,
         balance_source,
         fcr,
-        head_root,
         finalized_checkpoint,
         unrealized_justified_checkpoint: observed_justified_checkpoint,
+        observed_justified_checkpoint,
+        genesis_checkpoint,
         equivocating_indices: BTreeSet::new(),
         block_roots,
     }
 }
 
 const VALIDATOR_SET_SIZES: [usize; 5] = [64, 16_000, 100_000, 500_000, 1_000_000];
+
+/// A representative chain head + slot for the slot-agnostic building-block benchmarks below
+/// (the `epoch_catch_up` configuration, where the FFG sweep is live).
+const REPRESENTATIVE_HEAD_SLOT: u64 = 65;
+const REPRESENTATIVE_CURRENT_SLOT: u64 = 66;
 
 // ---------------------------------------------------------------------------
 // Benchmarks
@@ -250,8 +307,8 @@ fn bench_get_current_target_score(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
             b.iter(|| {
                 data.fcr.get_current_target_score::<E>(
-                    data.head_root,
-                    Slot::new(EPOCH_BOUNDARY_SLOT),
+                    block_root_at(REPRESENTATIVE_HEAD_SLOT),
+                    Slot::new(REPRESENTATIVE_CURRENT_SLOT),
                     &data.proto_array,
                     &data.votes,
                     &data.equivocating_indices,
@@ -296,31 +353,31 @@ fn bench_precompute_chain_scores(c: &mut Criterion) {
     group.finish();
 }
 
-/// Full confirmation algorithm (the complete production code path), measured at both an
-/// epoch-boundary current slot and a mid-epoch current slot. The boundary slot drives
-/// `is_confirmed_chain_safe`/restart-from-justified while short-circuiting the FFG sweep; the
-/// mid-epoch slot drives the FFG sweep instead. Both run the O(V × depth) precompute.
+/// Full confirmation algorithm (the complete production code path), measured across the realistic
+/// (chain position, FCR run slot) scenarios in `SCENARIOS`. Benchmark ids are
+/// `get_latest_confirmed/{scenario}/{n}`.
 fn bench_get_latest_confirmed(c: &mut Criterion) {
     let mut group = c.benchmark_group("get_latest_confirmed");
 
     for &n in &VALIDATOR_SET_SIZES {
-        let data = build_chain(n);
+        let mut data = build_chain(n);
 
         if n >= 100_000 {
             group.sample_size(10);
         }
 
-        for (slot_context, current_slot) in [
-            ("epoch_boundary", EPOCH_BOUNDARY_SLOT),
-            ("mid_epoch", MID_EPOCH_SLOT),
-        ] {
-            group.bench_with_input(BenchmarkId::new(slot_context, n), &n, |b, _| {
+        for scenario in SCENARIOS {
+            data.apply_scenario(scenario);
+            let head_root = block_root_at(scenario.head_slot);
+            let current_slot = Slot::new(scenario.current_slot);
+
+            group.bench_with_input(BenchmarkId::new(scenario.name, n), &n, |b, _| {
                 b.iter(|| {
                     data.fcr.get_latest_confirmed::<E>(
-                        data.head_root,
+                        head_root,
                         &data.finalized_checkpoint,
                         &data.unrealized_justified_checkpoint,
-                        Slot::new(current_slot),
+                        current_slot,
                         &data.proto_array,
                         &data.votes,
                         &data.equivocating_indices,

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -55,6 +55,7 @@ pub use slot_assignments::UNSET_SLOT;
 
 use proto_array::core::{ProtoArray, VoteTracker};
 use safe_arith::{ArithError, SafeArith};
+use std::cell::OnceCell;
 use std::collections::BTreeSet;
 use tracing::{debug, debug_span};
 use types::{BeaconState, Checkpoint, Epoch, EthSpec, Hash256, Slot};
@@ -449,6 +450,9 @@ impl FastConfirmationRule {
             )?
         };
 
+        // Shared across both FFG predicates so the O(V) honest-support sweep runs at most once.
+        let honest_ffg_support = HonestFfgSupportCache::new();
+
         if get_block_epoch::<E>(confirmed_root, proto_array)?.safe_add(1)? == current_epoch
             && get_voting_source_epoch::<E>(self.previous_slot_head, current_slot, proto_array)?
                 .safe_add(2)?
@@ -461,6 +465,7 @@ impl FastConfirmationRule {
                     proto_array,
                     votes,
                     equivocating_indices,
+                    &honest_ffg_support,
                 )? && (unrealized_justification_of(self.previous_slot_head, proto_array)?
                     .epoch
                     .safe_add(1)?
@@ -521,6 +526,7 @@ impl FastConfirmationRule {
                         proto_array,
                         votes,
                         equivocating_indices,
+                        &honest_ffg_support,
                     )?
                 {
                     break;
@@ -556,6 +562,7 @@ impl FastConfirmationRule {
                             proto_array,
                             votes,
                             equivocating_indices,
+                            &honest_ffg_support,
                         )?))
             {
                 confirmed_root = tentative_confirmed_root;
@@ -904,6 +911,7 @@ impl FastConfirmationRule {
     // -----------------------------------------------------------------------
 
     /// Spec: `will_no_conflicting_checkpoint_be_justified`.
+    #[allow(clippy::too_many_arguments)]
     fn will_no_conflicting_checkpoint_be_justified<E: EthSpec>(
         &self,
         head_root: Hash256,
@@ -912,6 +920,7 @@ impl FastConfirmationRule {
         proto_array: &ProtoArray,
         votes: &[VoteTracker],
         equivocating_indices: &BTreeSet<u64>,
+        honest_ffg_support: &HonestFfgSupportCache,
     ) -> Result<bool, Error> {
         if get_current_target::<E>(head_root, current_slot, proto_array)?
             == *unrealized_justified_checkpoint
@@ -920,7 +929,8 @@ impl FastConfirmationRule {
         }
 
         let total_active_balance = self.head_balance_source.total_active_balance;
-        let honest_ffg = self.compute_honest_ffg_support::<E>(
+        let honest_ffg = honest_ffg_support.get_or_compute::<E>(
+            self,
             head_root,
             current_slot,
             proto_array,
@@ -938,9 +948,11 @@ impl FastConfirmationRule {
         proto_array: &ProtoArray,
         votes: &[VoteTracker],
         equivocating_indices: &BTreeSet<u64>,
+        honest_ffg_support: &HonestFfgSupportCache,
     ) -> Result<bool, Error> {
         let total_active_balance = self.head_balance_source.total_active_balance;
-        let honest_ffg = self.compute_honest_ffg_support::<E>(
+        let honest_ffg = honest_ffg_support.get_or_compute::<E>(
+            self,
             head_root,
             current_slot,
             proto_array,
@@ -1103,6 +1115,44 @@ impl FastConfirmationRule {
                 equivocating_indices,
             )?,
         })
+    }
+}
+
+/// DIVERGENCE (same shape as `AttestationScoreCache`): memoizes the O(V) `compute_honest_ffg_support`
+/// sweep so both FFG predicates share one pass per `get_latest_confirmed` call instead of
+/// recomputing it. The spec recomputes; the control flow is unchanged.
+struct HonestFfgSupportCache {
+    support: OnceCell<u64>,
+}
+
+impl HonestFfgSupportCache {
+    fn new() -> Self {
+        Self {
+            support: OnceCell::new(),
+        }
+    }
+
+    fn get_or_compute<E: EthSpec>(
+        &self,
+        rule: &FastConfirmationRule,
+        head_root: Hash256,
+        current_slot: Slot,
+        proto_array: &ProtoArray,
+        votes: &[VoteTracker],
+        equivocating_indices: &BTreeSet<u64>,
+    ) -> Result<u64, Error> {
+        if let Some(support) = self.support.get() {
+            return Ok(*support);
+        }
+        let support = rule.compute_honest_ffg_support::<E>(
+            head_root,
+            current_slot,
+            proto_array,
+            votes,
+            equivocating_indices,
+        )?;
+        let _ = self.support.set(support);
+        Ok(support)
     }
 }
 


### PR DESCRIPTION
Builds on the FCR spec-alignment work in #86. Two things: a benchmark harness for the per-slot FCR cost, and one optimization it surfaced.
## Benchmarks
New criterion harness (`consensus/fast_confirmation/benches/fcr_bench.rs`) on `MainnetEthSpec`, sizes 16k–1M validators. `get_latest_confirmed` is measured across a succinct table of realistic **(chain position, FCR run slot)** scenarios:
| Scenario | head | run @ | confirmed | what runs |
|---|---|---|---|---|
| `steady_mid_epoch` | 69 | 70 | 66 | no FFG sweep, short precompute — the ~97% case |
| `epoch_first_slot` | 63 | 64 | 40 | boundary short-circuits the FFG sweep |
| `epoch_catch_up` | 65 | 66 | 40 | FFG sweep fires (worst normal case) |
| `missed_epoch_start` | 63 | 68 | 40 | FFG-sweep window extended past the boundary |
This makes the two cost regimes explicit: the steady-state per-slot cost is just the O(V) precompute, while the worst case (early-epoch catch-up, before confirmation advances into the current epoch) additionally runs the O(V) FFG sweep.
## Optimization: memoize the honest-FFG-support sweep
`get_current_target_score` is an O(V) pass, and both `will_no_conflicting_checkpoint_be_justified` and `will_current_target_be_justified` need `compute_honest_ffg_support` for the same fixed `(head, current_slot, …)` within a single `get_latest_confirmed` call. In the catch-up window it was computed **twice** (loop1 + loop2 / the final gate), which is why that case was the ~500 ms worst case at 1M.
Fix: a small `HonestFfgSupportCache` (`OnceCell`) passed to both predicates as an extra param — the exact same shape as `is_one_confirmed` sourcing its per-block value from `AttestationScoreCache` (documented DIVERGENCE). The sweep now runs at most once per call; **the spec functions and their control flow stay byte-identical**.
### Result (n=1M)
| Scenario | before | after |
|---|---|---|
| `steady_mid_epoch` | 64.4 ms | 66.8 ms |
| `epoch_first_slot` | 225.2 ms | 235.7 ms |
| `epoch_catch_up` | 501.7 ms | **302.4 ms** |
| `missed_epoch_start` | 502.7 ms | **297.6 ms** |
The worst case drops ~40% (one full sweep removed); the no-sweep scenarios are unchanged, confirming behavior is identical — just the redundant pass eliminated.
Further levers (early-exit the sweep at the decision threshold, parallelize the O(V) passes, incremental support maintenance) are noted but not included here.