### PR TITLE
Fix balance source data key

### DIFF
--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1111,6 +1111,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .as_ref()
                 .unwrap_or(&snapshot.beacon_state),
             &snapshot.beacon_state,
+            snapshot.beacon_block_root,
             spec.confirmation_byzantine_threshold,
             spec.proposer_score_boost,
         )

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1106,12 +1106,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             )?)
         };
         FastConfirmationRule::new(
+            snapshot.beacon_block_root,
+            &snapshot.beacon_state,
             finalized_checkpoint,
             loaded_checkpoint_state
                 .as_ref()
                 .unwrap_or(&snapshot.beacon_state),
-            &snapshot.beacon_state,
-            snapshot.beacon_block_root,
             spec.confirmation_byzantine_threshold,
             spec.proposer_score_boost,
         )

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -263,10 +263,10 @@ fn build_chain(num_validators: usize) -> BenchData {
         .build_all_committee_caches(&spec)
         .expect("committee caches");
     let mut fcr = FastConfirmationRule::new(
+        finalized_checkpoint.root,
+        &seed_state,
         finalized_checkpoint,
         &seed_state,
-        &seed_state,
-        finalized_checkpoint.root,
         25,
         40,
     )

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -13,7 +13,9 @@ use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use ethereum_hashing::hash_fixed;
-use fast_confirmation::{BalanceSourceData, CheckpointAndBalance, FastConfirmationRule};
+use fast_confirmation::{
+    BalanceSourceData, BalanceSourceKey, CheckpointAndBalance, FastConfirmationRule,
+};
 use fixed_bytes::FixedBytesExtended;
 use proto_array::core::{ProtoArray, VoteTracker};
 use proto_array::{Block, ExecutionStatus, JustifiedBalances, ProtoArrayForkChoice};
@@ -229,7 +231,9 @@ fn build_chain(num_validators: usize) -> BenchData {
 
     let total_active_balance = BALANCE.saturating_mul(num_validators as u64);
     let balance_source = BalanceSourceData {
-        dependent_root: observed_justified_checkpoint.root,
+        key: BalanceSourceKey::NoSlashings {
+            epoch_boundary_root: observed_justified_checkpoint.root,
+        },
         total_active_balance,
         effective_balances: vec![BALANCE; num_validators],
         slashed: vec![false; num_validators],
@@ -258,8 +262,15 @@ fn build_chain(num_validators: usize) -> BenchData {
     seed_state
         .build_all_committee_caches(&spec)
         .expect("committee caches");
-    let mut fcr = FastConfirmationRule::new(finalized_checkpoint, &seed_state, &seed_state, 25, 40)
-        .expect("fcr initialization");
+    let mut fcr = FastConfirmationRule::new(
+        finalized_checkpoint,
+        &seed_state,
+        &seed_state,
+        finalized_checkpoint.root,
+        25,
+        40,
+    )
+    .expect("fcr initialization");
     fcr.test_set_head_balance_source(balance_source.clone());
 
     BenchData {

--- a/consensus/fast_confirmation/src/balance_source.rs
+++ b/consensus/fast_confirmation/src/balance_source.rs
@@ -1,33 +1,30 @@
 //! Validator-balance snapshot used by the Fast Confirmation Rule.
 
 use crate::Error;
-use types::{BeaconState, Epoch, EthSpec, Hash256};
+use safe_arith::SafeArith;
+use types::{BeaconState, EthSpec, Hash256};
 
-/// Cache key identifying the validator-set view a [`BalanceSourceData`] was built from.
+/// Cache key identifying the validator-set view a `BalanceSourceData` was built from.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BalanceSourceKey {
     /// No slashings have been processed in the epoch (`state.slashings[epoch % E] == 0`): the
-    /// epoch's dependent root (block at the last slot of the previous epoch) pins the effective
+    /// epoch's boundary root (block at the last slot of the previous epoch) pins the effective
     /// balances, activation set and slashed flags for the whole epoch.
     NoSlashings { epoch_boundary_root: Hash256 },
     /// At least one slashing has been processed in the epoch. Slashings flip `Validator.slashed`
-    /// mid-epoch without moving the dependent root, so the snapshot is keyed on its own block
-    /// root instead and every head change rebuilds it for the rest of the epoch (cf. the
-    /// unrealized-checkpoints fix in sigp/lighthouse#9471). A further slashing can only arrive
-    /// via a new block, so the block root also distinguishes different slashing sets.
+    /// mid-epoch without moving the epoch boundary root, so the snapshot is keyed on its own block
+    /// root instead and every head change rebuilds it for the rest of the epoch.
     SlashingsPresent { head_block_root: Hash256 },
 }
 
 impl BalanceSourceKey {
-    /// `block_root` is the root of the block the snapshot's `state` descends from (the head
-    /// root for the head source; the checkpoint root for checkpoint sources).
+    /// Create a key for a specific `block_root` and its state.
     pub(crate) fn compute<E: EthSpec>(
         state: &BeaconState<E>,
-        epoch: Epoch,
         block_root: Hash256,
     ) -> Result<Self, Error> {
         let epoch_slashings = state
-            .get_slashings(epoch)
+            .get_slashings(state.current_epoch())
             .map_err(|e| Error::SlashingsOutOfBounds(format!("slashings lookup: {e:?}")))?;
         if epoch_slashings > 0 {
             Ok(Self::SlashingsPresent {
@@ -35,7 +32,7 @@ impl BalanceSourceKey {
             })
         } else {
             Ok(Self::NoSlashings {
-                epoch_boundary_root: crate::dependent_root::<E>(state, epoch)?,
+                epoch_boundary_root: get_epoch_boundary_root::<E>(state)?,
             })
         }
     }
@@ -57,18 +54,15 @@ pub struct BalanceSourceData {
 }
 
 impl BalanceSourceData {
-    /// Build a balance source for a single `epoch` in one pass over the validator set, tagged with
-    /// its [`BalanceSourceKey`] (computed from `state`, `epoch` and `block_root`). Effective
-    /// balance is counted for active validators regardless of slashed status (matching the spec's
-    /// `get_total_active_balance`); `slashed` is recorded separately for the slashed-filtering
-    /// used by `get_block_support_between_slots`. The total uses a saturating add — it is a sum
-    /// of effective balances and cannot realistically overflow.
-    pub(crate) fn for_epoch<E: EthSpec>(
+    /// Create a balance source for `state` at its current epoch.
+    ///
+    /// The state must be pulled up to the desired epoch prior to calling this function.
+    pub(crate) fn new<E: EthSpec>(
         state: &BeaconState<E>,
-        epoch: Epoch,
         block_root: Hash256,
     ) -> Result<Self, Error> {
-        let key = BalanceSourceKey::compute(state, epoch, block_root)?;
+        let current_epoch = state.current_epoch();
+        let key = BalanceSourceKey::compute(state, block_root)?;
         let validators = state.validators();
         let mut effective_balances = Vec::with_capacity(validators.len());
         let mut slashed = Vec::with_capacity(validators.len());
@@ -76,7 +70,7 @@ impl BalanceSourceData {
 
         for validator in validators.iter() {
             slashed.push(validator.slashed);
-            if validator.is_active_at(epoch) {
+            if validator.is_active_at(current_epoch) {
                 effective_balances.push(validator.effective_balance);
                 total_active_balance =
                     total_active_balance.saturating_add(validator.effective_balance);
@@ -117,4 +111,21 @@ impl BalanceSourceData {
             self.balance(val_idx)
         }
     }
+}
+
+/// Block root at the last slot of the previous epoch.
+///
+/// Used to identify the balance source fields of the `validator` registry in the absence of
+/// slashings.
+fn get_epoch_boundary_root<E: EthSpec>(state: &BeaconState<E>) -> Result<Hash256, Error> {
+    if state.current_epoch() == 0 {
+        return Ok(Hash256::ZERO);
+    }
+    let slot = state
+        .current_epoch()
+        .start_slot(E::slots_per_epoch())
+        .safe_sub(1)?;
+    Ok(*state
+        .get_block_root(slot)
+        .map_err(|e| Error::BlockRootsOutOfBounds(format!("{e:?}")))?)
 }

--- a/consensus/fast_confirmation/src/balance_source.rs
+++ b/consensus/fast_confirmation/src/balance_source.rs
@@ -3,13 +3,51 @@
 use crate::Error;
 use types::{BeaconState, Epoch, EthSpec, Hash256};
 
+/// Cache key identifying the validator-set view a [`BalanceSourceData`] was built from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BalanceSourceKey {
+    /// No slashings have been processed in the epoch (`state.slashings[epoch % E] == 0`): the
+    /// epoch's dependent root (block at the last slot of the previous epoch) pins the effective
+    /// balances, activation set and slashed flags for the whole epoch.
+    NoSlashings { epoch_boundary_root: Hash256 },
+    /// At least one slashing has been processed in the epoch. Slashings flip `Validator.slashed`
+    /// mid-epoch without moving the dependent root, so the snapshot is keyed on its own block
+    /// root instead and every head change rebuilds it for the rest of the epoch (cf. the
+    /// unrealized-checkpoints fix in sigp/lighthouse#9471). A further slashing can only arrive
+    /// via a new block, so the block root also distinguishes different slashing sets.
+    SlashingsPresent { head_block_root: Hash256 },
+}
+
+impl BalanceSourceKey {
+    /// `block_root` is the root of the block the snapshot's `state` descends from (the head
+    /// root for the head source; the checkpoint root for checkpoint sources).
+    pub(crate) fn compute<E: EthSpec>(
+        state: &BeaconState<E>,
+        epoch: Epoch,
+        block_root: Hash256,
+    ) -> Result<Self, Error> {
+        let epoch_slashings = state
+            .get_slashings(epoch)
+            .map_err(|e| Error::SlashingsOutOfBounds(format!("slashings lookup: {e:?}")))?;
+        if epoch_slashings > 0 {
+            Ok(Self::SlashingsPresent {
+                head_block_root: block_root,
+            })
+        } else {
+            Ok(Self::NoSlashings {
+                epoch_boundary_root: crate::dependent_root::<E>(state, epoch)?,
+            })
+        }
+    }
+}
+
 /// Snapshot of a validator set's effective balances for one epoch.
 ///
-/// `dependent_root` (the block at the last slot of the previous epoch) is the chain-identity that
-/// fixes this snapshot — two chains sharing it have the same view — and is used as the cache key.
+/// The [`BalanceSourceKey`] fixes this snapshot — two chains sharing it have the same view — and
+/// is used as the cache key.
 #[derive(Clone, Debug)]
 pub struct BalanceSourceData {
-    pub dependent_root: Hash256,
+    pub key: BalanceSourceKey,
     pub total_active_balance: u64,
     /// Effective balance per validator index. 0 for inactive.
     pub effective_balances: Vec<u64>,
@@ -20,15 +58,17 @@ pub struct BalanceSourceData {
 
 impl BalanceSourceData {
     /// Build a balance source for a single `epoch` in one pass over the validator set, tagged with
-    /// the epoch's dependent root. Effective balance is counted for active validators regardless of
-    /// slashed status (matching the spec's `get_total_active_balance`); `slashed` is recorded
-    /// separately for the slashed-filtering used by `get_block_support_between_slots`. The total
-    /// uses a saturating add — it is a sum of effective balances and cannot realistically overflow.
+    /// its [`BalanceSourceKey`] (computed from `state`, `epoch` and `block_root`). Effective
+    /// balance is counted for active validators regardless of slashed status (matching the spec's
+    /// `get_total_active_balance`); `slashed` is recorded separately for the slashed-filtering
+    /// used by `get_block_support_between_slots`. The total uses a saturating add — it is a sum
+    /// of effective balances and cannot realistically overflow.
     pub(crate) fn for_epoch<E: EthSpec>(
         state: &BeaconState<E>,
         epoch: Epoch,
+        block_root: Hash256,
     ) -> Result<Self, Error> {
-        let dependent_root = crate::dependent_root::<E>(state, epoch)?;
+        let key = BalanceSourceKey::compute(state, epoch, block_root)?;
         let validators = state.validators();
         let mut effective_balances = Vec::with_capacity(validators.len());
         let mut slashed = Vec::with_capacity(validators.len());
@@ -46,7 +86,7 @@ impl BalanceSourceData {
         }
 
         Ok(Self {
-            dependent_root,
+            key,
             total_active_balance,
             effective_balances,
             slashed,

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -31,7 +31,7 @@
 //! 4. **Snapshot balance sources** (`BalanceSourceData`): the current/previous observed-justified
 //!    sources are rebuilt only at the epoch-boundary rotation (bundled with their checkpoint in
 //!    `CheckpointAndBalance`), and the head source only when its `BalanceSourceKey` changes
-//!    (the dependent root normally, per head block once the epoch contains a slashing) — instead
+//!    (the epoch boundary root normally, per head block once the epoch contains a slashing) — instead
 //!    of re-scanning the validator set every slot.
 //!
 //! The visible algorithm deliberately keeps the spec function names and control-flow shape;
@@ -137,7 +137,7 @@ pub struct FastConfirmationRule {
 
     // === FFG data from the head state ===
     /// Built from the spec's `get_pulled_up_head_state`. Keyed (via `BalanceSourceData.key`)
-    /// on the head's dependent root — or the head block root itself once the epoch contains a
+    /// on the head's epoch boundary root — or the head block root itself once the epoch contains a
     /// slashing — so a reorg past the previous-epoch boundary or an intra-epoch slashing
     /// rebuilds it.
     head_balance_source: BalanceSourceData,
@@ -169,10 +169,10 @@ impl FastConfirmationRule {
     /// head-derived caches come from `head_state`, whose block root is `head_root`.
     /// `byzantine_threshold` is clamped to [0, 25].
     pub fn new<E: EthSpec>(
+        head_root: Hash256,
+        head_state: &BeaconState<E>,
         finalized_checkpoint: Checkpoint,
         checkpoint_state: &BeaconState<E>,
-        head_state: &BeaconState<E>,
-        head_root: Hash256,
         byzantine_threshold: u64,
         proposer_score_boost: u64,
     ) -> Result<Self, Error> {
@@ -182,11 +182,8 @@ impl FastConfirmationRule {
         if checkpoint_state.current_epoch() != finalized_checkpoint.epoch {
             return Err(Error::MissingCheckpointState(finalized_checkpoint));
         }
-        let checkpoint_balance = BalanceSourceData::for_epoch(
-            checkpoint_state,
-            finalized_checkpoint.epoch,
-            finalized_checkpoint.root,
-        )?;
+        let checkpoint_balance =
+            BalanceSourceData::new(checkpoint_state, finalized_checkpoint.root)?;
         Ok(Self {
             confirmed_root: finalized_checkpoint.root,
             previous_epoch_observed_justified: CheckpointAndBalance::new(
@@ -203,11 +200,7 @@ impl FastConfirmationRule {
             byzantine_threshold,
             proposer_score_boost,
             slot_assignments: SlotAssignments::new(head_state)?,
-            head_balance_source: BalanceSourceData::for_epoch(
-                head_state,
-                head_state.current_epoch(),
-                head_root,
-            )?,
+            head_balance_source: BalanceSourceData::new(head_state, head_root)?,
             last_update_slot: None,
             spec_test_mode: false,
         })
@@ -322,11 +315,7 @@ impl FastConfirmationRule {
 
         // Rebuild the head-derived caches when the head changes (including within a slot, e.g. a
         // late block or reorg). Each cache is rebuilt from scratch, independently, when its own
-        // key is stale. The slot assignments are keyed on the head's dependent root (a reorg past
-        // the previous-epoch boundary, or a new epoch). The balance source is keyed on its
-        // `BalanceSourceKey`, whose `SlashingsPresent` variant additionally forces a rebuild
-        // when a slashing lands mid-epoch and flips `slashed` flags without moving the dependent
-        // root (the FCR analogue of the unrealized-checkpoints fix in sigp/lighthouse#9471).
+        // key is stale.
         let head_dependent_root = dependent_root::<E>(head_state, current_epoch)?;
 
         if self.slot_assignments.dependent_root() != head_dependent_root {
@@ -334,11 +323,10 @@ impl FastConfirmationRule {
             self.slot_assignments = SlotAssignments::new::<E>(head_state)?;
         }
 
-        let head_balance_key = BalanceSourceKey::compute(head_state, current_epoch, head_root)?;
+        let head_balance_key = BalanceSourceKey::compute(head_state, head_root)?;
         if self.head_balance_source.key != head_balance_key {
             let _span = debug_span!("fcr_rebuild_head_balance").entered();
-            self.head_balance_source =
-                BalanceSourceData::for_epoch(head_state, current_epoch, head_root)?;
+            self.head_balance_source = BalanceSourceData::new(head_state, head_root)?;
         }
 
         // Spec: update_fast_confirmation_variables must be called at most once per slot.
@@ -374,11 +362,7 @@ impl FastConfirmationRule {
                         }
                         CheckpointAndBalance::new(new_current_cp, {
                             let _span = debug_span!("fcr_rebuild_current_balance").entered();
-                            BalanceSourceData::for_epoch(
-                                checkpoint_state,
-                                new_current_cp.epoch,
-                                new_current_cp.root,
-                            )?
+                            BalanceSourceData::new(checkpoint_state, new_current_cp.root)?
                         })
                     };
                 self.previous_epoch_observed_justified =
@@ -1560,16 +1544,16 @@ mod tests {
     }
 
     /// Regression test: a slashing processed mid-epoch must rebuild the head balance source
-    /// even though the dependent root is unchanged for the rest of the epoch (the FCR analogue
+    /// even though the epoch boundary root is unchanged for the rest of the epoch (the FCR analogue
     /// of the unrealized-checkpoints bug fixed in sigp/lighthouse#9471).
     #[test]
     fn head_balance_source_rebuilt_after_intra_epoch_slashing() {
         use state_processing::per_slot_processing;
         use types::MinimalEthSpec;
-        type ME = MinimalEthSpec;
+        type E = MinimalEthSpec;
 
-        let spec = ME::default_spec();
-        let mut state: BeaconState<ME> = BeaconState::new(0, Default::default(), &spec);
+        let spec = E::default_spec();
+        let mut state: BeaconState<E> = BeaconState::new(0, Default::default(), &spec);
         for _ in 0..32 {
             let validator = types::Validator {
                 effective_balance: spec.max_effective_balance,
@@ -1593,7 +1577,7 @@ mod tests {
 
         // Advance to a mid-epoch slot: at an epoch start the dependent root changes and would
         // rebuild the source regardless, masking the bug.
-        let mid_epoch_slot = Slot::new(ME::slots_per_epoch() + 4);
+        let mid_epoch_slot = Slot::new(E::slots_per_epoch() + 4);
         while state.slot() < mid_epoch_slot {
             per_slot_processing(&mut state, None, &spec).expect("should advance slot");
         }
@@ -1607,7 +1591,7 @@ mod tests {
         };
         let head_root_a = Hash256::repeat_byte(2);
         let mut fcr =
-            FastConfirmationRule::new::<ME>(checkpoint, &state, &state, head_root_a, 25, 40)
+            FastConfirmationRule::new::<E>(head_root_a, &state, checkpoint, &state, 25, 40)
                 .expect("fcr initialization");
 
         assert!(matches!(
@@ -1626,7 +1610,7 @@ mod tests {
             .expect("set slashings");
 
         let head_root_b = Hash256::repeat_byte(3);
-        fcr.update_fast_confirmation_variables::<ME>(
+        fcr.update_fast_confirmation_variables::<E>(
             head_root_b,
             &checkpoint,
             state.slot(),
@@ -1647,7 +1631,7 @@ mod tests {
 
         // While the epoch contains a slashing, every head change rebuilds the source.
         let head_root_c = Hash256::repeat_byte(4);
-        fcr.update_fast_confirmation_variables::<ME>(
+        fcr.update_fast_confirmation_variables::<E>(
             head_root_c,
             &checkpoint,
             state.slot(),

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -30,7 +30,8 @@
 //!
 //! 4. **Snapshot balance sources** (`BalanceSourceData`): the current/previous observed-justified
 //!    sources are rebuilt only at the epoch-boundary rotation (bundled with their checkpoint in
-//!    `CheckpointAndBalance`), and the head source only when its dependent root changes — instead
+//!    `CheckpointAndBalance`), and the head source only when its `BalanceSourceKey` changes
+//!    (the dependent root normally, per head block once the epoch contains a slashing) — instead
 //!    of re-scanning the validator set every slot.
 //!
 //! The visible algorithm deliberately keeps the spec function names and control-flow shape;
@@ -41,7 +42,7 @@ pub mod metrics;
 pub mod optimizations;
 mod slot_assignments;
 
-pub use balance_source::BalanceSourceData;
+pub use balance_source::{BalanceSourceData, BalanceSourceKey};
 pub use optimizations::CheckpointAndBalance;
 use optimizations::{AttestationScoreCache, HonestFfgSupportCache};
 use slot_assignments::SlotAssignments;
@@ -70,6 +71,7 @@ pub enum Error {
     BlockEpochNone(Hash256),
     CommitteeCacheUninitialized(String),
     BlockRootsOutOfBounds(String),
+    SlashingsOutOfBounds(String),
     IndexOutOfBounds(usize),
     ArithError(ArithError),
 }
@@ -134,8 +136,10 @@ pub struct FastConfirmationRule {
     slot_assignments: SlotAssignments,
 
     // === FFG data from the head state ===
-    /// Built from the spec's `get_pulled_up_head_state`. Keyed (via `BalanceSourceData.dependent_root`)
-    /// on the head's dependent root, so a reorg past the previous-epoch boundary rebuilds it.
+    /// Built from the spec's `get_pulled_up_head_state`. Keyed (via `BalanceSourceData.key`)
+    /// on the head's dependent root — or the head block root itself once the epoch contains a
+    /// slashing — so a reorg past the previous-epoch boundary or an intra-epoch slashing
+    /// rebuilds it.
     head_balance_source: BalanceSourceData,
 
     // === Internal bookkeeping ===
@@ -159,14 +163,16 @@ impl FastConfirmationRule {
 
     /// Initialize FCR from the finalized checkpoint, its checkpoint state and the head state,
     /// building the balance sources and committee assignments up front (each tagged with its own
-    /// dependent root derived from the state). The spec seeds both observed-justified checkpoints
-    /// with the finalized checkpoint, so both balance sources come from `checkpoint_state`
-    /// (spec: `store.checkpoint_states[finalized_checkpoint]`); the head-derived caches come from
-    /// `head_state`. `byzantine_threshold` is clamped to [0, 25].
+    /// `BalanceSourceKey` derived from the state). The spec seeds both observed-justified
+    /// checkpoints with the finalized checkpoint, so both balance sources come from
+    /// `checkpoint_state` (spec: `store.checkpoint_states[finalized_checkpoint]`); the
+    /// head-derived caches come from `head_state`, whose block root is `head_root`.
+    /// `byzantine_threshold` is clamped to [0, 25].
     pub fn new<E: EthSpec>(
         finalized_checkpoint: Checkpoint,
         checkpoint_state: &BeaconState<E>,
         head_state: &BeaconState<E>,
+        head_root: Hash256,
         byzantine_threshold: u64,
         proposer_score_boost: u64,
     ) -> Result<Self, Error> {
@@ -176,8 +182,11 @@ impl FastConfirmationRule {
         if checkpoint_state.current_epoch() != finalized_checkpoint.epoch {
             return Err(Error::MissingCheckpointState(finalized_checkpoint));
         }
-        let checkpoint_balance =
-            BalanceSourceData::for_epoch(checkpoint_state, finalized_checkpoint.epoch)?;
+        let checkpoint_balance = BalanceSourceData::for_epoch(
+            checkpoint_state,
+            finalized_checkpoint.epoch,
+            finalized_checkpoint.root,
+        )?;
         Ok(Self {
             confirmed_root: finalized_checkpoint.root,
             previous_epoch_observed_justified: CheckpointAndBalance::new(
@@ -197,6 +206,7 @@ impl FastConfirmationRule {
             head_balance_source: BalanceSourceData::for_epoch(
                 head_state,
                 head_state.current_epoch(),
+                head_root,
             )?,
             last_update_slot: None,
             spec_test_mode: false,
@@ -311,9 +321,12 @@ impl FastConfirmationRule {
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
 
         // Rebuild the head-derived caches when the head changes (including within a slot, e.g. a
-        // late block or reorg). Each cache is keyed on the head's dependent root; rebuild it from
-        // scratch, independently, when its own dependent root is stale (a reorg past the
-        // previous-epoch boundary, or a new epoch).
+        // late block or reorg). Each cache is rebuilt from scratch, independently, when its own
+        // key is stale. The slot assignments are keyed on the head's dependent root (a reorg past
+        // the previous-epoch boundary, or a new epoch). The balance source is keyed on its
+        // `BalanceSourceKey`, whose `SlashingsPresent` variant additionally forces a rebuild
+        // when a slashing lands mid-epoch and flips `slashed` flags without moving the dependent
+        // root (the FCR analogue of the unrealized-checkpoints fix in sigp/lighthouse#9471).
         let head_dependent_root = dependent_root::<E>(head_state, current_epoch)?;
 
         if self.slot_assignments.dependent_root() != head_dependent_root {
@@ -321,9 +334,11 @@ impl FastConfirmationRule {
             self.slot_assignments = SlotAssignments::new::<E>(head_state)?;
         }
 
-        if self.head_balance_source.dependent_root != head_dependent_root {
+        let head_balance_key = BalanceSourceKey::compute(head_state, current_epoch, head_root)?;
+        if self.head_balance_source.key != head_balance_key {
             let _span = debug_span!("fcr_rebuild_head_balance").entered();
-            self.head_balance_source = BalanceSourceData::for_epoch(head_state, current_epoch)?;
+            self.head_balance_source =
+                BalanceSourceData::for_epoch(head_state, current_epoch, head_root)?;
         }
 
         // Spec: update_fast_confirmation_variables must be called at most once per slot.
@@ -359,7 +374,11 @@ impl FastConfirmationRule {
                         }
                         CheckpointAndBalance::new(new_current_cp, {
                             let _span = debug_span!("fcr_rebuild_current_balance").entered();
-                            BalanceSourceData::for_epoch(checkpoint_state, new_current_cp.epoch)?
+                            BalanceSourceData::for_epoch(
+                                checkpoint_state,
+                                new_current_cp.epoch,
+                                new_current_cp.root,
+                            )?
                         })
                     };
                 self.previous_epoch_observed_justified =
@@ -1537,6 +1556,110 @@ mod tests {
         assert_eq!(
             adjust_committee_weight_estimate_to_ensure_safety(0).unwrap(),
             0
+        );
+    }
+
+    /// Regression test: a slashing processed mid-epoch must rebuild the head balance source
+    /// even though the dependent root is unchanged for the rest of the epoch (the FCR analogue
+    /// of the unrealized-checkpoints bug fixed in sigp/lighthouse#9471).
+    #[test]
+    fn head_balance_source_rebuilt_after_intra_epoch_slashing() {
+        use state_processing::per_slot_processing;
+        use types::MinimalEthSpec;
+        type ME = MinimalEthSpec;
+
+        let spec = ME::default_spec();
+        let mut state: BeaconState<ME> = BeaconState::new(0, Default::default(), &spec);
+        for _ in 0..32 {
+            let validator = types::Validator {
+                effective_balance: spec.max_effective_balance,
+                activation_epoch: Epoch::new(0),
+                exit_epoch: spec.far_future_epoch,
+                withdrawable_epoch: spec.far_future_epoch,
+                ..Default::default()
+            };
+            state
+                .validators_mut()
+                .push(validator)
+                .expect("push validator");
+            state
+                .balances_mut()
+                .push(spec.max_effective_balance)
+                .expect("push balance");
+        }
+        state
+            .build_all_committee_caches(&spec)
+            .expect("committee caches");
+
+        // Advance to a mid-epoch slot: at an epoch start the dependent root changes and would
+        // rebuild the source regardless, masking the bug.
+        let mid_epoch_slot = Slot::new(ME::slots_per_epoch() + 4);
+        while state.slot() < mid_epoch_slot {
+            per_slot_processing(&mut state, None, &spec).expect("should advance slot");
+        }
+        state
+            .build_all_committee_caches(&spec)
+            .expect("committee caches");
+
+        let checkpoint = Checkpoint {
+            epoch: state.current_epoch(),
+            root: Hash256::repeat_byte(1),
+        };
+        let head_root_a = Hash256::repeat_byte(2);
+        let mut fcr =
+            FastConfirmationRule::new::<ME>(checkpoint, &state, &state, head_root_a, 25, 40)
+                .expect("fcr initialization");
+
+        assert!(matches!(
+            fcr.head_balance_source.key,
+            BalanceSourceKey::NoSlashings { .. }
+        ));
+        assert!(!fcr.head_balance_source.slashed[0]);
+        let pre_slashing_key = fcr.head_balance_source.key;
+
+        // Simulate a slashing landing in a new head block within the same epoch (mirroring what
+        // `slash_validator` does to the state).
+        let effective_balance = spec.max_effective_balance;
+        state.get_validator_mut(0).expect("validator 0").slashed = true;
+        state
+            .set_slashings(state.current_epoch(), effective_balance)
+            .expect("set slashings");
+
+        let head_root_b = Hash256::repeat_byte(3);
+        fcr.update_fast_confirmation_variables::<ME>(
+            head_root_b,
+            &checkpoint,
+            state.slot(),
+            &state,
+            None,
+        )
+        .expect("update variables");
+
+        // The regression assertion: the balance source must have been rebuilt.
+        assert!(fcr.head_balance_source.slashed[0]);
+        assert_eq!(
+            fcr.head_balance_source.key,
+            BalanceSourceKey::SlashingsPresent {
+                head_block_root: head_root_b
+            }
+        );
+        assert_ne!(fcr.head_balance_source.key, pre_slashing_key);
+
+        // While the epoch contains a slashing, every head change rebuilds the source.
+        let head_root_c = Hash256::repeat_byte(4);
+        fcr.update_fast_confirmation_variables::<ME>(
+            head_root_c,
+            &checkpoint,
+            state.slot(),
+            &state,
+            None,
+        )
+        .expect("update variables");
+        assert_eq!(
+            fcr.head_balance_source.key,
+            BalanceSourceKey::SlashingsPresent {
+                head_block_root: head_root_c
+            }
         );
     }
 }


### PR DESCRIPTION
Fix the issue with the `BalanceSourceData` being technically wrong in the presence of **proposer** slashings.