### PR TITLE
🤖 FCR: resolve committee assignments on demand from cached shufflings

### DIFF
--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1054,6 +1054,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             equivocating_indices,
             &head_state,
             checkpoint_state.as_ref(),
+            &store.spec,
         )?;
 
         let confirmed_node = fork_choice
@@ -1114,6 +1115,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .unwrap_or(&snapshot.beacon_state),
             spec.confirmation_byzantine_threshold,
             spec.proposer_score_boost,
+            spec,
         )
     }
 

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1111,6 +1111,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .as_ref()
                 .unwrap_or(&snapshot.beacon_state),
             &snapshot.beacon_state,
+            snapshot.beacon_block_root,
             spec.confirmation_byzantine_threshold,
             spec.proposer_score_boost,
         )

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1106,12 +1106,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             )?)
         };
         FastConfirmationRule::new(
+            snapshot.beacon_block_root,
+            &snapshot.beacon_state,
             finalized_checkpoint,
             loaded_checkpoint_state
                 .as_ref()
                 .unwrap_or(&snapshot.beacon_state),
-            &snapshot.beacon_state,
-            snapshot.beacon_block_root,
             spec.confirmation_byzantine_threshold,
             spec.proposer_score_boost,
         )

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -263,10 +263,10 @@ fn build_chain(num_validators: usize) -> BenchData {
         .build_all_committee_caches(&spec)
         .expect("committee caches");
     let mut fcr = FastConfirmationRule::new(
+        finalized_checkpoint.root,
+        &seed_state,
         finalized_checkpoint,
         &seed_state,
-        &seed_state,
-        finalized_checkpoint.root,
         25,
         40,
     )

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -13,7 +13,9 @@ use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use ethereum_hashing::hash_fixed;
-use fast_confirmation::{BalanceSourceData, CheckpointAndBalance, FastConfirmationRule};
+use fast_confirmation::{
+    BalanceSourceData, BalanceSourceKey, CheckpointAndBalance, FastConfirmationRule,
+};
 use fixed_bytes::FixedBytesExtended;
 use proto_array::core::{ProtoArray, VoteTracker};
 use proto_array::{Block, ExecutionStatus, JustifiedBalances, ProtoArrayForkChoice};
@@ -229,7 +231,9 @@ fn build_chain(num_validators: usize) -> BenchData {
 
     let total_active_balance = BALANCE.saturating_mul(num_validators as u64);
     let balance_source = BalanceSourceData {
-        dependent_root: observed_justified_checkpoint.root,
+        key: BalanceSourceKey::NoSlashings {
+            epoch_boundary_root: observed_justified_checkpoint.root,
+        },
         total_active_balance,
         effective_balances: vec![BALANCE; num_validators],
         slashed: vec![false; num_validators],
@@ -258,8 +262,15 @@ fn build_chain(num_validators: usize) -> BenchData {
     seed_state
         .build_all_committee_caches(&spec)
         .expect("committee caches");
-    let mut fcr = FastConfirmationRule::new(finalized_checkpoint, &seed_state, &seed_state, 25, 40)
-        .expect("fcr initialization");
+    let mut fcr = FastConfirmationRule::new(
+        finalized_checkpoint,
+        &seed_state,
+        &seed_state,
+        finalized_checkpoint.root,
+        25,
+        40,
+    )
+    .expect("fcr initialization");
     fcr.test_set_head_balance_source(balance_source.clone());
 
     BenchData {

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -283,6 +283,7 @@ fn build_chain_inner(
         &seed_state,
         25,
         40,
+        &spec,
     )
     .expect("fcr initialization");
     fcr.test_set_head_balance_source(balance_source.clone());

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -127,6 +127,16 @@ impl BenchData {
 /// Build the synthetic chain (slots 0..=CHAIN_TIP_SLOT) with `num_validators` voting for scattered
 /// recent blocks, plus an FCR seeded with the shared balances/checkpoints.
 fn build_chain(num_validators: usize) -> BenchData {
+    build_chain_inner(num_validators, E::slots_per_epoch() as usize, None)
+}
+
+/// `build_chain`, with `seed_validators` in the committee-cached seed state (so `is_in_range`
+/// covers them) and an optional missed slot: block `gap_slot + 1` then parents to `gap_slot - 1`.
+fn build_chain_inner(
+    num_validators: usize,
+    seed_validators: usize,
+    gap_slot: Option<u64>,
+) -> BenchData {
     let spec = E::default_spec();
     let genesis_root = block_root_at(0);
 
@@ -162,6 +172,10 @@ fn build_chain(num_validators: usize) -> BenchData {
     let mut block_roots = vec![genesis_root];
 
     for slot_u in 1..=CHAIN_TIP_SLOT {
+        if Some(slot_u) == gap_slot {
+            block_roots.push(block_roots[(slot_u - 1) as usize]);
+            continue;
+        }
         let slot = Slot::new(slot_u);
         let epoch = slot.epoch(E::slots_per_epoch());
         let root = block_root_at(slot_u);
@@ -243,7 +257,7 @@ fn build_chain(num_validators: usize) -> BenchData {
     // slot-tracking variables, so a small committee-cache-ready state suffices (its assignments
     // aren't on the O(V) cost path).
     let mut seed_state = BeaconState::<E>::new(0, Default::default(), &spec);
-    for _ in 0..E::slots_per_epoch() {
+    for _ in 0..seed_validators {
         seed_state
             .validators_mut()
             .push(Validator {
@@ -397,10 +411,45 @@ fn bench_get_latest_confirmed(c: &mut Criterion) {
     group.finish();
 }
 
+/// `get_latest_confirmed` with a missed slot at the confirmation frontier (block 68 parents to 66),
+/// so `compute_empty_slot_support_discount` runs `get_block_support`'s O(V) `is_in_range` loop over
+/// the full committee-cached validator set — the on-demand committee-cache lookup at scale.
+fn bench_get_latest_confirmed_empty_slots(c: &mut Criterion) {
+    let mut group = c.benchmark_group("get_latest_confirmed_empty_slots");
+    for &n in &VALIDATOR_SET_SIZES {
+        let mut data = build_chain_inner(n, n, Some(67));
+        if n >= 100_000 {
+            group.sample_size(10);
+        }
+        data.apply_scenario(&Scenario {
+            name: "missed_slot",
+            head_slot: 69,
+            current_slot: 70,
+            confirmed_slot: 66,
+        });
+        let head_root = block_root_at(69);
+        group.bench_with_input(BenchmarkId::new("missed_slot", n), &n, |b, _| {
+            b.iter(|| {
+                data.fcr.get_latest_confirmed::<E>(
+                    head_root,
+                    &data.finalized_checkpoint,
+                    &data.unrealized_justified_checkpoint,
+                    Slot::new(70),
+                    &data.proto_array,
+                    &data.votes,
+                    &data.equivocating_indices,
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_get_current_target_score,
     bench_precompute_chain_scores,
     bench_get_latest_confirmed,
+    bench_get_latest_confirmed_empty_slots,
 );
 criterion_main!(benches);

--- a/consensus/fast_confirmation/src/balance_source.rs
+++ b/consensus/fast_confirmation/src/balance_source.rs
@@ -1,33 +1,30 @@
 //! Validator-balance snapshot used by the Fast Confirmation Rule.
 
 use crate::Error;
-use types::{BeaconState, Epoch, EthSpec, Hash256};
+use safe_arith::SafeArith;
+use types::{BeaconState, EthSpec, Hash256};
 
-/// Cache key identifying the validator-set view a [`BalanceSourceData`] was built from.
+/// Cache key identifying the validator-set view a `BalanceSourceData` was built from.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BalanceSourceKey {
     /// No slashings have been processed in the epoch (`state.slashings[epoch % E] == 0`): the
-    /// epoch's dependent root (block at the last slot of the previous epoch) pins the effective
+    /// epoch's boundary root (block at the last slot of the previous epoch) pins the effective
     /// balances, activation set and slashed flags for the whole epoch.
     NoSlashings { epoch_boundary_root: Hash256 },
     /// At least one slashing has been processed in the epoch. Slashings flip `Validator.slashed`
-    /// mid-epoch without moving the dependent root, so the snapshot is keyed on its own block
-    /// root instead and every head change rebuilds it for the rest of the epoch (cf. the
-    /// unrealized-checkpoints fix in sigp/lighthouse#9471). A further slashing can only arrive
-    /// via a new block, so the block root also distinguishes different slashing sets.
+    /// mid-epoch without moving the epoch boundary root, so the snapshot is keyed on its own block
+    /// root instead and every head change rebuilds it for the rest of the epoch.
     SlashingsPresent { head_block_root: Hash256 },
 }
 
 impl BalanceSourceKey {
-    /// `block_root` is the root of the block the snapshot's `state` descends from (the head
-    /// root for the head source; the checkpoint root for checkpoint sources).
+    /// Create a key for a specific `block_root` and its state.
     pub(crate) fn compute<E: EthSpec>(
         state: &BeaconState<E>,
-        epoch: Epoch,
         block_root: Hash256,
     ) -> Result<Self, Error> {
         let epoch_slashings = state
-            .get_slashings(epoch)
+            .get_slashings(state.current_epoch())
             .map_err(|e| Error::SlashingsOutOfBounds(format!("slashings lookup: {e:?}")))?;
         if epoch_slashings > 0 {
             Ok(Self::SlashingsPresent {
@@ -35,7 +32,7 @@ impl BalanceSourceKey {
             })
         } else {
             Ok(Self::NoSlashings {
-                epoch_boundary_root: crate::dependent_root::<E>(state, epoch)?,
+                epoch_boundary_root: get_epoch_boundary_root::<E>(state)?,
             })
         }
     }
@@ -57,18 +54,15 @@ pub struct BalanceSourceData {
 }
 
 impl BalanceSourceData {
-    /// Build a balance source for a single `epoch` in one pass over the validator set, tagged with
-    /// its [`BalanceSourceKey`] (computed from `state`, `epoch` and `block_root`). Effective
-    /// balance is counted for active validators regardless of slashed status (matching the spec's
-    /// `get_total_active_balance`); `slashed` is recorded separately for the slashed-filtering
-    /// used by `get_block_support_between_slots`. The total uses a saturating add — it is a sum
-    /// of effective balances and cannot realistically overflow.
-    pub(crate) fn for_epoch<E: EthSpec>(
+    /// Create a balance source for `state` at its current epoch.
+    ///
+    /// The state must be pulled up to the desired epoch prior to calling this function.
+    pub(crate) fn new<E: EthSpec>(
         state: &BeaconState<E>,
-        epoch: Epoch,
         block_root: Hash256,
     ) -> Result<Self, Error> {
-        let key = BalanceSourceKey::compute(state, epoch, block_root)?;
+        let current_epoch = state.current_epoch();
+        let key = BalanceSourceKey::compute(state, block_root)?;
         let validators = state.validators();
         let mut effective_balances = Vec::with_capacity(validators.len());
         let mut slashed = Vec::with_capacity(validators.len());
@@ -76,7 +70,7 @@ impl BalanceSourceData {
 
         for validator in validators.iter() {
             slashed.push(validator.slashed);
-            if validator.is_active_at(epoch) {
+            if validator.is_active_at(current_epoch) {
                 effective_balances.push(validator.effective_balance);
                 total_active_balance =
                     total_active_balance.saturating_add(validator.effective_balance);
@@ -117,4 +111,21 @@ impl BalanceSourceData {
             self.balance(val_idx)
         }
     }
+}
+
+/// Block root at the last slot of the previous epoch.
+///
+/// Used to identify the balance source fields of the `validator` registry in the absence of
+/// slashings.
+fn get_epoch_boundary_root<E: EthSpec>(state: &BeaconState<E>) -> Result<Hash256, Error> {
+    if state.current_epoch() == 0 {
+        return Ok(Hash256::ZERO);
+    }
+    let slot = state
+        .current_epoch()
+        .start_slot(E::slots_per_epoch())
+        .safe_sub(1)?;
+    Ok(*state
+        .get_block_root(slot)
+        .map_err(|e| Error::BlockRootsOutOfBounds(format!("{e:?}")))?)
 }

--- a/consensus/fast_confirmation/src/balance_source.rs
+++ b/consensus/fast_confirmation/src/balance_source.rs
@@ -3,13 +3,51 @@
 use crate::Error;
 use types::{BeaconState, Epoch, EthSpec, Hash256};
 
+/// Cache key identifying the validator-set view a [`BalanceSourceData`] was built from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BalanceSourceKey {
+    /// No slashings have been processed in the epoch (`state.slashings[epoch % E] == 0`): the
+    /// epoch's dependent root (block at the last slot of the previous epoch) pins the effective
+    /// balances, activation set and slashed flags for the whole epoch.
+    NoSlashings { epoch_boundary_root: Hash256 },
+    /// At least one slashing has been processed in the epoch. Slashings flip `Validator.slashed`
+    /// mid-epoch without moving the dependent root, so the snapshot is keyed on its own block
+    /// root instead and every head change rebuilds it for the rest of the epoch (cf. the
+    /// unrealized-checkpoints fix in sigp/lighthouse#9471). A further slashing can only arrive
+    /// via a new block, so the block root also distinguishes different slashing sets.
+    SlashingsPresent { head_block_root: Hash256 },
+}
+
+impl BalanceSourceKey {
+    /// `block_root` is the root of the block the snapshot's `state` descends from (the head
+    /// root for the head source; the checkpoint root for checkpoint sources).
+    pub(crate) fn compute<E: EthSpec>(
+        state: &BeaconState<E>,
+        epoch: Epoch,
+        block_root: Hash256,
+    ) -> Result<Self, Error> {
+        let epoch_slashings = state
+            .get_slashings(epoch)
+            .map_err(|e| Error::SlashingsOutOfBounds(format!("slashings lookup: {e:?}")))?;
+        if epoch_slashings > 0 {
+            Ok(Self::SlashingsPresent {
+                head_block_root: block_root,
+            })
+        } else {
+            Ok(Self::NoSlashings {
+                epoch_boundary_root: crate::dependent_root::<E>(state, epoch)?,
+            })
+        }
+    }
+}
+
 /// Snapshot of a validator set's effective balances for one epoch.
 ///
-/// `dependent_root` (the block at the last slot of the previous epoch) is the chain-identity that
-/// fixes this snapshot — two chains sharing it have the same view — and is used as the cache key.
+/// The [`BalanceSourceKey`] fixes this snapshot — two chains sharing it have the same view — and
+/// is used as the cache key.
 #[derive(Clone, Debug)]
 pub struct BalanceSourceData {
-    pub dependent_root: Hash256,
+    pub key: BalanceSourceKey,
     pub total_active_balance: u64,
     /// Effective balance per validator index. 0 for inactive.
     pub effective_balances: Vec<u64>,
@@ -20,15 +58,17 @@ pub struct BalanceSourceData {
 
 impl BalanceSourceData {
     /// Build a balance source for a single `epoch` in one pass over the validator set, tagged with
-    /// the epoch's dependent root. Effective balance is counted for active validators regardless of
-    /// slashed status (matching the spec's `get_total_active_balance`); `slashed` is recorded
-    /// separately for the slashed-filtering used by `get_block_support_between_slots`. The total
-    /// uses a saturating add — it is a sum of effective balances and cannot realistically overflow.
+    /// its [`BalanceSourceKey`] (computed from `state`, `epoch` and `block_root`). Effective
+    /// balance is counted for active validators regardless of slashed status (matching the spec's
+    /// `get_total_active_balance`); `slashed` is recorded separately for the slashed-filtering
+    /// used by `get_block_support_between_slots`. The total uses a saturating add — it is a sum
+    /// of effective balances and cannot realistically overflow.
     pub(crate) fn for_epoch<E: EthSpec>(
         state: &BeaconState<E>,
         epoch: Epoch,
+        block_root: Hash256,
     ) -> Result<Self, Error> {
-        let dependent_root = crate::dependent_root::<E>(state, epoch)?;
+        let key = BalanceSourceKey::compute(state, epoch, block_root)?;
         let validators = state.validators();
         let mut effective_balances = Vec::with_capacity(validators.len());
         let mut slashed = Vec::with_capacity(validators.len());
@@ -46,7 +86,7 @@ impl BalanceSourceData {
         }
 
         Ok(Self {
-            dependent_root,
+            key,
             total_active_balance,
             effective_balances,
             slashed,

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -46,7 +46,6 @@ pub use balance_source::{BalanceSourceData, BalanceSourceKey};
 pub use optimizations::CheckpointAndBalance;
 use optimizations::{AttestationScoreCache, HonestFfgSupportCache};
 use slot_assignments::SlotAssignments;
-pub use slot_assignments::UNSET_SLOT;
 
 use proto_array::core::{ProtoArray, ProtoNode, VoteTracker};
 use safe_arith::{ArithError, SafeArith};
@@ -318,9 +317,9 @@ impl FastConfirmationRule {
         // key is stale.
         let head_dependent_root = dependent_root::<E>(head_state, current_epoch)?;
 
-        if self.slot_assignments.dependent_root() != head_dependent_root {
+        if self.head_assignments.dependent_root() != head_dependent_root {
             let _span = debug_span!("fcr_rebuild_assignments").entered();
-            self.slot_assignments = SlotAssignments::new::<E>(head_state)?;
+            self.slot_assignments.rebuild::<E>(state)?;
         }
 
         let head_balance_key = BalanceSourceKey::compute(head_state, head_root)?;

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -31,7 +31,7 @@
 //! 4. **Snapshot balance sources** (`BalanceSourceData`): the current/previous observed-justified
 //!    sources are rebuilt only at the epoch-boundary rotation (bundled with their checkpoint in
 //!    `CheckpointAndBalance`), and the head source only when its `BalanceSourceKey` changes
-//!    (the dependent root normally, per head block once the epoch contains a slashing) — instead
+//!    (the epoch boundary root normally, per head block once the epoch contains a slashing) — instead
 //!    of re-scanning the validator set every slot.
 //!
 //! The visible algorithm deliberately keeps the spec function names and control-flow shape;
@@ -137,7 +137,7 @@ pub struct FastConfirmationRule {
 
     // === FFG data from the head state ===
     /// Built from the spec's `get_pulled_up_head_state`. Keyed (via `BalanceSourceData.key`)
-    /// on the head's dependent root — or the head block root itself once the epoch contains a
+    /// on the head's epoch boundary root — or the head block root itself once the epoch contains a
     /// slashing — so a reorg past the previous-epoch boundary or an intra-epoch slashing
     /// rebuilds it.
     head_balance_source: BalanceSourceData,
@@ -169,10 +169,10 @@ impl FastConfirmationRule {
     /// head-derived caches come from `head_state`, whose block root is `head_root`.
     /// `byzantine_threshold` is clamped to [0, 25].
     pub fn new<E: EthSpec>(
+        head_root: Hash256,
+        head_state: &BeaconState<E>,
         finalized_checkpoint: Checkpoint,
         checkpoint_state: &BeaconState<E>,
-        head_state: &BeaconState<E>,
-        head_root: Hash256,
         byzantine_threshold: u64,
         proposer_score_boost: u64,
     ) -> Result<Self, Error> {
@@ -182,11 +182,8 @@ impl FastConfirmationRule {
         if checkpoint_state.current_epoch() != finalized_checkpoint.epoch {
             return Err(Error::MissingCheckpointState(finalized_checkpoint));
         }
-        let checkpoint_balance = BalanceSourceData::for_epoch(
-            checkpoint_state,
-            finalized_checkpoint.epoch,
-            finalized_checkpoint.root,
-        )?;
+        let checkpoint_balance =
+            BalanceSourceData::new(checkpoint_state, finalized_checkpoint.root)?;
         Ok(Self {
             confirmed_root: finalized_checkpoint.root,
             previous_epoch_observed_justified: CheckpointAndBalance::new(
@@ -203,11 +200,7 @@ impl FastConfirmationRule {
             byzantine_threshold,
             proposer_score_boost,
             slot_assignments: SlotAssignments::new(head_state)?,
-            head_balance_source: BalanceSourceData::for_epoch(
-                head_state,
-                head_state.current_epoch(),
-                head_root,
-            )?,
+            head_balance_source: BalanceSourceData::new(head_state, head_root)?,
             last_update_slot: None,
             spec_test_mode: false,
         })
@@ -322,11 +315,7 @@ impl FastConfirmationRule {
 
         // Rebuild the head-derived caches when the head changes (including within a slot, e.g. a
         // late block or reorg). Each cache is rebuilt from scratch, independently, when its own
-        // key is stale. The slot assignments are keyed on the head's dependent root (a reorg past
-        // the previous-epoch boundary, or a new epoch). The balance source is keyed on its
-        // `BalanceSourceKey`, whose `SlashingsPresent` variant additionally forces a rebuild
-        // when a slashing lands mid-epoch and flips `slashed` flags without moving the dependent
-        // root (the FCR analogue of the unrealized-checkpoints fix in sigp/lighthouse#9471).
+        // key is stale.
         let head_dependent_root = dependent_root::<E>(head_state, current_epoch)?;
 
         if self.slot_assignments.dependent_root() != head_dependent_root {
@@ -334,11 +323,10 @@ impl FastConfirmationRule {
             self.slot_assignments = SlotAssignments::new::<E>(head_state)?;
         }
 
-        let head_balance_key = BalanceSourceKey::compute(head_state, current_epoch, head_root)?;
+        let head_balance_key = BalanceSourceKey::compute(head_state, head_root)?;
         if self.head_balance_source.key != head_balance_key {
             let _span = debug_span!("fcr_rebuild_head_balance").entered();
-            self.head_balance_source =
-                BalanceSourceData::for_epoch(head_state, current_epoch, head_root)?;
+            self.head_balance_source = BalanceSourceData::new(head_state, head_root)?;
         }
 
         // Spec: update_fast_confirmation_variables must be called at most once per slot.
@@ -374,11 +362,7 @@ impl FastConfirmationRule {
                         }
                         CheckpointAndBalance::new(new_current_cp, {
                             let _span = debug_span!("fcr_rebuild_current_balance").entered();
-                            BalanceSourceData::for_epoch(
-                                checkpoint_state,
-                                new_current_cp.epoch,
-                                new_current_cp.root,
-                            )?
+                            BalanceSourceData::new(checkpoint_state, new_current_cp.root)?
                         })
                     };
                 self.previous_epoch_observed_justified =
@@ -1560,16 +1544,16 @@ mod tests {
     }
 
     /// Regression test: a slashing processed mid-epoch must rebuild the head balance source
-    /// even though the dependent root is unchanged for the rest of the epoch (the FCR analogue
+    /// even though the epoch boundary root is unchanged for the rest of the epoch (the FCR analogue
     /// of the unrealized-checkpoints bug fixed in sigp/lighthouse#9471).
     #[test]
     fn head_balance_source_rebuilt_after_intra_epoch_slashing() {
         use state_processing::per_slot_processing;
         use types::MinimalEthSpec;
-        type ME = MinimalEthSpec;
+        type E = MinimalEthSpec;
 
-        let spec = ME::default_spec();
-        let mut state: BeaconState<ME> = BeaconState::new(0, Default::default(), &spec);
+        let spec = E::default_spec();
+        let mut state: BeaconState<E> = BeaconState::new(0, Default::default(), &spec);
         for _ in 0..32 {
             let validator = types::Validator {
                 effective_balance: spec.max_effective_balance,
@@ -1593,7 +1577,7 @@ mod tests {
 
         // Advance to a mid-epoch slot: at an epoch start the dependent root changes and would
         // rebuild the source regardless, masking the bug.
-        let mid_epoch_slot = Slot::new(ME::slots_per_epoch() + 4);
+        let mid_epoch_slot = Slot::new(E::slots_per_epoch() + 4);
         while state.slot() < mid_epoch_slot {
             per_slot_processing(&mut state, None, &spec).expect("should advance slot");
         }
@@ -1607,7 +1591,7 @@ mod tests {
         };
         let head_root_a = Hash256::repeat_byte(2);
         let mut fcr =
-            FastConfirmationRule::new::<ME>(checkpoint, &state, &state, head_root_a, 25, 40)
+            FastConfirmationRule::new::<E>(head_root_a, &state, checkpoint, &state, 25, 40)
                 .expect("fcr initialization");
 
         assert!(matches!(
@@ -1626,7 +1610,7 @@ mod tests {
             .expect("set slashings");
 
         let head_root_b = Hash256::repeat_byte(3);
-        fcr.update_fast_confirmation_variables::<ME>(
+        fcr.update_fast_confirmation_variables::<E>(
             head_root_b,
             &checkpoint,
             state.slot(),
@@ -1647,7 +1631,7 @@ mod tests {
 
         // While the epoch contains a slashing, every head change rebuilds the source.
         let head_root_c = Hash256::repeat_byte(4);
-        fcr.update_fast_confirmation_variables::<ME>(
+        fcr.update_fast_confirmation_variables::<E>(
             head_root_c,
             &checkpoint,
             state.slot(),

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -45,13 +45,13 @@ mod slot_assignments;
 pub use balance_source::{BalanceSourceData, BalanceSourceKey};
 pub use optimizations::CheckpointAndBalance;
 use optimizations::{AttestationScoreCache, HonestFfgSupportCache};
-use slot_assignments::SlotAssignments;
+use slot_assignments::{SlotAssignments, attestation_shuffling_id};
 
 use proto_array::core::{ProtoArray, ProtoNode, VoteTracker};
 use safe_arith::{ArithError, SafeArith};
 use std::collections::BTreeSet;
 use tracing::{debug, debug_span};
-use types::{BeaconState, Checkpoint, Epoch, EthSpec, Hash256, Slot};
+use types::{BeaconState, BeaconStateError, ChainSpec, Checkpoint, Epoch, EthSpec, Hash256, Slot};
 
 #[derive(Debug, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
@@ -72,6 +72,9 @@ pub enum Error {
     BlockRootsOutOfBounds(String),
     SlashingsOutOfBounds(String),
     IndexOutOfBounds(usize),
+    InvalidSlotAssignmentEpoch { epoch: Epoch, state_epoch: Epoch },
+    AttestationShufflingIdError(BeaconStateError),
+    CommitteeCacheError(BeaconStateError),
     ArithError(ArithError),
 }
 
@@ -174,6 +177,7 @@ impl FastConfirmationRule {
         checkpoint_state: &BeaconState<E>,
         byzantine_threshold: u64,
         proposer_score_boost: u64,
+        spec: &ChainSpec,
     ) -> Result<Self, Error> {
         let byzantine_threshold = byzantine_threshold.min(Self::MAX_BYZANTINE_THRESHOLD);
         // Sanity: the supplied state must be the checkpoint's state, advanced to the
@@ -198,7 +202,7 @@ impl FastConfirmationRule {
             current_slot_head: finalized_checkpoint.root,
             byzantine_threshold,
             proposer_score_boost,
-            slot_assignments: SlotAssignments::new(head_state)?,
+            slot_assignments: SlotAssignments::new(head_state, spec)?,
             head_balance_source: BalanceSourceData::new(head_state, head_root)?,
             last_update_slot: None,
             spec_test_mode: false,
@@ -238,6 +242,7 @@ impl FastConfirmationRule {
         equivocating_indices: &BTreeSet<u64>,
         head_state: &BeaconState<E>,
         checkpoint_state: Option<&BeaconState<E>>,
+        spec: &ChainSpec,
     ) -> Result<(), Error> {
         let _span = debug_span!("fcr_on_fast_confirmation", slot = %current_slot).entered();
 
@@ -247,6 +252,7 @@ impl FastConfirmationRule {
             current_slot,
             head_state,
             checkpoint_state,
+            spec,
         )?;
 
         if !self.spec_test_mode {
@@ -308,6 +314,7 @@ impl FastConfirmationRule {
         current_slot: Slot,
         head_state: &BeaconState<E>,
         checkpoint_state: Option<&BeaconState<E>>,
+        spec: &ChainSpec,
     ) -> Result<(), Error> {
         let _span = debug_span!("fcr_update_variables", slot = %current_slot).entered();
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
@@ -315,11 +322,11 @@ impl FastConfirmationRule {
         // Rebuild the head-derived caches when the head changes (including within a slot, e.g. a
         // late block or reorg). Each cache is rebuilt from scratch, independently, when its own
         // key is stale.
-        let head_dependent_root = dependent_root::<E>(head_state, current_epoch)?;
+        let head_current_epoch_shuffling_id = attestation_shuffling_id(head_state, current_epoch)?;
 
-        if self.head_assignments.dependent_root() != head_dependent_root {
+        if *self.slot_assignments.key() != head_current_epoch_shuffling_id {
             let _span = debug_span!("fcr_rebuild_assignments").entered();
-            self.slot_assignments.rebuild::<E>(state)?;
+            self.slot_assignments.rebuild::<E>(head_state, spec)?;
         }
 
         let head_balance_key = BalanceSourceKey::compute(head_state, head_root)?;
@@ -1373,21 +1380,6 @@ fn compute_start_slot_at_epoch<E: EthSpec>(epoch: Epoch) -> Slot {
     epoch.start_slot(E::slots_per_epoch())
 }
 
-/// Shuffling/validator-set decision root for `epoch`: the block at the last slot of the previous
-/// epoch. Genesis has no previous epoch, so it is identified by the zero root.
-pub(crate) fn dependent_root<E: EthSpec>(
-    state: &BeaconState<E>,
-    epoch: Epoch,
-) -> Result<Hash256, Error> {
-    if epoch == 0 {
-        return Ok(Hash256::ZERO);
-    }
-    let slot = compute_start_slot_at_epoch::<E>(epoch).safe_sub(1)?;
-    Ok(*state
-        .get_block_root(slot)
-        .map_err(|e| Error::BlockRootsOutOfBounds(format!("dep_root lookup: {e:?}")))?)
-}
-
 /// Spec: `is_full_validator_set_covered`.
 fn is_full_validator_set_covered<E: EthSpec>(
     start_slot: Slot,
@@ -1590,7 +1582,7 @@ mod tests {
         };
         let head_root_a = Hash256::repeat_byte(2);
         let mut fcr =
-            FastConfirmationRule::new::<E>(head_root_a, &state, checkpoint, &state, 25, 40)
+            FastConfirmationRule::new::<E>(head_root_a, &state, checkpoint, &state, 25, 40, &spec)
                 .expect("fcr initialization");
 
         assert!(matches!(
@@ -1615,6 +1607,7 @@ mod tests {
             state.slot(),
             &state,
             None,
+            &spec,
         )
         .expect("update variables");
 
@@ -1636,6 +1629,7 @@ mod tests {
             state.slot(),
             &state,
             None,
+            &spec,
         )
         .expect("update variables");
         assert_eq!(

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -30,7 +30,8 @@
 //!
 //! 4. **Snapshot balance sources** (`BalanceSourceData`): the current/previous observed-justified
 //!    sources are rebuilt only at the epoch-boundary rotation (bundled with their checkpoint in
-//!    `CheckpointAndBalance`), and the head source only when its dependent root changes — instead
+//!    `CheckpointAndBalance`), and the head source only when its `BalanceSourceKey` changes
+//!    (the dependent root normally, per head block once the epoch contains a slashing) — instead
 //!    of re-scanning the validator set every slot.
 //!
 //! The visible algorithm deliberately keeps the spec function names and control-flow shape;
@@ -41,7 +42,7 @@ pub mod metrics;
 pub mod optimizations;
 mod slot_assignments;
 
-pub use balance_source::BalanceSourceData;
+pub use balance_source::{BalanceSourceData, BalanceSourceKey};
 pub use optimizations::CheckpointAndBalance;
 use optimizations::{AttestationScoreCache, HonestFfgSupportCache};
 use slot_assignments::SlotAssignments;
@@ -70,6 +71,7 @@ pub enum Error {
     BlockEpochNone(Hash256),
     CommitteeCacheUninitialized(String),
     BlockRootsOutOfBounds(String),
+    SlashingsOutOfBounds(String),
     IndexOutOfBounds(usize),
     ArithError(ArithError),
 }
@@ -134,8 +136,10 @@ pub struct FastConfirmationRule {
     slot_assignments: SlotAssignments,
 
     // === FFG data from the head state ===
-    /// Built from the spec's `get_pulled_up_head_state`. Keyed (via `BalanceSourceData.dependent_root`)
-    /// on the head's dependent root, so a reorg past the previous-epoch boundary rebuilds it.
+    /// Built from the spec's `get_pulled_up_head_state`. Keyed (via `BalanceSourceData.key`)
+    /// on the head's dependent root — or the head block root itself once the epoch contains a
+    /// slashing — so a reorg past the previous-epoch boundary or an intra-epoch slashing
+    /// rebuilds it.
     head_balance_source: BalanceSourceData,
 
     // === Internal bookkeeping ===
@@ -159,14 +163,16 @@ impl FastConfirmationRule {
 
     /// Initialize FCR from the finalized checkpoint, its checkpoint state and the head state,
     /// building the balance sources and committee assignments up front (each tagged with its own
-    /// dependent root derived from the state). The spec seeds both observed-justified checkpoints
-    /// with the finalized checkpoint, so both balance sources come from `checkpoint_state`
-    /// (spec: `store.checkpoint_states[finalized_checkpoint]`); the head-derived caches come from
-    /// `head_state`. `byzantine_threshold` is clamped to [0, 25].
+    /// `BalanceSourceKey` derived from the state). The spec seeds both observed-justified
+    /// checkpoints with the finalized checkpoint, so both balance sources come from
+    /// `checkpoint_state` (spec: `store.checkpoint_states[finalized_checkpoint]`); the
+    /// head-derived caches come from `head_state`, whose block root is `head_root`.
+    /// `byzantine_threshold` is clamped to [0, 25].
     pub fn new<E: EthSpec>(
         finalized_checkpoint: Checkpoint,
         checkpoint_state: &BeaconState<E>,
         head_state: &BeaconState<E>,
+        head_root: Hash256,
         byzantine_threshold: u64,
         proposer_score_boost: u64,
     ) -> Result<Self, Error> {
@@ -176,8 +182,11 @@ impl FastConfirmationRule {
         if checkpoint_state.current_epoch() != finalized_checkpoint.epoch {
             return Err(Error::MissingCheckpointState(finalized_checkpoint));
         }
-        let checkpoint_balance =
-            BalanceSourceData::for_epoch(checkpoint_state, finalized_checkpoint.epoch)?;
+        let checkpoint_balance = BalanceSourceData::for_epoch(
+            checkpoint_state,
+            finalized_checkpoint.epoch,
+            finalized_checkpoint.root,
+        )?;
         Ok(Self {
             confirmed_root: finalized_checkpoint.root,
             previous_epoch_observed_justified: CheckpointAndBalance::new(
@@ -197,6 +206,7 @@ impl FastConfirmationRule {
             head_balance_source: BalanceSourceData::for_epoch(
                 head_state,
                 head_state.current_epoch(),
+                head_root,
             )?,
             last_update_slot: None,
             spec_test_mode: false,
@@ -311,9 +321,12 @@ impl FastConfirmationRule {
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
 
         // Rebuild the head-derived caches when the head changes (including within a slot, e.g. a
-        // late block or reorg). Each cache is keyed on the head's dependent root; rebuild it from
-        // scratch, independently, when its own dependent root is stale (a reorg past the
-        // previous-epoch boundary, or a new epoch).
+        // late block or reorg). Each cache is rebuilt from scratch, independently, when its own
+        // key is stale. The slot assignments are keyed on the head's dependent root (a reorg past
+        // the previous-epoch boundary, or a new epoch). The balance source is keyed on its
+        // `BalanceSourceKey`, whose `SlashingsPresent` variant additionally forces a rebuild
+        // when a slashing lands mid-epoch and flips `slashed` flags without moving the dependent
+        // root (the FCR analogue of the unrealized-checkpoints fix in sigp/lighthouse#9471).
         let head_dependent_root = dependent_root::<E>(head_state, current_epoch)?;
 
         if self.slot_assignments.dependent_root() != head_dependent_root {
@@ -321,9 +334,11 @@ impl FastConfirmationRule {
             self.slot_assignments = SlotAssignments::new::<E>(head_state)?;
         }
 
-        if self.head_balance_source.dependent_root != head_dependent_root {
+        let head_balance_key = BalanceSourceKey::compute(head_state, current_epoch, head_root)?;
+        if self.head_balance_source.key != head_balance_key {
             let _span = debug_span!("fcr_rebuild_head_balance").entered();
-            self.head_balance_source = BalanceSourceData::for_epoch(head_state, current_epoch)?;
+            self.head_balance_source =
+                BalanceSourceData::for_epoch(head_state, current_epoch, head_root)?;
         }
 
         // Spec: update_fast_confirmation_variables must be called at most once per slot.
@@ -359,7 +374,11 @@ impl FastConfirmationRule {
                         }
                         CheckpointAndBalance::new(new_current_cp, {
                             let _span = debug_span!("fcr_rebuild_current_balance").entered();
-                            BalanceSourceData::for_epoch(checkpoint_state, new_current_cp.epoch)?
+                            BalanceSourceData::for_epoch(
+                                checkpoint_state,
+                                new_current_cp.epoch,
+                                new_current_cp.root,
+                            )?
                         })
                     };
                 self.previous_epoch_observed_justified =
@@ -1537,6 +1556,110 @@ mod tests {
         assert_eq!(
             adjust_committee_weight_estimate_to_ensure_safety(0).unwrap(),
             0
+        );
+    }
+
+    /// Regression test: a slashing processed mid-epoch must rebuild the head balance source
+    /// even though the dependent root is unchanged for the rest of the epoch (the FCR analogue
+    /// of the unrealized-checkpoints bug fixed in sigp/lighthouse#9471).
+    #[test]
+    fn head_balance_source_rebuilt_after_intra_epoch_slashing() {
+        use state_processing::per_slot_processing;
+        use types::MinimalEthSpec;
+        type ME = MinimalEthSpec;
+
+        let spec = ME::default_spec();
+        let mut state: BeaconState<ME> = BeaconState::new(0, Default::default(), &spec);
+        for _ in 0..32 {
+            let validator = types::Validator {
+                effective_balance: spec.max_effective_balance,
+                activation_epoch: Epoch::new(0),
+                exit_epoch: spec.far_future_epoch,
+                withdrawable_epoch: spec.far_future_epoch,
+                ..Default::default()
+            };
+            state
+                .validators_mut()
+                .push(validator)
+                .expect("push validator");
+            state
+                .balances_mut()
+                .push(spec.max_effective_balance)
+                .expect("push balance");
+        }
+        state
+            .build_all_committee_caches(&spec)
+            .expect("committee caches");
+
+        // Advance to a mid-epoch slot: at an epoch start the dependent root changes and would
+        // rebuild the source regardless, masking the bug.
+        let mid_epoch_slot = Slot::new(ME::slots_per_epoch() + 4);
+        while state.slot() < mid_epoch_slot {
+            per_slot_processing(&mut state, None, &spec).expect("should advance slot");
+        }
+        state
+            .build_all_committee_caches(&spec)
+            .expect("committee caches");
+
+        let checkpoint = Checkpoint {
+            epoch: state.current_epoch(),
+            root: Hash256::repeat_byte(1),
+        };
+        let head_root_a = Hash256::repeat_byte(2);
+        let mut fcr =
+            FastConfirmationRule::new::<ME>(checkpoint, &state, &state, head_root_a, 25, 40)
+                .expect("fcr initialization");
+
+        assert!(matches!(
+            fcr.head_balance_source.key,
+            BalanceSourceKey::NoSlashings { .. }
+        ));
+        assert!(!fcr.head_balance_source.slashed[0]);
+        let pre_slashing_key = fcr.head_balance_source.key;
+
+        // Simulate a slashing landing in a new head block within the same epoch (mirroring what
+        // `slash_validator` does to the state).
+        let effective_balance = spec.max_effective_balance;
+        state.get_validator_mut(0).expect("validator 0").slashed = true;
+        state
+            .set_slashings(state.current_epoch(), effective_balance)
+            .expect("set slashings");
+
+        let head_root_b = Hash256::repeat_byte(3);
+        fcr.update_fast_confirmation_variables::<ME>(
+            head_root_b,
+            &checkpoint,
+            state.slot(),
+            &state,
+            None,
+        )
+        .expect("update variables");
+
+        // The regression assertion: the balance source must have been rebuilt.
+        assert!(fcr.head_balance_source.slashed[0]);
+        assert_eq!(
+            fcr.head_balance_source.key,
+            BalanceSourceKey::SlashingsPresent {
+                head_block_root: head_root_b
+            }
+        );
+        assert_ne!(fcr.head_balance_source.key, pre_slashing_key);
+
+        // While the epoch contains a slashing, every head change rebuilds the source.
+        let head_root_c = Hash256::repeat_byte(4);
+        fcr.update_fast_confirmation_variables::<ME>(
+            head_root_c,
+            &checkpoint,
+            state.slot(),
+            &state,
+            None,
+        )
+        .expect("update variables");
+        assert_eq!(
+            fcr.head_balance_source.key,
+            BalanceSourceKey::SlashingsPresent {
+                head_block_root: head_root_c
+            }
         );
     }
 }

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -45,7 +45,7 @@ mod slot_assignments;
 pub use balance_source::{BalanceSourceData, BalanceSourceKey};
 pub use optimizations::CheckpointAndBalance;
 use optimizations::{AttestationScoreCache, HonestFfgSupportCache};
-use slot_assignments::{SlotAssignments, attestation_shuffling_id};
+use slot_assignments::{SlotAssignments, WindowEpoch, attestation_shuffling_id};
 
 use proto_array::core::{ProtoArray, ProtoNode, VoteTracker};
 use safe_arith::{ArithError, SafeArith};
@@ -72,7 +72,6 @@ pub enum Error {
     BlockRootsOutOfBounds(String),
     SlashingsOutOfBounds(String),
     IndexOutOfBounds(usize),
-    InvalidSlotAssignmentEpoch { epoch: Epoch, state_epoch: Epoch },
     AttestationShufflingIdError(BeaconStateError),
     CommitteeCacheError(BeaconStateError),
     ArithError(ArithError),
@@ -202,7 +201,7 @@ impl FastConfirmationRule {
             current_slot_head: finalized_checkpoint.root,
             byzantine_threshold,
             proposer_score_boost,
-            slot_assignments: SlotAssignments::new(head_state, spec)?,
+            slot_assignments: SlotAssignments::new(head_state, spec, None)?,
             head_balance_source: BalanceSourceData::new(head_state, head_root)?,
             last_update_slot: None,
             spec_test_mode: false,
@@ -317,16 +316,17 @@ impl FastConfirmationRule {
         spec: &ChainSpec,
     ) -> Result<(), Error> {
         let _span = debug_span!("fcr_update_variables", slot = %current_slot).entered();
-        let current_epoch = current_slot.epoch(E::slots_per_epoch());
 
         // Rebuild the head-derived caches when the head changes (including within a slot, e.g. a
         // late block or reorg). Each cache is rebuilt from scratch, independently, when its own
         // key is stale.
-        let head_current_epoch_shuffling_id = attestation_shuffling_id(head_state, current_epoch)?;
+        let head_current_epoch_shuffling_id =
+            attestation_shuffling_id(head_state, WindowEpoch::Current)?;
 
         if *self.slot_assignments.key() != head_current_epoch_shuffling_id {
             let _span = debug_span!("fcr_rebuild_assignments").entered();
-            self.slot_assignments.rebuild::<E>(head_state, spec)?;
+            self.slot_assignments =
+                SlotAssignments::new(head_state, spec, Some(&self.slot_assignments))?;
         }
 
         let head_balance_key = BalanceSourceKey::compute(head_state, head_root)?;

--- a/consensus/fast_confirmation/src/slot_assignments.rs
+++ b/consensus/fast_confirmation/src/slot_assignments.rs
@@ -1,5 +1,5 @@
 //! Committee slot assignments for the Fast Confirmation Rule, resolved on demand from the
-//! committee-cache shufflings covering the `[current-2 ..= current+1]` epoch window.
+//! committee-cache shufflings covering the `[current-2, current]` epoch window.
 
 use crate::Error;
 use safe_arith::SafeArith;
@@ -8,6 +8,78 @@ use types::{
     AttestationShufflingId, BeaconState, ChainSpec, CommitteeCache, Epoch, EthSpec, Hash256,
     RelativeEpoch, Slot,
 };
+
+/// One of the three epochs the FCR examines for committee assignments, relative to a beacon
+/// state's current epoch.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum WindowEpoch {
+    PrevPrev,
+    Previous,
+    Current,
+}
+
+impl WindowEpoch {
+    fn epoch<E: EthSpec>(self, state: &BeaconState<E>) -> Epoch {
+        match self {
+            Self::PrevPrev => state.previous_epoch().saturating_sub(1u64),
+            Self::Previous => state.previous_epoch(),
+            Self::Current => state.current_epoch(),
+        }
+    }
+
+    fn shuffling_id<E: EthSpec>(
+        self,
+        state: &BeaconState<E>,
+    ) -> Result<AttestationShufflingId, Error> {
+        // Block root is only used for genesis so we use zero.
+        let block_root = Hash256::ZERO;
+        match self {
+            Self::Current => AttestationShufflingId::new(block_root, state, RelativeEpoch::Current)
+                .map_err(Error::AttestationShufflingIdError),
+            Self::Previous => {
+                AttestationShufflingId::new(block_root, state, RelativeEpoch::Previous)
+                    .map_err(Error::AttestationShufflingIdError)
+            }
+            Self::PrevPrev => {
+                let epoch = self.epoch(state);
+                let shuffling_decision_slot = epoch
+                    .saturating_sub(1u64)
+                    .start_slot(E::slots_per_epoch())
+                    .saturating_sub(1u64);
+                let shuffling_decision_root = state
+                    .get_block_root(shuffling_decision_slot)
+                    .copied()
+                    .unwrap_or(block_root);
+                Ok(AttestationShufflingId::from_components(
+                    epoch,
+                    shuffling_decision_root,
+                ))
+            }
+        }
+    }
+
+    /// The committee cache for this window position. `Current`/`Previous` are read from the state's
+    /// caches; `PrevPrev` has no cached slot in the state, so its shuffling is recomputed.
+    fn committee_cache<E: EthSpec>(
+        self,
+        state: &BeaconState<E>,
+        spec: &ChainSpec,
+    ) -> Result<Arc<CommitteeCache>, Error> {
+        match self {
+            Self::Current => Ok(state
+                .committee_cache(RelativeEpoch::Current)
+                .map_err(Error::CommitteeCacheError)?
+                .clone()),
+            Self::Previous => Ok(state
+                .committee_cache(RelativeEpoch::Previous)
+                .map_err(Error::CommitteeCacheError)?
+                .clone()),
+            Self::PrevPrev => state
+                .initialize_committee_cache(self.epoch(state), spec)
+                .map_err(Error::CommitteeCacheError),
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 struct SlotAssignment {
@@ -19,79 +91,35 @@ struct SlotAssignment {
     epoch_end_slot: Slot,
 }
 
+/// The attestation shuffling id for `window_epoch` relative to `state`.
 pub(crate) fn attestation_shuffling_id<E: EthSpec>(
     state: &BeaconState<E>,
-    epoch: Epoch,
+    window_epoch: WindowEpoch,
 ) -> Result<AttestationShufflingId, Error> {
-    // Block root is only used for genesis so we use zero.
-    let block_root = Hash256::ZERO;
-
-    if epoch == state.current_epoch() {
-        AttestationShufflingId::new(block_root, state, RelativeEpoch::Current)
-            .map_err(Error::AttestationShufflingIdError)
-    } else if epoch == state.previous_epoch() {
-        AttestationShufflingId::new(block_root, state, RelativeEpoch::Previous)
-            .map_err(Error::AttestationShufflingIdError)
-    } else if epoch == state.previous_epoch().saturating_sub(1u64) {
-        let shuffling_decision_slot = epoch
-            .saturating_sub(1u64)
-            .start_slot(E::slots_per_epoch())
-            .saturating_sub(1u64);
-        let shuffling_decision_root = state
-            .get_block_root(shuffling_decision_slot)
-            .copied()
-            .unwrap_or(block_root);
-        Ok(AttestationShufflingId::from_components(
-            epoch,
-            shuffling_decision_root,
-        ))
-    } else {
-        Err(Error::InvalidSlotAssignmentEpoch {
-            epoch,
-            state_epoch: state.current_epoch(),
-        })
-    }
+    window_epoch.shuffling_id(state)
 }
 
 impl SlotAssignment {
+    /// Build the assignment for `window_epoch` relative to `state`, re-using a matching cache from
+    /// `prev` when its shuffling is unchanged (a rebuild rotating the window down an epoch).
     fn new<E: EthSpec>(
         state: &BeaconState<E>,
-        epoch: Epoch,
+        window_epoch: WindowEpoch,
         spec: &ChainSpec,
+        prev: Option<&SlotAssignments>,
     ) -> Result<Self, Error> {
-        let (key, committee_cache) = if epoch == state.current_epoch() {
-            let key = attestation_shuffling_id(state, epoch)?;
-            let committee_cache = state
-                .committee_cache(RelativeEpoch::Current)
-                .map_err(Error::CommitteeCacheError)?
-                .clone();
-            (key, committee_cache)
-        } else if epoch == state.previous_epoch() {
-            let key = attestation_shuffling_id(state, epoch)?;
-            let committee_cache = state
-                .committee_cache(RelativeEpoch::Previous)
-                .map_err(Error::CommitteeCacheError)?
-                .clone();
-            (key, committee_cache)
-        } else if epoch == state.previous_epoch().saturating_sub(1u64) {
-            let key = attestation_shuffling_id(state, epoch)?;
-            let committee_cache = state
-                .initialize_committee_cache(epoch, spec)
-                .map_err(Error::CommitteeCacheError)?;
-            (key, committee_cache)
-        } else {
-            return Err(Error::InvalidSlotAssignmentEpoch {
-                epoch,
-                state_epoch: state.current_epoch(),
-            });
-        };
-        let epoch_start_slot = epoch.start_slot(E::slots_per_epoch());
-        let epoch_end_slot = epoch.end_slot(E::slots_per_epoch());
+        let key = window_epoch.shuffling_id(state)?;
+        if let Some(existing) =
+            prev.and_then(|prev| prev.assignments.iter().find(|existing| existing.key == key))
+        {
+            return Ok(existing.clone());
+        }
+        let epoch = window_epoch.epoch(state);
         Ok(Self {
             key,
-            committee_cache,
-            epoch_start_slot,
-            epoch_end_slot,
+            committee_cache: window_epoch.committee_cache(state, spec)?,
+            epoch_start_slot: epoch.start_slot(E::slots_per_epoch()),
+            epoch_end_slot: epoch.end_slot(E::slots_per_epoch()),
         })
     }
 }
@@ -103,45 +131,21 @@ pub(crate) struct SlotAssignments {
 }
 
 impl SlotAssignments {
-    pub(crate) fn new<E: EthSpec>(state: &BeaconState<E>, spec: &ChainSpec) -> Result<Self, Error> {
-        let assignments = [
-            SlotAssignment::new(state, state.previous_epoch().saturating_sub(1u64), spec)?,
-            SlotAssignment::new(state, state.previous_epoch(), spec)?,
-            SlotAssignment::new(state, state.current_epoch(), spec)?,
-        ];
-        Ok(Self { assignments })
-    }
-
-    /// Refresh the committee caches for `state`'s epochs, building only shufflings not already held.
-    pub(crate) fn rebuild<E: EthSpec>(
-        &mut self,
+    /// Build the `[current-2, current]` committee caches for `state`. When `prev` is supplied (a
+    /// rebuild triggered by a head change), any cache whose shuffling is unchanged is re-used from
+    /// it rather than rebuilt — the common case where we just rotate the window down an epoch.
+    pub(crate) fn new<E: EthSpec>(
         state: &BeaconState<E>,
         spec: &ChainSpec,
-    ) -> Result<(), Error> {
-        let get_assignment = |epoch: Epoch| {
-            let key = attestation_shuffling_id(state, epoch)?;
-
-            // Re-use a previously cached assignment (the common case where we are rotating caches
-            // down one or two epochs).
-            for existing_assignment in &self.assignments {
-                if key == existing_assignment.key {
-                    return Ok(existing_assignment.clone());
-                }
-            }
-
-            // Otherwise rebuild (which is usually quick too, because we just clone a committee
-            // cache from `state`).
-            SlotAssignment::new(state, epoch, spec)
-        };
-
-        let new_assignments = [
-            get_assignment(state.previous_epoch().saturating_sub(1u64))?,
-            get_assignment(state.previous_epoch())?,
-            get_assignment(state.current_epoch())?,
-        ];
-
-        self.assignments = new_assignments;
-        Ok(())
+        prev: Option<&Self>,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            assignments: [
+                SlotAssignment::new(state, WindowEpoch::PrevPrev, spec, prev)?,
+                SlotAssignment::new(state, WindowEpoch::Previous, spec, prev)?,
+                SlotAssignment::new(state, WindowEpoch::Current, spec, prev)?,
+            ],
+        })
     }
 
     pub(crate) fn key(&self) -> &AttestationShufflingId {
@@ -239,7 +243,7 @@ mod tests {
     #[test]
     fn builds_from_genesis_state() {
         let (state, spec) = genesis_state(64);
-        SlotAssignments::new::<E>(&state, &spec).expect("builds from genesis state");
+        SlotAssignments::new::<E>(&state, &spec, None).expect("builds from genesis state");
     }
 
     #[test]
@@ -248,7 +252,7 @@ mod tests {
         let spe = E::slots_per_epoch();
         let start = Slot::new(spe * 2);
         advance_state(&mut state, start, &spec);
-        let sa = SlotAssignments::new::<E>(&state, &spec).expect("build");
+        let sa = SlotAssignments::new::<E>(&state, &spec, None).expect("build");
 
         let end = Slot::new(spe * 2 + spe - 1);
         for val_idx in 0..state.validators().len() {
@@ -262,7 +266,7 @@ mod tests {
     #[test]
     fn is_in_range_returns_false_for_uncovered_epochs() {
         let (state, spec) = genesis_state(64);
-        let sa = SlotAssignments::new::<E>(&state, &spec).expect("build");
+        let sa = SlotAssignments::new::<E>(&state, &spec, None).expect("build");
         let far = Slot::new(E::slots_per_epoch() * 5);
         for val_idx in 0..state.validators().len() {
             assert!(!sa.is_in_range(val_idx, far, far).unwrap());

--- a/consensus/fast_confirmation/src/slot_assignments.rs
+++ b/consensus/fast_confirmation/src/slot_assignments.rs
@@ -3,75 +3,150 @@
 
 use crate::Error;
 use safe_arith::SafeArith;
-use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use types::{BeaconState, CommitteeCache, Epoch, EthSpec, Hash256, RelativeEpoch, Slot};
+use types::{
+    AttestationShufflingId, BeaconState, ChainSpec, CommitteeCache, Epoch, EthSpec, Hash256,
+    RelativeEpoch, Slot,
+};
 
-/// Epochs covered, oldest to newest: `[current-2, current-1, current, current+1]`.
-const WINDOW: usize = 4;
+#[derive(Debug, Clone)]
+struct SlotAssignment {
+    key: AttestationShufflingId,
+    committee_cache: Arc<CommitteeCache>,
+    /// Start slot of `key.shuffling_epoch` cached for quick access.
+    epoch_start_slot: Slot,
+    /// End slot of `key.shuffling_epoch` cached for quick access.
+    #[allow(dead_code)]
+    epoch_end_slot: Slot,
+}
 
-/// Committee assignments over the FCR epoch window. Shufflings are keyed by their dependent root,
-/// so a rebuild reuses the ones already held (notably `current-2`, which was `current-1` last
-/// epoch) instead of recomputing them.
+pub(crate) fn attestation_shuffling_id<E: EthSpec>(
+    state: &BeaconState<E>,
+    epoch: Epoch,
+) -> Result<AttestationShufflingId, Error> {
+    // Block root is only used for genesis so we use zero.
+    let block_root = Hash256::ZERO;
+
+    if epoch == state.current_epoch() {
+        AttestationShufflingId::new(block_root, state, RelativeEpoch::Current)
+            .map_err(Error::AttestationShufflingIdError)
+    } else if epoch == state.previous_epoch() {
+        AttestationShufflingId::new(block_root, state, RelativeEpoch::Previous)
+            .map_err(Error::AttestationShufflingIdError)
+    } else if epoch == state.previous_epoch().saturating_sub(1u64) {
+        let shuffling_decision_slot = epoch
+            .saturating_sub(1u64)
+            .start_slot(E::slots_per_epoch())
+            .saturating_sub(1u64);
+        let shuffling_decision_root = state
+            .get_block_root(shuffling_decision_slot)
+            .copied()
+            .unwrap_or(block_root);
+        Ok(AttestationShufflingId::from_components(
+            epoch,
+            shuffling_decision_root,
+        ))
+    } else {
+        Err(Error::InvalidSlotAssignmentEpoch {
+            epoch,
+            state_epoch: state.current_epoch(),
+        })
+    }
+}
+
+impl SlotAssignment {
+    fn new<E: EthSpec>(
+        state: &BeaconState<E>,
+        epoch: Epoch,
+        spec: &ChainSpec,
+    ) -> Result<Self, Error> {
+        let (key, committee_cache) = if epoch == state.current_epoch() {
+            let key = attestation_shuffling_id(state, epoch)?;
+            let committee_cache = state
+                .committee_cache(RelativeEpoch::Current)
+                .map_err(Error::CommitteeCacheError)?
+                .clone();
+            (key, committee_cache)
+        } else if epoch == state.previous_epoch() {
+            let key = attestation_shuffling_id(state, epoch)?;
+            let committee_cache = state
+                .committee_cache(RelativeEpoch::Previous)
+                .map_err(Error::CommitteeCacheError)?
+                .clone();
+            (key, committee_cache)
+        } else if epoch == state.previous_epoch().saturating_sub(1u64) {
+            let key = attestation_shuffling_id(state, epoch)?;
+            let committee_cache = state
+                .initialize_committee_cache(epoch, spec)
+                .map_err(Error::CommitteeCacheError)?;
+            (key, committee_cache)
+        } else {
+            return Err(Error::InvalidSlotAssignmentEpoch {
+                epoch,
+                state_epoch: state.current_epoch(),
+            });
+        };
+        let epoch_start_slot = epoch.start_slot(E::slots_per_epoch());
+        let epoch_end_slot = epoch.end_slot(E::slots_per_epoch());
+        Ok(Self {
+            key,
+            committee_cache,
+            epoch_start_slot,
+            epoch_end_slot,
+        })
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct SlotAssignments {
-    /// Shufflings for the readable window epochs, keyed by dependent root so a rebuild reuses them.
-    cache: HashMap<Hash256, Arc<CommitteeCache>>,
-    /// `(shuffling, epoch_start_slot)` per window epoch; `None` when the shuffling isn't yet held
-    /// (e.g. `current-2` right after a cold start).
-    window: [(Option<Arc<CommitteeCache>>, Slot); WINDOW],
-    dependent_root: Hash256,
+    /// Committee caches in epoch ascending order (current - 2, current - 1, current).
+    assignments: [SlotAssignment; 3],
 }
 
 impl SlotAssignments {
-    pub(crate) fn new<E: EthSpec>(state: &BeaconState<E>) -> Result<Self, Error> {
-        let mut assignments = Self {
-            cache: HashMap::new(),
-            window: std::array::from_fn(|_| (None, Slot::new(0))),
-            dependent_root: Hash256::ZERO,
-        };
-        assignments.rebuild(state)?;
-        Ok(assignments)
+    pub(crate) fn new<E: EthSpec>(state: &BeaconState<E>, spec: &ChainSpec) -> Result<Self, Error> {
+        let assignments = [
+            SlotAssignment::new(state, state.previous_epoch().saturating_sub(1u64), spec)?,
+            SlotAssignment::new(state, state.previous_epoch(), spec)?,
+            SlotAssignment::new(state, state.current_epoch(), spec)?,
+        ];
+        Ok(Self { assignments })
     }
 
-    /// Refresh the window for `state`'s current epoch, fetching only shufflings not already held.
-    pub(crate) fn rebuild<E: EthSpec>(&mut self, state: &BeaconState<E>) -> Result<(), Error> {
-        let spe = E::slots_per_epoch();
-        let current = state.current_epoch();
+    /// Refresh the committee caches for `state`'s epochs, building only shufflings not already held.
+    pub(crate) fn rebuild<E: EthSpec>(
+        &mut self,
+        state: &BeaconState<E>,
+        spec: &ChainSpec,
+    ) -> Result<(), Error> {
+        let get_assignment = |epoch: Epoch| {
+            let key = attestation_shuffling_id(state, epoch)?;
 
-        // The previous/current shufflings have readable dependent roots; cache them for reuse.
-        for relative in [RelativeEpoch::Previous, RelativeEpoch::Current] {
-            let root = crate::dependent_root::<E>(state, relative.into_epoch(current))?;
-            if let Entry::Vacant(entry) = self.cache.entry(root) {
-                entry.insert(committee_cache(state, relative)?);
+            // Re-use a previously cached assignment (the common case where we are rotating caches
+            // down one or two epochs).
+            for existing_assignment in &self.assignments {
+                if key == existing_assignment.key {
+                    return Ok(existing_assignment.clone());
+                }
             }
-        }
-        // The next epoch's decision root isn't readable yet, so fetch it fresh each rebuild.
-        let next = committee_cache(state, RelativeEpoch::Next)?;
 
-        let mut window: [(Option<Arc<CommitteeCache>>, Slot); WINDOW] =
-            std::array::from_fn(|_| (None, Slot::new(0)));
-        let mut live = HashSet::new();
-        for (slot, epoch) in window.iter_mut().zip([
-            current.saturating_sub(Epoch::new(2)),
-            current.saturating_sub(Epoch::new(1)),
-            current,
-        ]) {
-            let root = crate::dependent_root::<E>(state, epoch)?;
-            live.insert(root);
-            *slot = (self.cache.get(&root).cloned(), epoch.start_slot(spe));
-        }
-        window[WINDOW - 1] = (Some(next), current.safe_add(1)?.start_slot(spe));
+            // Otherwise rebuild (which is usually quick too, because we just clone a committee
+            // cache from `state`).
+            SlotAssignment::new(state, epoch, spec)
+        };
 
-        self.window = window;
-        self.dependent_root = crate::dependent_root::<E>(state, current)?;
-        self.cache.retain(|root, _| live.contains(root));
+        let new_assignments = [
+            get_assignment(state.previous_epoch().saturating_sub(1u64))?,
+            get_assignment(state.previous_epoch())?,
+            get_assignment(state.current_epoch())?,
+        ];
+
+        self.assignments = new_assignments;
         Ok(())
     }
 
-    pub(crate) fn dependent_root(&self) -> Hash256 {
-        self.dependent_root
+    pub(crate) fn key(&self) -> &AttestationShufflingId {
+        &self.assignments[2].key
     }
 
     /// True if `val_idx` attests in any window epoch at a slot within `[start, end]`.
@@ -81,26 +156,19 @@ impl SlotAssignments {
         start: Slot,
         end: Slot,
     ) -> Result<bool, Error> {
-        for (cache, epoch_start) in &self.window {
-            let Some(cache) = cache else { continue };
-            if assigned_slot(cache, *epoch_start, val_idx)?
-                .is_some_and(|slot| slot >= start && slot <= end)
+        for assignment in &self.assignments {
+            if assigned_slot(
+                &assignment.committee_cache,
+                assignment.epoch_start_slot,
+                val_idx,
+            )?
+            .is_some_and(|slot| slot >= start && slot <= end)
             {
                 return Ok(true);
             }
         }
         Ok(false)
     }
-}
-
-fn committee_cache<E: EthSpec>(
-    state: &BeaconState<E>,
-    relative: RelativeEpoch,
-) -> Result<Arc<CommitteeCache>, Error> {
-    Ok(state
-        .committee_cache(relative)
-        .map_err(|e| Error::CommitteeCacheUninitialized(format!("{e:?}")))?
-        .clone())
 }
 
 /// The committee slot `val_idx` attests in for `cache`'s epoch, or `None` if it has no duty.
@@ -167,8 +235,8 @@ mod tests {
 
     #[test]
     fn builds_from_genesis_state() {
-        let (state, _) = genesis_state(64);
-        SlotAssignments::new::<E>(&state).expect("builds from genesis state");
+        let (state, spec) = genesis_state(64);
+        SlotAssignments::new::<E>(&state, &spec).expect("builds from genesis state");
     }
 
     #[test]
@@ -177,7 +245,7 @@ mod tests {
         let spe = E::slots_per_epoch();
         let start = Slot::new(spe * 2);
         advance_state(&mut state, start, &spec);
-        let sa = SlotAssignments::new::<E>(&state).expect("build");
+        let sa = SlotAssignments::new::<E>(&state, &spec).expect("build");
 
         let end = Slot::new(spe * 2 + spe - 1);
         for val_idx in 0..state.validators().len() {
@@ -190,8 +258,8 @@ mod tests {
 
     #[test]
     fn is_in_range_returns_false_for_uncovered_epochs() {
-        let (state, _) = genesis_state(64);
-        let sa = SlotAssignments::new::<E>(&state).expect("build");
+        let (state, spec) = genesis_state(64);
+        let sa = SlotAssignments::new::<E>(&state, &spec).expect("build");
         let far = Slot::new(E::slots_per_epoch() * 5);
         for val_idx in 0..state.validators().len() {
             assert!(!sa.is_in_range(val_idx, far, far).unwrap());

--- a/consensus/fast_confirmation/src/slot_assignments.rs
+++ b/consensus/fast_confirmation/src/slot_assignments.rs
@@ -16,7 +16,6 @@ struct SlotAssignment {
     /// Start slot of `key.shuffling_epoch` cached for quick access.
     epoch_start_slot: Slot,
     /// End slot of `key.shuffling_epoch` cached for quick access.
-    #[allow(dead_code)]
     epoch_end_slot: Slot,
 }
 
@@ -157,6 +156,10 @@ impl SlotAssignments {
         end: Slot,
     ) -> Result<bool, Error> {
         for assignment in &self.assignments {
+            // Skip this epoch's cache if it has no overlap with the requested range.
+            if assignment.epoch_end_slot < start || assignment.epoch_start_slot > end {
+                continue;
+            }
             if assigned_slot(
                 &assignment.committee_cache,
                 assignment.epoch_start_slot,

--- a/consensus/fast_confirmation/src/slot_assignments.rs
+++ b/consensus/fast_confirmation/src/slot_assignments.rs
@@ -1,142 +1,91 @@
-//! Per-validator committee slot assignment table used by the Fast Confirmation Rule.
+//! Committee slot assignments for the Fast Confirmation Rule, resolved on demand from the
+//! committee-cache shufflings covering the `[current-2 ..= current+1]` epoch window.
 
 use crate::Error;
 use safe_arith::SafeArith;
-use types::{BeaconState, EthSpec, Hash256, RelativeEpoch, Slot};
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use types::{BeaconState, CommitteeCache, Epoch, EthSpec, Hash256, RelativeEpoch, Slot};
 
-/// Per-validator committee slot assignments across a 3-epoch window.
-///
-/// Each active validator is assigned to exactly one committee slot per epoch.
-/// This structure tracks those assignments for epochs `[current-1, current, current+1]`,
-/// stored as a flat `Vec<Slot>` with stride 3 for cache-friendly iteration over all
-/// validators.
-///
-/// # Layout
-///
-/// ```text
-///                    previous   current    next
-/// validator 0:       slot_a     slot_b     slot_c
-/// validator 1:       slot_d     slot_e     slot_f
-/// ...
-/// ```
-///
-/// Stored flat: `[slot_a, slot_b, slot_c, slot_d, slot_e, slot_f, ...]`
-///
-/// Access: `slots[validator_index * 3 + column]` where column 0/1/2 is the
-/// `[previous, current, next]` epoch of the state it was built from.
-///
-/// # Sentinel
-///
-/// `UNSET_SLOT` (`Slot(u64::MAX)`) marks uninitialized entries. Reading an unset
-/// slot via `is_in_range` returns an error, catching rebuild bugs early.
+/// Epochs covered, oldest to newest: `[current-2, current-1, current, current+1]`.
+const WINDOW: usize = 4;
+
+/// Committee assignments over the FCR epoch window. Shufflings are keyed by their dependent root,
+/// so a rebuild reuses the ones already held (notably `current-2`, which was `current-1` last
+/// epoch) instead of recomputing them.
 #[derive(Clone, Debug)]
 pub(crate) struct SlotAssignments {
-    /// Length is `validator_count * 3` (stride-3 layout, see the type-level docs).
-    slots: Vec<Slot>,
-    /// Shuffling decision root the table was built for. The owner rebuilds when it changes.
+    /// Shufflings for the readable window epochs, keyed by dependent root so a rebuild reuses them.
+    cache: HashMap<Hash256, Arc<CommitteeCache>>,
+    /// `(shuffling, epoch_start_slot)` per window epoch; `None` when the shuffling isn't yet held
+    /// (e.g. `current-2` right after a cold start).
+    window: [(Option<Arc<CommitteeCache>>, Slot); WINDOW],
     dependent_root: Hash256,
 }
 
-/// Number of epoch columns in the slot assignment table.
-const NUM_EPOCH_COLUMNS: usize = 3;
-
-/// Sentinel value for unset slot assignments. Using `u64::MAX` instead of `Slot(0)`
-/// avoids ambiguity with genesis slot 0 and allows hard error detection on read.
-pub const UNSET_SLOT: Slot = Slot::new(u64::MAX);
-
 impl SlotAssignments {
-    /// Build assignments from a beacon state, tagged with the dependent root it derives for the
-    /// state's current epoch.
-    ///
-    /// Computes the 3-epoch window `[previous, current, next]` and fills assignments from the
-    /// state's committee caches; validators with no committee duty in a column are left `UNSET_SLOT`.
-    /// The owner rebuilds (replaces) the table whenever that dependent root changes.
-    ///
-    /// # Performance
-    ///
-    /// Instead of calling `get_attestation_duties()` per validator (O(N × C) where C =
-    /// committees per epoch), we iterate the committee cache's shuffled list directly and
-    /// derive slot from shuffled position in O(1). Total cost: O(N) per epoch column.
     pub(crate) fn new<E: EthSpec>(state: &BeaconState<E>) -> Result<Self, Error> {
-        let dependent_root = crate::dependent_root::<E>(state, state.current_epoch())?;
-        let validator_count = state.validators().len();
-        let total_columns = validator_count.safe_mul(NUM_EPOCH_COLUMNS)?;
-        let mut new_slots = vec![UNSET_SLOT; total_columns];
-
-        // Fill from the committee caches by iterating each epoch's shuffled list directly.
-        // This is O(active_validators) per epoch instead of O(validators × committees).
-        for (col, relative_epoch, epoch) in [
-            (0, RelativeEpoch::Previous, state.previous_epoch()),
-            (1, RelativeEpoch::Current, state.current_epoch()),
-            (2, RelativeEpoch::Next, state.current_epoch().safe_add(1)?),
-        ] {
-            let committee_cache = state
-                .committee_cache(relative_epoch)
-                .map_err(|e| Error::CommitteeCacheUninitialized(format!("{e:?}")))?;
-
-            let shuffling = committee_cache.shuffling();
-            let committees_per_slot = committee_cache.committees_per_slot() as usize;
-            let epoch_start = epoch.start_slot(E::slots_per_epoch());
-
-            // Each position in the shuffled list maps to a committee, which maps to a slot.
-            // committee_index_in_epoch = position * total_committees / shuffling_len
-            // slot_offset = committee_index_in_epoch / committees_per_slot
-            let total_committees = committees_per_slot.safe_mul(E::slots_per_epoch() as usize)?;
-            let shuffling_len = shuffling.len();
-
-            for (position, &val_idx) in shuffling.iter().enumerate() {
-                let committee_index = position
-                    .safe_mul(total_committees)?
-                    .safe_div(shuffling_len)?;
-                let slot_offset = committee_index.safe_div(committees_per_slot)?;
-                let slot = epoch_start.safe_add(slot_offset as u64)?;
-                if val_idx < validator_count {
-                    let idx = val_idx.safe_mul(NUM_EPOCH_COLUMNS)?.safe_add(col)?;
-                    *new_slots.get_mut(idx).ok_or(Error::IndexOutOfBounds(idx))? = slot;
-                }
-            }
-        }
-
-        Ok(Self {
-            slots: new_slots,
-            dependent_root,
-        })
+        let mut assignments = Self {
+            cache: HashMap::new(),
+            window: std::array::from_fn(|_| (None, Slot::new(0))),
+            dependent_root: Hash256::ZERO,
+        };
+        assignments.rebuild(state)?;
+        Ok(assignments)
     }
 
-    /// Shuffling decision root this table was built for.
+    /// Refresh the window for `state`'s current epoch, fetching only shufflings not already held.
+    pub(crate) fn rebuild<E: EthSpec>(&mut self, state: &BeaconState<E>) -> Result<(), Error> {
+        let spe = E::slots_per_epoch();
+        let current = state.current_epoch();
+
+        // The previous/current shufflings have readable dependent roots; cache them for reuse.
+        for relative in [RelativeEpoch::Previous, RelativeEpoch::Current] {
+            let root = crate::dependent_root::<E>(state, relative.into_epoch(current))?;
+            if let Entry::Vacant(entry) = self.cache.entry(root) {
+                entry.insert(committee_cache(state, relative)?);
+            }
+        }
+        // The next epoch's decision root isn't readable yet, so fetch it fresh each rebuild.
+        let next = committee_cache(state, RelativeEpoch::Next)?;
+
+        let mut window: [(Option<Arc<CommitteeCache>>, Slot); WINDOW] =
+            std::array::from_fn(|_| (None, Slot::new(0)));
+        let mut live = HashSet::new();
+        for (slot, epoch) in window.iter_mut().zip([
+            current.saturating_sub(Epoch::new(2)),
+            current.saturating_sub(Epoch::new(1)),
+            current,
+        ]) {
+            let root = crate::dependent_root::<E>(state, epoch)?;
+            live.insert(root);
+            *slot = (self.cache.get(&root).cloned(), epoch.start_slot(spe));
+        }
+        window[WINDOW - 1] = (Some(next), current.safe_add(1)?.start_slot(spe));
+
+        self.window = window;
+        self.dependent_root = crate::dependent_root::<E>(state, current)?;
+        self.cache.retain(|root, _| live.contains(root));
+        Ok(())
+    }
+
     pub(crate) fn dependent_root(&self) -> Hash256 {
         self.dependent_root
     }
 
-    /// Get the assigned slot for a validator in a given column (0, 1, or 2).
-    fn get(&self, val_idx: usize, col: usize) -> Option<Slot> {
-        let idx = val_idx
-            .safe_mul(NUM_EPOCH_COLUMNS)
-            .ok()?
-            .safe_add(col)
-            .ok()?;
-        self.slots.get(idx).copied()
-    }
-
-    /// Check if a validator is assigned to any committee in the slot range `[start, end]`.
-    ///
-    /// Iterates over all 3 epoch columns and returns `true` if any assigned slot
-    /// falls within the range (inclusive). Columns with no assignment (`UNSET_SLOT`,
-    /// or an out-of-range index) are treated as "not in range".
+    /// True if `val_idx` attests in any window epoch at a slot within `[start, end]`.
     pub(crate) fn is_in_range(
         &self,
         val_idx: usize,
-        start_slot: Slot,
-        end_slot: Slot,
+        start: Slot,
+        end: Slot,
     ) -> Result<bool, Error> {
-        for col in 0..NUM_EPOCH_COLUMNS {
-            let Some(slot) = self.get(val_idx, col) else {
-                continue;
-            };
-            if slot == UNSET_SLOT {
-                continue;
-            }
-            if slot >= start_slot && slot <= end_slot {
+        for (cache, epoch_start) in &self.window {
+            let Some(cache) = cache else { continue };
+            if assigned_slot(cache, *epoch_start, val_idx)?
+                .is_some_and(|slot| slot >= start && slot <= end)
+            {
                 return Ok(true);
             }
         }
@@ -144,51 +93,72 @@ impl SlotAssignments {
     }
 }
 
+fn committee_cache<E: EthSpec>(
+    state: &BeaconState<E>,
+    relative: RelativeEpoch,
+) -> Result<Arc<CommitteeCache>, Error> {
+    Ok(state
+        .committee_cache(relative)
+        .map_err(|e| Error::CommitteeCacheUninitialized(format!("{e:?}")))?
+        .clone())
+}
+
+/// The committee slot `val_idx` attests in for `cache`'s epoch, or `None` if it has no duty.
+/// Inverts the spec's `compute_committee` position ranges: the committee for shuffled position `p`
+/// is `(p * count + count - 1) / len`, mapped to a slot via `committees_per_slot`.
+fn assigned_slot(
+    cache: &CommitteeCache,
+    epoch_start: Slot,
+    val_idx: usize,
+) -> Result<Option<Slot>, Error> {
+    let Some(position) = cache.shuffled_position(val_idx) else {
+        return Ok(None);
+    };
+    let total = cache.epoch_committee_count()?;
+    let committee = position
+        .safe_mul(total)?
+        .safe_add(total.safe_sub(1)?)?
+        .safe_div(cache.active_validator_count())?;
+    let offset = committee.safe_div(cache.committees_per_slot() as usize)?;
+    Ok(Some(epoch_start.safe_add(offset as u64)?))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use state_processing::per_slot_processing;
-    use types::{Epoch, MinimalEthSpec};
+    use types::{MinimalEthSpec, Validator};
 
     type E = MinimalEthSpec;
 
-    /// Build a minimal genesis state with `n` validators and committee caches.
-    /// Uses BeaconState::new directly with manually-added validators to avoid
-    /// needing deposit proofs.
     fn genesis_state(n: usize) -> (BeaconState<E>, types::ChainSpec) {
         let spec = E::default_spec();
         let mut state = BeaconState::new(0, Default::default(), &spec);
-
-        // Manually populate validators and balances.
         for _ in 0..n {
-            let validator = types::Validator {
-                effective_balance: spec.max_effective_balance,
-                activation_epoch: Epoch::new(0),
-                exit_epoch: spec.far_future_epoch,
-                withdrawable_epoch: spec.far_future_epoch,
-                ..Default::default()
-            };
             state
                 .validators_mut()
-                .push(validator)
+                .push(Validator {
+                    effective_balance: spec.max_effective_balance,
+                    activation_epoch: Epoch::new(0),
+                    exit_epoch: spec.far_future_epoch,
+                    withdrawable_epoch: spec.far_future_epoch,
+                    ..Default::default()
+                })
                 .expect("push validator");
             state
                 .balances_mut()
                 .push(spec.max_effective_balance)
                 .expect("push balance");
         }
-
         state
             .build_all_committee_caches(&spec)
             .expect("committee caches");
-
         (state, spec)
     }
 
-    /// Advance a state to a given slot, rebuilding committee caches.
-    fn advance_state(state: &mut BeaconState<E>, target_slot: Slot, spec: &types::ChainSpec) {
-        while state.slot() < target_slot {
-            per_slot_processing(state, None, spec).expect("should advance slot");
+    fn advance_state(state: &mut BeaconState<E>, target: Slot, spec: &types::ChainSpec) {
+        while state.slot() < target {
+            per_slot_processing(state, None, spec).expect("advance slot");
         }
         state
             .build_all_committee_caches(spec)
@@ -197,71 +167,34 @@ mod tests {
 
     #[test]
     fn builds_from_genesis_state() {
-        let (state, _spec) = genesis_state(64);
+        let (state, _) = genesis_state(64);
         SlotAssignments::new::<E>(&state).expect("builds from genesis state");
     }
 
     #[test]
-    fn rebuild_populates_assignments_for_correct_epochs() {
+    fn every_validator_attests_once_in_current_epoch() {
         let (mut state, spec) = genesis_state(64);
-
-        // Advance state to epoch 2.
-        let epoch_2_start = E::slots_per_epoch() * 2;
-        advance_state(&mut state, Slot::new(epoch_2_start), &spec);
-
-        let sa = SlotAssignments::new::<E>(&state).expect("build should succeed");
-
-        // Every validator should have an assignment in at least the current epoch.
-        let validator_count = state.validators().len();
         let spe = E::slots_per_epoch();
-        for val_idx in 0..validator_count {
-            // Check current epoch column (col 1 = epoch 2).
-            let slot = sa.get(val_idx, 1).expect("valid index");
-            assert_ne!(
-                slot, UNSET_SLOT,
+        let start = Slot::new(spe * 2);
+        advance_state(&mut state, start, &spec);
+        let sa = SlotAssignments::new::<E>(&state).expect("build");
+
+        let end = Slot::new(spe * 2 + spe - 1);
+        for val_idx in 0..state.validators().len() {
+            assert!(
+                sa.is_in_range(val_idx, start, end).unwrap(),
                 "validator {val_idx} missing epoch 2 assignment"
             );
-            // Assignment slot must be within epoch 2.
-            let epoch_2_end = epoch_2_start + spe - 1;
-            assert!(
-                slot.as_u64() >= epoch_2_start && slot.as_u64() <= epoch_2_end,
-                "validator {val_idx} assigned to slot {} which is not in epoch 2 [{epoch_2_start}, {epoch_2_end}]",
-                slot
-            );
         }
-
-        // Slots in epoch 2 should be findable via is_in_range.
-        let mid_epoch_2 = Slot::new(epoch_2_start + spe / 2);
-        let mut found_any = false;
-        for val_idx in 0..validator_count {
-            if sa
-                .is_in_range(val_idx, Slot::new(epoch_2_start), mid_epoch_2)
-                .unwrap()
-            {
-                found_any = true;
-                break;
-            }
-        }
-        assert!(
-            found_any,
-            "at least one validator should be assigned in first half of epoch 2"
-        );
     }
 
     #[test]
     fn is_in_range_returns_false_for_uncovered_epochs() {
-        let (state, _spec) = genesis_state(64);
-
-        // State at epoch 0, covers epochs [0, 0, 1].
-        let sa = SlotAssignments::new::<E>(&state).expect("should build");
-
-        // Query for a slot in epoch 5 — no validator should match.
-        let far_slot = Slot::new(E::slots_per_epoch() * 5);
+        let (state, _) = genesis_state(64);
+        let sa = SlotAssignments::new::<E>(&state).expect("build");
+        let far = Slot::new(E::slots_per_epoch() * 5);
         for val_idx in 0..state.validators().len() {
-            assert!(
-                !sa.is_in_range(val_idx, far_slot, far_slot).unwrap(),
-                "validator {val_idx} should NOT be in range for epoch 5"
-            );
+            assert!(!sa.is_in_range(val_idx, far, far).unwrap());
         }
     }
 }


### PR DESCRIPTION
Drops the precomputed per-validator `SlotAssignments` table. `is_in_range` now resolves a
validator's committee slot on demand from the committee-cache shufflings the state already holds.

## What changed
- Covers the `[current-2 ..= current]` epoch window (adds `current-2` for spec alignment).
- Shufflings are held by attester shuffling ID. A rebuild reuses those already cached.
- `is_in_range` computes the slot per query (`shuffled_position` + committee-index inversion).

## Trade-off
- Removes the per-epoch `O(V)` table build and ~24 MB resident at 1M validators; the shuffling data
  is shared with the state via `Arc`.
- The per-query cost is higher (two integer divisions vs a table read), but `is_in_range` is off
  the hot path: it only runs on the empty-slot support path (`get_block_support_between_slots`),
  which a dense chain skips entirely.

## Bench

Adds `get_latest_confirmed_empty_slots` to `fcr_bench`, which forces the empty-slot path (a missed
slot at the confirmation frontier) so `is_in_range` runs over the full committee-cached validator
set — the only path where these assignments are read.
