### PR TITLE
🤖 Preserve FCR vote epochs during V29 migration

### DIFF
--- a/beacon_node/beacon_chain/src/schema_change/migration_schema_v29.rs
+++ b/beacon_node/beacon_chain/src/schema_change/migration_schema_v29.rs
@@ -57,8 +57,23 @@ pub fn upgrade_to_v29<T: BeaconChainTypes>(
         .proto_array_v28
         .previous_proposer_boost;
 
-    // Convert to v29.
-    let mut persisted_v29 = PersistedForkChoiceV29::from(persisted_v28);
+    let PersistedForkChoiceV28 {
+        fork_choice_v28,
+        fork_choice_store,
+    } = persisted_v28;
+    let fork_choice::PersistedForkChoiceV28 {
+        proto_array_v28,
+        queued_attestations_v28: _,
+    } = fork_choice_v28;
+    let mut persisted_v29 = PersistedForkChoiceV29 {
+        fork_choice: fork_choice::PersistedForkChoiceV29 {
+            proto_array: proto_array::core::SszContainerV29::from_v28_with_slots_per_epoch(
+                proto_array_v28,
+                T::EthSpec::slots_per_epoch(),
+            ),
+        },
+        fork_choice_store,
+    };
 
     // Subtract the proposer boost from the boosted node and all its ancestors.
     //

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -53,6 +53,30 @@ impl VoteTracker {
     }
 }
 
+impl VoteTrackerV28 {
+    pub fn into_v29_with_slots_per_epoch(self, slots_per_epoch: u64) -> VoteTracker {
+        let next_slot = if self.next_root.is_zero() {
+            Slot::new(0)
+        } else {
+            self.next_epoch.start_slot(slots_per_epoch)
+        };
+        let current_slot = if self.current_root == self.next_root {
+            next_slot
+        } else {
+            Slot::new(0)
+        };
+
+        VoteTracker {
+            current_root: self.current_root,
+            next_root: self.next_root,
+            current_slot,
+            next_slot,
+            current_payload_present: false,
+            next_payload_present: false,
+        }
+    }
+}
+
 // This impl is only used upon upgrade from pre-Gloas to Gloas with all pre-Gloas nodes.
 // The payload status is `false` for pre-Gloas nodes.
 impl From<VoteTrackerV28> for VoteTracker {
@@ -1345,6 +1369,37 @@ mod test_compute_deltas {
 
     fn test_node_slots(count: usize) -> Vec<Slot> {
         vec![Slot::new(0); count]
+    }
+
+    #[test]
+    fn v28_vote_conversion_preserves_latest_message_epoch() {
+        let root = hash_from_index(1);
+        let vote = VoteTrackerV28 {
+            current_root: root,
+            next_root: root,
+            next_epoch: Epoch::new(2),
+        };
+
+        let converted = vote.into_v29_with_slots_per_epoch(MainnetEthSpec::slots_per_epoch());
+
+        assert_eq!(converted.current_root, root);
+        assert_eq!(converted.next_root, root);
+        assert_eq!(converted.current_slot, Slot::new(64));
+        assert_eq!(converted.next_slot, Slot::new(64));
+    }
+
+    #[test]
+    fn v28_vote_conversion_only_sets_next_slot_for_pending_vote() {
+        let vote = VoteTrackerV28 {
+            current_root: hash_from_index(1),
+            next_root: hash_from_index(2),
+            next_epoch: Epoch::new(2),
+        };
+
+        let converted = vote.into_v29_with_slots_per_epoch(MainnetEthSpec::slots_per_epoch());
+
+        assert_eq!(converted.current_slot, Slot::new(0));
+        assert_eq!(converted.next_slot, Slot::new(64));
     }
 
     #[test]

--- a/consensus/proto_array/src/ssz_container.rs
+++ b/consensus/proto_array/src/ssz_container.rs
@@ -53,6 +53,27 @@ impl SszContainerV29 {
             indices: proto_array.indices.iter().map(|(k, v)| (*k, *v)).collect(),
         }
     }
+
+    pub fn from_v28_with_slots_per_epoch(v28: SszContainerV28, slots_per_epoch: u64) -> Self {
+        Self {
+            votes: v28
+                .votes_v28
+                .into_iter()
+                .map(|vote| vote.into_v29_with_slots_per_epoch(slots_per_epoch))
+                .collect(),
+            prune_threshold: v28.prune_threshold,
+            nodes: v28
+                .nodes
+                .into_iter()
+                .map(|mut node| {
+                    node.best_child = None;
+                    node.best_descendant = None;
+                    ProtoNode::V17(node)
+                })
+                .collect(),
+            indices: v28.indices,
+        }
+    }
 }
 
 impl TryFrom<(SszContainerV29, JustifiedBalances)> for ProtoArrayForkChoice {


### PR DESCRIPTION
Links audit/review artifact: #100

Implements FCR-09 from the audit:

- Adds a slots-per-epoch-aware V28-to-V29 vote conversion path for schema migration.
- Preserves migrated steady-state latest-message epochs as V29 vote slots so FCR current-target support does not silently read epoch zero.
- Leaves pending next-root votes with only next_slot inferred, because the current root epoch is not represented in V28.

Validation run locally:

- cargo fmt --package proto_array --package beacon_chain
- cargo test -p proto_array v28_vote_conversion --lib
- cargo check -p beacon_chain
- git diff --check