### PR TITLE
Drop unused Clone derive on FastConfirmationRule

### DIFF
--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -98,7 +98,7 @@ const COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR: u64 = 5;
 ///
 /// Lives as an `Option<FastConfirmationRule>` on `BeaconChain`.
 /// `None` = FCR disabled.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct FastConfirmationRule {
     // === Output ===
     /// The latest confirmed block root. Fed into `safe_block_hash` for the EL.


### PR DESCRIPTION
## Summary

`FastConfirmationRule` derives `Clone`, but it is never cloned:
- It lives behind `Option<Mutex<FastConfirmationRule>>` on `CanonicalHead`, which does not (and cannot, due to the `Mutex`) derive `Clone`.
- No `.clone()` call or trait bound on `FastConfirmationRule` exists anywhere in the workspace (`beacon_chain`, `ef_tests`, or the crate itself).

Dropping `#[derive(Clone, Debug)]` → `#[derive(Debug)]` compiles cleanly across `fast_confirmation`, `beacon_chain`, and `ef_tests` (tests included).