### PR TITLE
Alternative fix for the checkpoint state problem

### DIFF
--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -908,6 +908,7 @@ where
             Arc::new(head_snapshot),
             head_payload_status,
             self.chain_config.fast_confirmation,
+            &store,
             &self.spec,
         )
         .map_err(|e| format!("Unable to initialize canonical head: {e}"))?;

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1003,7 +1003,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // The current head's pulled-up state (spec `get_pulled_up_head_state`). FCR errors
         // must never affect consensus, so on failure we log and skip it this tick.
-        let (state_root, mut state) =
+        let (state_root, mut head_state) =
             match store.get_advanced_hot_state(head_root, current_slot, head_state_root) {
                 Ok(Some(state)) => state,
                 Ok(None) => {
@@ -1021,20 +1021,26 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // A previous-epoch head is pulled up to the current epoch boundary; a current-epoch
         // head is already pulled up, so leave it as-is.
         let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
-        if state.current_epoch() < current_epoch {
+        if head_state.current_epoch() < current_epoch {
             let epoch_start = current_epoch.start_slot(T::EthSpec::slots_per_epoch());
-            complete_state_advance(&mut state, Some(state_root), epoch_start, &store.spec)
+            complete_state_advance(&mut head_state, Some(state_root), epoch_start, &store.spec)
                 .map_err(|e| {
                     FastConfirmationError::UnableToObtainHeadState(format!(
                         "Error advancing head state: {e:?}"
                     ))
                 })?;
         }
-        state.build_all_caches(&store.spec).map_err(|e| {
+        head_state.build_all_caches(&store.spec).map_err(|e| {
             FastConfirmationError::UnableToObtainHeadState(format!(
                 "Error building head caches: {e:?}"
             ))
         })?;
+
+        // Load the checkpoint state if it will be required.
+        let checkpoint_state = fcr
+            .checkpoint_state_needed::<T::EthSpec>(current_slot)
+            .map(|checkpoint| Self::load_fcr_checkpoint_state(store, checkpoint))
+            .transpose()?;
 
         let old_update_slot = fcr.last_update_slot();
         fcr.on_fast_confirmation::<T::EthSpec>(
@@ -1045,7 +1051,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             proto_array,
             votes,
             equivocating_indices,
-            &state,
+            &head_state,
+            checkpoint_state.as_ref(),
         )?;
 
         let confirmed_node = fork_choice
@@ -1069,6 +1076,40 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             new_confirmed_root: fcr.confirmed_root != old_confirmed_root,
             new_update_slot: fcr.last_update_slot() != old_update_slot,
         })
+    }
+
+    /// Load the state for `checkpoint` (spec: `store.checkpoint_states[checkpoint]`) — the
+    /// checkpoint block's post-state advanced to the first slot of `checkpoint.epoch`.
+    ///
+    /// No caches are built: FCR only iterates the validator set and reads `block_roots`
+    /// from this state.
+    fn load_fcr_checkpoint_state(
+        store: &BeaconStore<T>,
+        checkpoint: Checkpoint,
+    ) -> Result<BeaconState<T::EthSpec>, FastConfirmationError> {
+        let block = store
+            .get_blinded_block(&checkpoint.root)
+            .map_err(|e| FastConfirmationError::UnableToObtainCheckpointState(format!("{e:?}")))?
+            .ok_or(FastConfirmationError::CheckpointBlockNotFound {
+                block: checkpoint.root,
+                epoch: checkpoint.epoch,
+            })?;
+        let target_slot = checkpoint.epoch.start_slot(T::EthSpec::slots_per_epoch());
+        let (state_root, mut state) = store
+            .get_advanced_hot_state(checkpoint.root, target_slot, block.state_root())
+            .map_err(|e| FastConfirmationError::UnableToObtainCheckpointState(format!("{e:?}")))?
+            .ok_or_else(|| {
+                FastConfirmationError::UnableToObtainCheckpointState("not found".to_owned())
+            })?;
+        if state.slot() < target_slot {
+            complete_state_advance(&mut state, Some(state_root), target_slot, &store.spec)
+                .map_err(|e| {
+                    FastConfirmationError::UnableToObtainCheckpointState(format!(
+                        "Error advancing checkpoint state: {e:?}"
+                    ))
+                })?;
+        }
+        Ok(state)
     }
 
     /// Perform updates to caches and other components after the canonical head has been changed.

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -301,6 +301,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         snapshot: Arc<BeaconSnapshot<T::EthSpec>>,
         head_payload_status: proto_array::PayloadStatus,
         fast_confirmation: FastConfirmationMode,
+        store: &BeaconStore<T>,
         spec: &ChainSpec,
     ) -> Result<Self, String> {
         let fork_choice_view = fork_choice.cached_fork_choice_view();
@@ -308,11 +309,11 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
 
         let fcr = if fast_confirmation.is_enabled() {
             Some(Mutex::new(
-                FastConfirmationRule::new(
+                <BeaconChain<T>>::new_fast_confirmation_rule(
                     fork_choice_view.finalized_checkpoint,
-                    &snapshot.beacon_state,
-                    spec.confirmation_byzantine_threshold,
-                    spec.proposer_score_boost,
+                    &snapshot,
+                    store,
+                    spec,
                 )
                 .map_err(|e| format!("Unable to initialize fast confirmation rule: {e:?}"))?,
             ))
@@ -403,11 +404,11 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
 
         // Reset FCR to the restored finalized checkpoint so it doesn't carry stale state.
         if let Some(ref fcr_mutex) = self.fast_confirmation {
-            *fcr_mutex.lock() = FastConfirmationRule::new(
+            *fcr_mutex.lock() = <BeaconChain<T>>::new_fast_confirmation_rule(
                 fork_choice_view.finalized_checkpoint,
-                &self.cached_head.read().snapshot.beacon_state,
-                spec.confirmation_byzantine_threshold,
-                spec.proposer_score_boost,
+                &self.cached_head.read().snapshot,
+                store,
+                spec,
             )
             .map_err(|e| Error::DBInconsistent(format!("fast confirmation rule reset: {e:?}")))?;
         }
@@ -1076,6 +1077,43 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             new_confirmed_root: fcr.confirmed_root != old_confirmed_root,
             new_update_slot: fcr.last_update_slot() != old_update_slot,
         })
+    }
+
+    /// Build a `FastConfirmationRule` seeded from `finalized_checkpoint`, sourcing its balance
+    /// snapshots from the finalized checkpoint's state (spec: `store.checkpoint_states[checkpoint]`)
+    /// and its head-derived caches from the `snapshot` state.
+    ///
+    /// When the head snapshot *is* the checkpoint state — same block root, state at the first slot
+    /// of the checkpoint's epoch, as at genesis or checkpoint-sync startup — it is reused directly;
+    /// otherwise the checkpoint state is loaded from the `store`.
+    fn new_fast_confirmation_rule(
+        finalized_checkpoint: Checkpoint,
+        snapshot: &BeaconSnapshot<T::EthSpec>,
+        store: &BeaconStore<T>,
+        spec: &ChainSpec,
+    ) -> Result<FastConfirmationRule, FastConfirmationError> {
+        let target_slot = finalized_checkpoint
+            .epoch
+            .start_slot(T::EthSpec::slots_per_epoch());
+        let snapshot_is_checkpoint_state = snapshot.beacon_block_root == finalized_checkpoint.root
+            && snapshot.beacon_state.slot() == target_slot;
+        let loaded_checkpoint_state = if snapshot_is_checkpoint_state {
+            None
+        } else {
+            Some(Self::load_fcr_checkpoint_state(
+                store,
+                finalized_checkpoint,
+            )?)
+        };
+        FastConfirmationRule::new(
+            finalized_checkpoint,
+            loaded_checkpoint_state
+                .as_ref()
+                .unwrap_or(&snapshot.beacon_state),
+            &snapshot.beacon_state,
+            spec.confirmation_byzantine_threshold,
+            spec.proposer_score_boost,
+        )
     }
 
     /// Load the state for `checkpoint` (spec: `store.checkpoint_states[checkpoint]`) — the

--- a/beacon_node/beacon_chain/src/payload_bid_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/payload_bid_verification/tests.rs
@@ -153,6 +153,7 @@ impl TestContext {
             Arc::new(snapshot),
             PayloadStatus::Pending,
             FastConfirmationMode::Disabled,
+            &store,
             &spec,
         )
         .unwrap();

--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
@@ -102,6 +102,7 @@ impl TestContext {
             Arc::new(snapshot),
             PayloadStatus::Pending,
             FastConfirmationMode::Disabled,
+            &store,
             &spec,
         )
         .unwrap();

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -258,7 +258,7 @@ fn build_chain(num_validators: usize) -> BenchData {
     seed_state
         .build_all_committee_caches(&spec)
         .expect("committee caches");
-    let mut fcr = FastConfirmationRule::new(finalized_checkpoint, &seed_state, 25, 40)
+    let mut fcr = FastConfirmationRule::new(finalized_checkpoint, &seed_state, &seed_state, 25, 40)
         .expect("fcr initialization");
     fcr.test_set_head_balance_source(balance_source.clone());
 

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -157,33 +157,47 @@ impl FastConfirmationRule {
     /// Maximum valid value for `byzantine_threshold` (25%).
     const MAX_BYZANTINE_THRESHOLD: u64 = 25;
 
-    /// Initialize FCR from the finalized checkpoint and head `state`, building the balance sources
-    /// and committee assignments up front (each tagged with its own dependent root derived from the
-    /// state). `byzantine_threshold` is clamped to [0, 25].
+    /// Initialize FCR from the finalized checkpoint, its checkpoint state and the head state,
+    /// building the balance sources and committee assignments up front (each tagged with its own
+    /// dependent root derived from the state). The spec seeds both observed-justified checkpoints
+    /// with the finalized checkpoint, so both balance sources come from `checkpoint_state`
+    /// (spec: `store.checkpoint_states[finalized_checkpoint]`); the head-derived caches come from
+    /// `head_state`. `byzantine_threshold` is clamped to [0, 25].
     pub fn new<E: EthSpec>(
         finalized_checkpoint: Checkpoint,
-        state: &BeaconState<E>,
+        checkpoint_state: &BeaconState<E>,
+        head_state: &BeaconState<E>,
         byzantine_threshold: u64,
         proposer_score_boost: u64,
     ) -> Result<Self, Error> {
         let byzantine_threshold = byzantine_threshold.min(Self::MAX_BYZANTINE_THRESHOLD);
+        // Sanity: the supplied state must be the checkpoint's state, advanced to the
+        // checkpoint's epoch.
+        if checkpoint_state.current_epoch() != finalized_checkpoint.epoch {
+            return Err(Error::MissingCheckpointState(finalized_checkpoint));
+        }
+        let checkpoint_balance =
+            BalanceSourceData::for_epoch(checkpoint_state, finalized_checkpoint.epoch)?;
         Ok(Self {
             confirmed_root: finalized_checkpoint.root,
             previous_epoch_observed_justified: CheckpointAndBalance::new(
                 finalized_checkpoint,
-                BalanceSourceData::for_epoch(state, state.previous_epoch())?,
+                checkpoint_balance.clone(),
             ),
             current_epoch_observed_justified: CheckpointAndBalance::new(
                 finalized_checkpoint,
-                BalanceSourceData::for_epoch(state, state.current_epoch())?,
+                checkpoint_balance,
             ),
             previous_epoch_greatest_unrealized_checkpoint: finalized_checkpoint,
             previous_slot_head: finalized_checkpoint.root,
             current_slot_head: finalized_checkpoint.root,
             byzantine_threshold,
             proposer_score_boost,
-            slot_assignments: SlotAssignments::new(state)?,
-            head_balance_source: BalanceSourceData::for_epoch(state, state.current_epoch())?,
+            slot_assignments: SlotAssignments::new(head_state)?,
+            head_balance_source: BalanceSourceData::for_epoch(
+                head_state,
+                head_state.current_epoch(),
+            )?,
             last_update_slot: None,
             spec_test_mode: false,
         })

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -60,6 +60,8 @@ pub enum Error {
     NodeHasNoBlockHash(Hash256),
     ParentRootNotFound(Hash256),
     UnableToObtainHeadState(String),
+    UnableToObtainCheckpointState(String),
+    MissingCheckpointState(Checkpoint),
     AncestorNotFound { block: Hash256, slot: Slot },
     UnrealizedJustificationNotFound(Hash256),
     CheckpointBlockNotFound { block: Hash256, epoch: types::Epoch },
@@ -202,8 +204,12 @@ impl FastConfirmationRule {
     /// Top-level entry point. Spec: `on_fast_confirmation(fcr_store)`.
     ///
     /// Called after head selection, while the fork-choice read lock is held.
-    /// All parameters are borrowed from fork choice. The `state` is used to
-    /// rebuild balance sources when observed justified checkpoints change.
+    /// All parameters are borrowed from fork choice. The `head_state` is used to
+    /// rebuild the head balance source and committee assignments; `checkpoint_state`
+    /// backs the observed-justified balance source at the epoch-boundary rotation
+    /// (spec: `store.checkpoint_states[checkpoint]`). Callers should obtain the
+    /// required checkpoint via `checkpoint_state_needed` and may pass `None` when
+    /// it returns `None`.
     #[allow(clippy::too_many_arguments)]
     pub fn on_fast_confirmation<E: EthSpec>(
         &mut self,
@@ -214,7 +220,8 @@ impl FastConfirmationRule {
         proto_array: &ProtoArray,
         votes: &[VoteTracker],
         equivocating_indices: &BTreeSet<u64>,
-        state: &BeaconState<E>,
+        head_state: &BeaconState<E>,
+        checkpoint_state: Option<&BeaconState<E>>,
     ) -> Result<(), Error> {
         let _span = debug_span!("fcr_on_fast_confirmation", slot = %current_slot).entered();
 
@@ -222,7 +229,8 @@ impl FastConfirmationRule {
             head_root,
             unrealized_justified_checkpoint,
             current_slot,
-            state,
+            head_state,
+            checkpoint_state,
         )?;
 
         if !self.spec_test_mode {
@@ -247,6 +255,25 @@ impl FastConfirmationRule {
         self.last_update_slot
     }
 
+    /// True iff `update_fast_confirmation_variables` will rotate the observed-justified
+    /// checkpoint pairs when run at `current_slot` (once per slot, at the first slot of an
+    /// epoch).
+    fn will_rotate<E: EthSpec>(&self, current_slot: Slot) -> bool {
+        self.last_update_slot.is_none_or(|s| current_slot > s)
+            && is_start_slot_at_epoch::<E>(current_slot)
+    }
+
+    /// The checkpoint whose state (spec: `store.checkpoint_states[checkpoint]`) must be
+    /// supplied to `on_fast_confirmation` at `current_slot`, or `None` if no state is
+    /// required — either no rotation happens this slot, or the rotating checkpoint is
+    /// unchanged so its existing balance snapshot is reused.
+    pub fn checkpoint_state_needed<E: EthSpec>(&self, current_slot: Slot) -> Option<Checkpoint> {
+        (self.will_rotate::<E>(current_slot)
+            && self.previous_epoch_greatest_unrealized_checkpoint
+                != self.current_epoch_observed_justified.checkpoint())
+        .then_some(self.previous_epoch_greatest_unrealized_checkpoint)
+    }
+
     /// Spec: `get_previous_balance_source`.
     fn get_previous_balance_source(&self) -> &BalanceSourceData {
         self.previous_epoch_observed_justified.balances()
@@ -263,7 +290,8 @@ impl FastConfirmationRule {
         head_root: Hash256,
         unrealized_justified_checkpoint: &Checkpoint,
         current_slot: Slot,
-        state: &BeaconState<E>,
+        head_state: &BeaconState<E>,
+        checkpoint_state: Option<&BeaconState<E>>,
     ) -> Result<(), Error> {
         let _span = debug_span!("fcr_update_variables", slot = %current_slot).entered();
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
@@ -272,16 +300,16 @@ impl FastConfirmationRule {
         // late block or reorg). Each cache is keyed on the head's dependent root; rebuild it from
         // scratch, independently, when its own dependent root is stale (a reorg past the
         // previous-epoch boundary, or a new epoch).
-        let head_dependent_root = dependent_root::<E>(state, current_epoch)?;
+        let head_dependent_root = dependent_root::<E>(head_state, current_epoch)?;
 
         if self.slot_assignments.dependent_root() != head_dependent_root {
             let _span = debug_span!("fcr_rebuild_assignments").entered();
-            self.slot_assignments = SlotAssignments::new::<E>(state)?;
+            self.slot_assignments = SlotAssignments::new::<E>(head_state)?;
         }
 
         if self.head_balance_source.dependent_root != head_dependent_root {
             let _span = debug_span!("fcr_rebuild_head_balance").entered();
-            self.head_balance_source = BalanceSourceData::for_epoch(state, current_epoch)?;
+            self.head_balance_source = BalanceSourceData::for_epoch(head_state, current_epoch)?;
         }
 
         // Spec: update_fast_confirmation_variables must be called at most once per slot.
@@ -297,14 +325,29 @@ impl FastConfirmationRule {
             }
 
             // At first slot of epoch: rotate the (checkpoint, balances) pairs. `previous` takes
-            // `current`'s snapshot (spec-equal, no O(V) re-derive); `current` is rebuilt for the new
-            // checkpoint in one step so the pair stays coherent.
-            if is_start_slot_at_epoch::<E>(current_slot) {
+            // `current`'s snapshot (spec-equal, no O(V) re-derive); `current` is rebuilt in one
+            // step so the pair stays coherent, with balances from the new checkpoint's state
+            // (spec: `store.checkpoint_states[checkpoint]`) evaluated at the checkpoint's epoch.
+            // The first conjunct of `will_rotate` is always true inside the once-per-slot guard.
+            if self.will_rotate::<E>(current_slot) {
                 let new_current_cp = self.previous_epoch_greatest_unrealized_checkpoint;
-                let new_current = CheckpointAndBalance::new(new_current_cp, {
-                    let _span = debug_span!("fcr_rebuild_current_balance").entered();
-                    BalanceSourceData::for_epoch(state, current_epoch)?
-                });
+                let new_current =
+                    if new_current_cp == self.current_epoch_observed_justified.checkpoint() {
+                        // Same checkpoint keys the same `checkpoint_states` entry — reuse the snapshot.
+                        self.current_epoch_observed_justified.clone()
+                    } else {
+                        let checkpoint_state = checkpoint_state
+                            .ok_or(Error::MissingCheckpointState(new_current_cp))?;
+                        // Sanity: the supplied state must be the checkpoint's state, advanced to the
+                        // checkpoint's epoch.
+                        if checkpoint_state.current_epoch() != new_current_cp.epoch {
+                            return Err(Error::MissingCheckpointState(new_current_cp));
+                        }
+                        CheckpointAndBalance::new(new_current_cp, {
+                            let _span = debug_span!("fcr_rebuild_current_balance").entered();
+                            BalanceSourceData::for_epoch(checkpoint_state, new_current_cp.epoch)?
+                        })
+                    };
                 self.previous_epoch_observed_justified =
                     std::mem::replace(&mut self.current_epoch_observed_justified, new_current);
             }


### PR DESCRIPTION
This PR tries to fix the checkpoint state problem comprehensively and without introducing a new trait.

I wrote this with Fable, reviewed and tweaked. I think this is a bit cleaner than the trait approach, and it also handles initialisation properly (the other branch approximated by always using the head state).