### PR TITLE
FCR: comment cleanup + use build_all_committee_caches

### DIFF
--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -282,7 +282,7 @@ pub struct CanonicalHead<T: BeaconChainTypes> {
     /// Fast Confirmation Rule state. `None` = FCR disabled.
     ///
     /// Updated inside `recompute_head_at_slot_internal` after `get_head` completes, while
-    /// the fork-choice write lock is still held. The Mutex is only locked briefly during
+    /// the fork-choice read lock is still held. The Mutex is only locked briefly during
     /// FCR computation, which is already serialized by `recompute_head_lock`.
     pub fast_confirmation: Option<Mutex<FastConfirmationRule>>,
 }
@@ -792,7 +792,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     // Emit a `fast_confirmation` event on every FCR run, regardless of
                     // whether the confirmed block changed (beacon-APIs#616). `block`/`slot`
                     // identify the most recent confirmed block; `current_slot` is the
-                    // wall-clock slot the algorithm ran at.
+                    // slot the algorithm ran at.
                     if let Some(event_handler) = self.event_handler.as_ref()
                         && event_handler.has_fast_confirmation_subscribers()
                     {

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -31,15 +31,11 @@ const CHAIN_TIP_SLOT: u64 = 69;
 const OBSERVED_JUSTIFIED_SLOT: u64 = 32;
 
 /// A realistic FCR evaluation: where the chain head and last-confirmed block sit, and the
-/// wall-clock slot at which FCR runs. All scenarios sit in epoch 2 (current_epoch = 2).
+/// slot at which FCR runs. All scenarios sit in epoch 2 (current_epoch = 2).
 struct Scenario {
-    /// Short, descriptive name used in the benchmark id.
     name: &'static str,
-    /// Slot of the fork-choice head block (where the chain is).
     head_slot: u64,
-    /// Wall-clock slot at which FCR runs (where we run the FCR).
     current_slot: u64,
-    /// Slot of the latest already-confirmed block.
     confirmed_slot: u64,
 }
 
@@ -261,15 +257,9 @@ fn build_chain(num_validators: usize) -> BenchData {
             .push(spec.max_effective_balance)
             .expect("push balance");
     }
-    for relative_epoch in [
-        RelativeEpoch::Previous,
-        RelativeEpoch::Current,
-        RelativeEpoch::Next,
-    ] {
-        seed_state
-            .build_committee_cache(relative_epoch, &spec)
-            .expect("committee cache");
-    }
+    seed_state
+        .build_all_committee_caches(&spec)
+        .expect("committee caches");
     let mut fcr = FastConfirmationRule::new(finalized_checkpoint, &seed_state, 25, 40)
         .expect("fcr initialization");
     fcr.test_set_head_balance_source(balance_source.clone());

--- a/consensus/fast_confirmation/src/balance_source.rs
+++ b/consensus/fast_confirmation/src/balance_source.rs
@@ -13,7 +13,7 @@ pub struct BalanceSourceData {
     pub total_active_balance: u64,
     /// Effective balance per validator index. 0 for inactive.
     pub effective_balances: Vec<u64>,
-    /// True if the validator has been slashed. Used to filter support votes
+    /// Used to filter support votes
     /// (spec: `get_block_support_between_slots` excludes slashed validators).
     pub slashed: Vec<bool>,
 }

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -103,7 +103,7 @@ const COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR: u64 = 5;
 #[derive(Clone, Debug)]
 pub struct FastConfirmationRule {
     // === Output ===
-    /// The latest confirmed block root. Fed into `safe_block_hash` for the EL.
+    /// Fed into `safe_block_hash` for the EL.
     pub confirmed_root: Hash256,
 
     // === Tracking state (spec's 6 new store fields) ===
@@ -851,7 +851,6 @@ impl FastConfirmationRule {
     }
 
     /// Spec: `compute_adversarial_weight`.
-    ///
     fn compute_adversarial_weight<E: EthSpec>(
         &self,
         balance_source: &BalanceSourceData,
@@ -964,11 +963,12 @@ impl FastConfirmationRule {
         Ok(3u128 * honest_ffg as u128 >= 2u128 * total_active_balance as u128)
     }
 
-    /// Spec: `get_current_target_score` — estimates FFG support for current epoch target.
+    /// Spec: `get_current_target_score` — estimates FFG support for the current-epoch target.
     ///
-    /// For each validator with a latest message, computes the checkpoint at the
-    /// **vote's own epoch** for the vote's root, and checks if it matches the
-    /// current target. This ensures only votes from the current epoch count.
+    /// Sums the balance of validators whose latest-message checkpoint (resolved from the vote
+    /// root at the vote's epoch) matches the current target. Votes are epoch-filtered and
+    /// aggregated by `(root, epoch)`, so each checkpoint lookup runs once per distinct vote
+    /// rather than once per validator.
     pub fn get_current_target_score<E: EthSpec>(
         &self,
         head_root: Hash256,

--- a/consensus/fast_confirmation/src/slot_assignments.rs
+++ b/consensus/fast_confirmation/src/slot_assignments.rs
@@ -7,14 +7,14 @@ use types::{BeaconState, EthSpec, Hash256, RelativeEpoch, Slot};
 /// Per-validator committee slot assignments across a 3-epoch window.
 ///
 /// Each active validator is assigned to exactly one committee slot per epoch.
-/// This structure tracks those assignments for epochs `[current-2, current-1, current]`,
+/// This structure tracks those assignments for epochs `[current-1, current, current+1]`,
 /// stored as a flat `Vec<Slot>` with stride 3 for cache-friendly iteration over all
 /// validators.
 ///
 /// # Layout
 ///
 /// ```text
-///                    epoch-2    epoch-1    current
+///                    previous   current    next
 /// validator 0:       slot_a     slot_b     slot_c
 /// validator 1:       slot_d     slot_e     slot_f
 /// ...
@@ -31,7 +31,7 @@ use types::{BeaconState, EthSpec, Hash256, RelativeEpoch, Slot};
 /// slot via `is_in_range` returns an error, catching rebuild bugs early.
 #[derive(Clone, Debug)]
 pub(crate) struct SlotAssignments {
-    /// Flat array of slot assignments. Length = `validator_count * 3`.
+    /// Length is `validator_count * 3` (stride-3 layout, see the type-level docs).
     slots: Vec<Slot>,
     /// Shuffling decision root the table was built for. The owner rebuilds when it changes.
     dependent_root: Hash256,
@@ -133,8 +133,6 @@ impl SlotAssignments {
             let Some(slot) = self.get(val_idx, col) else {
                 continue;
             };
-            // UNSET_SLOT means no assignment in this epoch column (inactive validator
-            // or epoch not yet loaded). Treat as "not in range".
             if slot == UNSET_SLOT {
                 continue;
             }
@@ -181,14 +179,8 @@ mod tests {
         }
 
         state
-            .build_committee_cache(RelativeEpoch::Previous, &spec)
-            .expect("prev cache");
-        state
-            .build_committee_cache(RelativeEpoch::Current, &spec)
-            .expect("current cache");
-        state
-            .build_committee_cache(RelativeEpoch::Next, &spec)
-            .expect("next cache");
+            .build_all_committee_caches(&spec)
+            .expect("committee caches");
 
         (state, spec)
     }
@@ -199,14 +191,8 @@ mod tests {
             per_slot_processing(state, None, spec).expect("should advance slot");
         }
         state
-            .build_committee_cache(RelativeEpoch::Previous, spec)
-            .expect("prev cache");
-        state
-            .build_committee_cache(RelativeEpoch::Current, spec)
-            .expect("current cache");
-        state
-            .build_committee_cache(RelativeEpoch::Next, spec)
-            .expect("next cache");
+            .build_all_committee_caches(spec)
+            .expect("committee caches");
     }
 
     #[test]

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -496,7 +496,6 @@ impl<E: EthSpec> Case for ForkChoiceTest<E> {
                         tester.check_expected_proposer_head(*expected_proposer_head)?;
                     }
 
-                    // Fast Confirmation Rule checks
                     if let Some(expected) = confirmed_root {
                         tester.check_confirmed_root(*expected)?;
                     }


### PR DESCRIPTION
## Comment cleanup

Two real doc bugs:
- **`SlotAssignments`** doc mislabeled the epoch window as `[current-2, current-1, current]`; it's actually `[current-1, current, current+1]` (previous/current/next), per the fill code and the `Access:` line. Fixed the window label and the ASCII column headers.
- **`CanonicalHead::fast_confirmation`** doc said FCR runs "while the fork-choice **write** lock is still held" — it's the **read** lock (the write lock is downgraded before FCR runs; the module-level doc already says read lock). Fixed write→read.

Plus:
- Dropped stale "wall-clock slot" wording (FCR runs at the fork-choice `current_slot`, not wall-clock).
- Removed comments that merely restate the field/name they document (bench `Scenario` fields, `slashed`, `confirmed_root`, a redundant ef_tests section header, a duplicated `UNSET_SLOT` note).
- Refreshed the `get_current_target_score` doc to describe the epoch-filter + `RootBalanceMap` aggregation it now uses.

The verbatim spec-comment transcriptions in `get_latest_confirmed` (the numbered restart conditions) are left **unchanged**.

## Refactor

Replaced the three-call `build_committee_cache(Previous/Current/Next)` loops (bench + tests) with `BeaconState::build_all_committee_caches`.

Comments/formatting only + one mechanical refactor — no behavior change.