### PR TITLE
Run FCR with the fork-choice slot instead of wall-clock

### DIFF
--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -747,17 +747,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             let votes = fork_choice_read_lock.proto_array().votes();
             let equivocating_indices = fork_choice_read_lock.fc_store().equivocating_indices();
 
-            // FCR's spec runs once per slot at the *current* (wall-clock) slot. The
-            // state-advance timer drives `recompute_head_at_slot(next_slot = S+1)` near the
-            // end of wall-clock slot S, so the recompute's `current_slot` is one slot ahead.
-            // Feeding that to FCR rotates its tracking variables a slot early, skewing the
-            // epoch-boundary observed-justified snapshot and preventing bootstrap. Use the
-            // wall-clock slot instead.
-            let fcr_current_slot = self.slot().unwrap_or(current_slot);
-
-            // The current head's pulled-up state (spec `get_pulled_up_head_state`). FCR errors
-            // must never affect consensus, so on failure we log and skip it this tick.
-            let fcr_head_state = match self.fcr_pulled_up_head_state(head_root, fcr_current_slot) {
+            // Use `current_slot` — the slot the fork-choice head and proto_array were just computed
+            // for, with this slot's queued attestations applied — so FCR observes the same view it
+            // was handed rather than re-reading the wall clock.
+            //
+            // The current head's pulled-up state (spec `get_pulled_up_head_state`). FCR errors must
+            // never affect consensus, so on failure we log and skip it this tick.
+            let fcr_head_state = match self.fcr_pulled_up_head_state(head_root, current_slot) {
                 Ok(Some(state)) => Some(state),
                 Ok(None) => {
                     warn!("FCR: no head state cached, skipping tick");
@@ -775,7 +771,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     head_root,
                     &finalized_cp,
                     &unrealized_justified_cp,
-                    fcr_current_slot,
+                    current_slot,
                     proto_array,
                     votes,
                     equivocating_indices,
@@ -828,7 +824,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                                 SseFastConfirmation {
                                     block: fcr.confirmed_root,
                                     slot: confirmed_slot,
-                                    current_slot: fcr_current_slot,
+                                    current_slot,
                                 },
                             ));
                         }


### PR DESCRIPTION
## Summary

FCR was fed `self.slot()` (wall-clock) in `recompute_head_at_slot_internal`, but the head and proto_array it consumes are computed by `get_head(current_slot)` — the slot passed to the recompute. These diverge on the **state-advance timer** path, which calls `recompute_head_at_slot(S+1)` near the end of wall-clock slot `S` to dequeue that slot's attestations early. There, FCR received a head/proto_array resolved for `S+1` while being told the slot was `S`, plus a clock re-read race at the slot boundary.

This change feeds FCR `current_slot` so it observes exactly the view it was handed (consistent head, proto_array, dequeued attestations, and slot).

## Why it's safe

- The `last_update_slot` guard keeps the tracking-variable rotation **once per slot**.
- `per_slot_task` runs FCR at each slot start, so the end-of-epoch greatest-unrealized snapshot is taken **before** the state-advance timer's look-ahead recompute rotates the observed-justified checkpoints — the original "rotates a slot early / breaks bootstrap" concern does not apply.
- During sync FCR is skipped by the `MAX_ADVANCE_DISTANCE` guard, so the look-ahead never drives rotation pre-sync.

## Validation

- All 10 FCR EF-test groups pass.
- Mainnet (Fulu) checkpoint-sync + mock-EL run, ~3.5 epochs at head:
  - 0 FCR errors.
  - Bootstrapped finalized → head−1 at the first post-sync epoch boundary.
  - Crossed 3 epoch boundaries with confirmation delay steady at **1 slot**, zero new reverts, zero errors.

Diff: `canonical_head.rs` only (use `current_slot`; drop the wall-clock override and the now-redundant `fcr_current_slot` local).