### PR TITLE
Remove justified_finalized_payload_hash; keep fork_choice.rs unchanged from unstable

### DIFF
--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -610,12 +610,16 @@ where
         });
         let justified_root = self.justified_checkpoint().root;
         let finalized_root = self.finalized_checkpoint().root;
-        let justified_hash = self
-            .get_block(&justified_root)
-            .and_then(|b| b.justified_finalized_payload_hash());
-        let finalized_hash = self
-            .get_block(&finalized_root)
-            .and_then(|b| b.justified_finalized_payload_hash());
+        let justified_hash = self.get_block(&justified_root).and_then(|b| {
+            b.execution_status
+                .block_hash()
+                .or(b.execution_payload_parent_hash)
+        });
+        let finalized_hash = self.get_block(&finalized_root).and_then(|b| {
+            b.execution_status
+                .block_hash()
+                .or(b.execution_payload_parent_hash)
+        });
         self.forkchoice_update_parameters = ForkchoiceUpdateParameters {
             head_root,
             head_hash,

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -259,20 +259,6 @@ pub struct Block {
 }
 
 impl Block {
-    /// The execution block hash to advertise to the execution layer when this block is used
-    /// as a justified, finalized, or FCR-confirmed checkpoint.
-    ///
-    /// Returns the block's own payload hash when known (`execution_status`), falling back to
-    /// the parent payload hash. The fallback matters for Gloas blocks, whose `execution_status`
-    /// is `Irrelevant` (the payload is decoupled from the block): the payload of a checkpoint
-    /// block is not itself justified/finalized, since it is applied immediately prior to the
-    /// next block.
-    pub fn justified_finalized_payload_hash(&self) -> Option<ExecutionBlockHash> {
-        self.execution_status
-            .block_hash()
-            .or(self.execution_payload_parent_hash)
-    }
-
     /// Compute the proposer shuffling decision root of a child block in `child_block_epoch`.
     ///
     /// This function assumes that `child_block_epoch >= self.epoch`. It is the responsibility of


### PR DESCRIPTION
## Summary

`Block::justified_finalized_payload_hash` only wrapped the inline expression
`execution_status.block_hash().or(execution_payload_parent_hash)` that `unstable` **already** uses for `justified_hash`/`finalized_hash` in `get_forkchoice_update_parameters`. The FCR branch had extracted it into a `proto_array` method and reused it for FCR's `safe_block_hash` override — pulling an unrelated refactor of `fork_choice.rs` into the FCR PR.

This removes that footprint:

- **`consensus/fork_choice/src/fork_choice.rs`** — restored to `unstable` verbatim (the `justified_hash`/`finalized_hash` computation is back to the inline `.block_hash().or(...)`; **zero diff vs unstable**).
- **`consensus/proto_array/src/proto_array_fork_choice.rs`** — `justified_finalized_payload_hash` deleted. (The `VoteTracker` accessors and `ProtoArrayForkChoice::votes()` that FCR genuinely needs are untouched.)
- **`beacon_node/beacon_chain/src/canonical_head.rs`** — FCR's confirmed-root `safe_block_hash` override inlines the same expression at its single call site, so behavior is unchanged.

No behavior change (the helper was behavior-identical to the inline expression). Verified: `fork_choice.rs` matches `unstable`, no dangling references, fmt clean, and a test-inclusive compile (incl. `ef_tests`) passes.