### PR TITLE
FCR: make is_one_confirmed read like the spec; drop OneConfirmation structs

### DIFF
--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -644,7 +644,7 @@ impl FastConfirmationRule {
         )?;
 
         for root in &chain_roots {
-            if self.is_one_confirmed::<E>(
+            if !self.is_one_confirmed::<E>(
                 self.get_previous_balance_source(),
                 *root,
                 &attestation_scores,
@@ -653,28 +653,30 @@ impl FastConfirmationRule {
                 votes,
                 equivocating_indices,
             )? {
-                continue;
+                // `root` is not confirmed. Figure out why for debugging purposes. Duplicates code
+                // of `is_one_confirmed` to keep the original function spec identical. This block
+                // just needs to return `Some(_)` to match spec logic.
+                if is_optimistic_or_invalid(*root, proto_array)? {
+                    return Ok(Some("unconfirmed_optimistic"));
+                } else {
+                    let support = get_attestation_score(*root, &attestation_scores)?;
+                    let safety_threshold = self.compute_safety_threshold::<E>(
+                        self.get_previous_balance_source(),
+                        *root,
+                        current_slot,
+                        proto_array,
+                        votes,
+                        equivocating_indices,
+                    )?;
+                    if safety_threshold > 0 {
+                        metrics::observe(
+                            &metrics::FCR_UNCONFIRMED_SUPPORT_RATIO,
+                            support as f64 / safety_threshold as f64,
+                        );
+                    }
+                    return Ok(Some("unconfirmed_below_threshold"));
+                }
             }
-            // Not confirmed: record the reason for the FCR_REVERT_TO_FINALIZED label.
-            if is_optimistic_or_invalid(*root, proto_array)? {
-                return Ok(Some("unconfirmed_optimistic"));
-            }
-            let support = get_attestation_score(*root, &attestation_scores)?;
-            let safety_threshold = self.compute_safety_threshold::<E>(
-                self.get_previous_balance_source(),
-                *root,
-                current_slot,
-                proto_array,
-                votes,
-                equivocating_indices,
-            )?;
-            if safety_threshold > 0 {
-                metrics::observe(
-                    &metrics::FCR_UNCONFIRMED_SUPPORT_RATIO,
-                    support as f64 / safety_threshold as f64,
-                );
-            }
-            return Ok(Some("unconfirmed_below_threshold"));
         }
         Ok(None)
     }

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -644,7 +644,7 @@ impl FastConfirmationRule {
         )?;
 
         for root in &chain_roots {
-            let one_confirmation = self.one_confirmation::<E>(
+            if self.is_one_confirmed::<E>(
                 self.get_previous_balance_source(),
                 *root,
                 &attestation_scores,
@@ -652,14 +652,29 @@ impl FastConfirmationRule {
                 proto_array,
                 votes,
                 equivocating_indices,
-            )?;
-            if !one_confirmation.is_one_confirmed() {
-                let not_confirmed = one_confirmation.not_confirmed();
-                if let Some(ratio) = not_confirmed.support_ratio {
-                    metrics::observe(&metrics::FCR_UNCONFIRMED_SUPPORT_RATIO, ratio);
-                }
-                return Ok(Some(not_confirmed.reason));
+            )? {
+                continue;
             }
+            // Not confirmed: record the reason for the FCR_REVERT_TO_FINALIZED label.
+            if is_optimistic_or_invalid(*root, proto_array)? {
+                return Ok(Some("unconfirmed_optimistic"));
+            }
+            let support = get_attestation_score(*root, &attestation_scores)?;
+            let safety_threshold = self.compute_safety_threshold::<E>(
+                self.get_previous_balance_source(),
+                *root,
+                current_slot,
+                proto_array,
+                votes,
+                equivocating_indices,
+            )?;
+            if safety_threshold > 0 {
+                metrics::observe(
+                    &metrics::FCR_UNCONFIRMED_SUPPORT_RATIO,
+                    support as f64 / safety_threshold as f64,
+                );
+            }
+            return Ok(Some("unconfirmed_below_threshold"));
         }
         Ok(None)
     }
@@ -1077,56 +1092,19 @@ impl FastConfirmationRule {
         equivocating_indices: &BTreeSet<u64>,
     ) -> Result<bool, Error> {
         // Spec MUST: return false if the block's execution status is not VALID.
-        Ok(self
-            .one_confirmation::<E>(
-                balance_source,
-                block_root,
-                attestation_scores,
-                current_slot,
-                proto_array,
-                votes,
-                equivocating_indices,
-            )?
-            .is_one_confirmed())
-    }
-
-    // -----------------------------------------------------------------------
-    // Implementation caches / diagnostics
-    // -----------------------------------------------------------------------
-
-    /// Cached `is_one_confirmed` evaluation for metrics.
-    #[allow(clippy::too_many_arguments)]
-    fn one_confirmation<E: EthSpec>(
-        &self,
-        balance_source: &BalanceSourceData,
-        block_root: Hash256,
-        attestation_scores: &AttestationScoreCache,
-        current_slot: Slot,
-        proto_array: &ProtoArray,
-        votes: &[VoteTracker],
-        equivocating_indices: &BTreeSet<u64>,
-    ) -> Result<OneConfirmation, Error> {
-        let optimistic_or_invalid = is_optimistic_or_invalid(block_root, proto_array)?;
-        if optimistic_or_invalid {
-            return Ok(OneConfirmation {
-                optimistic_or_invalid,
-                support: 0,
-                safety_threshold: 0,
-            });
+        if is_optimistic_or_invalid(block_root, proto_array)? {
+            return Ok(false);
         }
-
-        Ok(OneConfirmation {
-            optimistic_or_invalid,
-            support: get_attestation_score(block_root, attestation_scores)?,
-            safety_threshold: self.compute_safety_threshold::<E>(
-                balance_source,
-                block_root,
-                current_slot,
-                proto_array,
-                votes,
-                equivocating_indices,
-            )?,
-        })
+        let support = get_attestation_score(block_root, attestation_scores)?;
+        let safety_threshold = self.compute_safety_threshold::<E>(
+            balance_source,
+            block_root,
+            current_slot,
+            proto_array,
+            votes,
+            equivocating_indices,
+        )?;
+        Ok(support > safety_threshold)
     }
 }
 
@@ -1314,42 +1292,6 @@ fn get_attestation_score(
     attestation_scores
         .get_attestation_score(block_root)
         .ok_or(Error::MissingPrecomputedScore(block_root))
-}
-
-struct OneConfirmation {
-    optimistic_or_invalid: bool,
-    support: u64,
-    safety_threshold: u64,
-}
-
-impl OneConfirmation {
-    fn is_one_confirmed(&self) -> bool {
-        !self.optimistic_or_invalid && self.support > self.safety_threshold
-    }
-
-    fn not_confirmed(&self) -> NotOneConfirmed {
-        if self.optimistic_or_invalid {
-            return NotOneConfirmed {
-                reason: "unconfirmed_optimistic",
-                support_ratio: None,
-            };
-        }
-
-        NotOneConfirmed {
-            reason: "unconfirmed_below_threshold",
-            support_ratio: (self.safety_threshold > 0)
-                .then(|| self.support as f64 / self.safety_threshold as f64),
-        }
-    }
-}
-
-/// Outcome of a failed one-confirmed check.
-struct NotOneConfirmed {
-    /// Revert reason tag, surfaced as the `FCR_REVERT_TO_FINALIZED` label.
-    reason: &'static str,
-    /// `support / safety_threshold`; `None` for the optimistic/missing-parent cases or when the
-    /// threshold is 0.
-    support_ratio: Option<f64>,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
`is_one_confirmed` is a spec function, but the spec's one-line predicate (`support > threshold`) was not visible in it. It delegated to `one_confirmation()`, which built a `OneConfirmation { optimistic_or_invalid, support, safety_threshold }` struct, and the actual comparison lived in `OneConfirmation::is_one_confirmed()` ~250 lines away. The `OneConfirmation` / `NotOneConfirmed` structs existed **only** to feed one diagnostic — the revert-reason label + support-ratio metric — in `is_confirmed_chain_safe`.