### PR TITLE
FCR: drop vestigial bench root offset; fix FFG-sweep divergence doc

### DIFF
--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -85,7 +85,7 @@ const SCENARIOS: &[Scenario] = &[
 fn block_root_at(slot: u64) -> Hash256 {
     let mut preimage = [0u8; 16];
     preimage[..8].copy_from_slice(b"fcr-root");
-    preimage[8..].copy_from_slice(&(slot + 1).to_le_bytes());
+    preimage[8..].copy_from_slice(&slot.to_le_bytes());
     Hash256::from_slice(&hash_fixed(&preimage))
 }
 

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -18,8 +18,9 @@
 //! 2. **Cached spec helpers**: `is_one_confirmed` still reads as
 //!    `support > compute_safety_threshold`, but `get_attestation_score` is backed by a
 //!    precomputed chain score cache. The FFG predicates compute `compute_honest_ffg_support`
-//!    internally; their call sites are short-circuited, so the O(V) FFG sweep only runs near
-//!    epoch boundaries (and at most a couple of times) rather than every slot.
+//!    internally; their call sites short-circuit on most slots, so the O(V) sweep runs only in the
+//!    first slots after an epoch boundary (while the confirmed block still trails the previous
+//!    epoch), and at most once per `get_latest_confirmed` call (memoized), not every slot.
 //!
 //! 3. **Vote-root balance aggregation** (`optimizations::RootBalanceMap`): before ancestor
 //!    lookups, validators with the same vote root (or root+epoch) are collapsed into one


### PR DESCRIPTION
Two small FCR cleanups on top of the latest `fcr`.

**1. Drop the vestigial `+1` in the benchmark's `block_root_at`.** It hashed `slot + 1`, a leftover from the earlier `Hash256::from_low_u64_be(slot + 1)` form, where the `+1` kept genesis (slot 0) off the all-zero root that collides with the null/no-vote sentinel. Hashing already yields a non-zero, prefix-varied root for slot 0, so the offset does nothing — hash the slot directly.

**2. Fix the cached-helpers divergence doc.** The old wording described the FFG-sweep timing backwards: the epoch-boundary slot *short-circuits* the sweep; it actually runs in the slots *after* a boundary (the catch-up window, while the confirmed block still trails the previous epoch), and — now that it's memoized — at most once per `get_latest_confirmed` call. (The `is_one_confirmed` clause in that item is left as-is; it became accurate once #94 inlined the predicate.)

No behavior change. `cargo nextest run -p fast_confirmation` green; `make lint-full` green.