### PR TITLE
FCR: iterate equivocating set in get_equivocation_score

### DIFF
--- a/consensus/fast_confirmation/src/balance_source.rs
+++ b/consensus/fast_confirmation/src/balance_source.rs
@@ -57,13 +57,6 @@ impl BalanceSourceData {
         self.effective_balances.get(val_idx).copied().unwrap_or(0)
     }
 
-    pub(crate) fn active_indices(&self) -> impl Iterator<Item = usize> + '_ {
-        self.effective_balances
-            .iter()
-            .enumerate()
-            .filter_map(|(i, balance)| (*balance > 0).then_some(i))
-    }
-
     pub(crate) fn unslashed_and_active_indices(&self) -> impl Iterator<Item = usize> + '_ {
         self.effective_balances
             .iter()

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -909,13 +909,15 @@ impl FastConfirmationRule {
         equivocating_indices: &BTreeSet<u64>,
     ) -> Result<u64, Error> {
         let mut score = 0u64;
-        for idx in balance_source.active_indices() {
-            if equivocating_indices.contains(&(idx as u64))
+        for &idx in equivocating_indices {
+            let idx = idx as usize;
+            let balance = balance_source.balance(idx);
+            if balance > 0
                 && self
                     .head_assignments
                     .is_in_range(idx, start_slot, end_slot)?
             {
-                score = score.safe_add(balance_source.balance(idx))?;
+                score = score.safe_add(balance)?;
             }
         }
         Ok(score)
@@ -1363,37 +1365,43 @@ fn estimate_committee_weight_between_slots<E: EthSpec>(
 
     let start_epoch = start_slot.as_u64().safe_div(spe)?;
     let end_epoch = end_slot.as_u64().safe_div(spe)?;
+    let committee_weight = total_active_balance.safe_div(spe)?;
 
     if start_epoch == end_epoch {
         let num_slots = end_slot
             .as_u64()
             .safe_sub(start_slot.as_u64())?
             .safe_add(1)?;
-        return Ok(total_active_balance.safe_div(spe)?.safe_mul(num_slots)?);
+        Ok(committee_weight.safe_mul(num_slots)?)
+    } else {
+        // A range that spans an epoch boundary, but does not span any full epoch
+        // needs pro-rata calculation
+
+        // See https://gist.github.com/saltiniroberto/9ee53d29c33878d79417abb2b4468c20
+        // for an explanation of the formula used below.
+
+        // First, calculate the number of committees in the end epoch
+        let slots_since_end_epoch = end_slot.as_u64().safe_rem(spe)?;
+        let num_slots_in_end_epoch = slots_since_end_epoch.safe_add(1)?;
+        // Next, calculate the number of slots remaining in the end epoch
+        let remaining_slots_in_end_epoch = spe.safe_sub(num_slots_in_end_epoch)?;
+
+        // Then, calculate the number of slots in the start epoch
+        let slots_since_start_epoch = start_slot.as_u64().safe_rem(spe)?;
+        let num_slots_in_start_epoch = spe.safe_sub(slots_since_start_epoch)?;
+
+        let start_epoch_weight = committee_weight.safe_mul(num_slots_in_start_epoch)?;
+        let end_epoch_weight = committee_weight.safe_mul(num_slots_in_end_epoch)?;
+
+        let start_epoch_weight_pro_rated = start_epoch_weight
+            .safe_div(spe)?
+            .safe_mul(remaining_slots_in_end_epoch)?;
+
+        // Each committee from the end epoch only contributes a pro-rated weight
+        adjust_committee_weight_estimate_to_ensure_safety(
+            start_epoch_weight_pro_rated.safe_add(end_epoch_weight)?,
+        )
     }
-
-    // Cross-epoch boundary but not covering a full epoch.
-    let slots_since_start_epoch = start_slot.as_u64().safe_rem(spe)?;
-    let num_slots_in_start_epoch = spe.safe_sub(slots_since_start_epoch)?;
-
-    let slots_since_end_epoch = end_slot.as_u64().safe_rem(spe)?;
-    let num_slots_in_end_epoch = slots_since_end_epoch.safe_add(1)?;
-    let remaining_slots_in_end_epoch = spe.safe_sub(num_slots_in_end_epoch)?;
-
-    let start_epoch_weight = total_active_balance
-        .safe_div(spe)?
-        .safe_mul(num_slots_in_start_epoch)?;
-    let end_epoch_weight = total_active_balance
-        .safe_div(spe)?
-        .safe_mul(num_slots_in_end_epoch)?;
-
-    let start_epoch_weight_pro_rated = start_epoch_weight
-        .safe_div(spe)?
-        .safe_mul(remaining_slots_in_end_epoch)?;
-
-    adjust_committee_weight_estimate_to_ensure_safety(
-        start_epoch_weight_pro_rated.safe_add(end_epoch_weight)?,
-    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`get_equivocation_score` previously scanned **all active validators** (`O(V)`) and intersected
each against the `equivocating_indices` set. Since `equivocating_indices` is typically empty or a
handful of validators, this is backwards: iterate the tiny equivocating set directly and test
committee membership via `is_in_range`.

Same result set (`active ∩ equivocating ∩ assigned-in-range`), now `O(|equivocating|)` instead of
`O(V)`. This function is on the `get_latest_confirmed` hot path (reached via
`compute_adversarial_weight` → `get_adversarial_weight` / `compute_honest_ffg_support`).

Also drops the now-unused `active_indices` helper.

## Benchmark

Existing `fcr_bench`, `get_latest_confirmed`, this branch vs `fcr` base:

| scenario | change |
|---|---|
| epoch_catch_up / 1M | **−4.7%** |
| epoch_catch_up / 500k | −3.8% |
| epoch_first_slot / 1M | −3.6% |
| missed_epoch_start / 500k | −3.2% |
| epoch_catch_up / 100k | −2.6% |
| epoch_first_slot / 500k | −2.3% |
| missed_epoch_start / 1M | −2.3% |
| steady_mid_epoch / 1M, 500k | +0.7%, +0.3% (noise) |

No regressions. The remaining `get_latest_confirmed` cost is dominated by the `O(V)`
`get_current_target_score` FFG sweep, which is untouched here.

> Note: an alternative that built a slot→validators reverse index and *enumerated* all committee
> participants was benchmarked and **regressed** this same path by +2% to +13% (a `HashSet` dedup
> plus a per-validator closure over `O(participants)`), so it was dropped in favour of the
> membership-test approach above.

## Correctness

All 10 FCR `ef_tests` groups pass.
